### PR TITLE
fix: metered 도메인 제거

### DIFF
--- a/docker/livekit/livekit.yaml
+++ b/docker/livekit/livekit.yaml
@@ -11,12 +11,12 @@ rtc:
     - stun.l.google.com:19302
     - stun1.l.google.com:19302
   turn_servers:
-    - host: "${METERED_DOMAIN}.metered.ca"
+    - host: "${METERED_DOMAIN}"
       port: 443
       protocol: tls
       username: "${METERED_USERNAME}"
       credential: "${METERED_PASSWORD}"
-    - host: "${METERED_DOMAIN}.metered.ca"
+    - host: "${METERED_DOMAIN}"
       port: 80
       protocol: tcp
       username: "${METERED_USERNAME}"


### PR DESCRIPTION
yaml에서 metered.ca를 제거해서 중복된 도메인명 제거