### PR TITLE
fix: pre-push build순서 조정, 다시 pnpm start 사용하게 변경

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -57,17 +57,17 @@ if [ -n "$FRONTEND_CHANGED" ]; then
     exit 1
   fi
 
-  echo "• Running E2E tests (playwright)..."
-  pnpm --filter frontend test:e2e
-  if [ $? -ne 0 ]; then
-    echo "❌ Frontend E2E tests failed"
-    exit 1
-  fi
-
   echo "• Building..."
   pnpm --filter frontend build
   if [ $? -ne 0 ]; then
     echo "❌ Frontend build failed"
+    exit 1
+  fi
+
+  echo "• Running E2E tests (playwright)..."
+  pnpm --filter frontend test:e2e
+  if [ $? -ne 0 ]; then
+    echo "❌ Frontend E2E tests failed"
     exit 1
   fi
 

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'pnpm dev --port 3001',
+    command: 'pnpm start --port 3001',
     url: 'http://localhost:3001',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,


### PR DESCRIPTION
## 💡 의도 / 배경
<!-- 무엇을, 왜 변경했는지 설명해주세요. 배경 및 문제를 적어주세요. -->
- 로컬에서 프론트엔드 개발 서버(`pnpm run dev`) 구동 상태로 커밋을 push할 때, [pre-push](cci:7://file:///f:/ssafy/prj/Peekle/.husky/pre-push:0:0-0:0) 훅의 E2E(Playwright) 테스트가 실행되면 백그라운드에서 임시 개발 서버를 새로(`pnpm dev --port 3001`) 띄우면서 두 서버 간에 `.next` 빌드 캐시 충돌이 발생했습니다.
- 이로 인해 기존 개발 시 켜져있던 포트 3000번의 개발 서버가 에러를 뿜으며 고장 나는 문제를 해결하고자 검사 순서와 실행 환경 구성을 변경했습니다.

## 🛠️ 작업 내용
<!-- 주요 구현 사항, 로직 변경, 추가된 기능 등을 리스트업 해주세요. -->
- [x] [.husky/pre-push](cci:7://file:///f:/ssafy/prj/Peekle/.husky/pre-push:0:0-0:0): 프론트엔드 검사 순서를 조정하여 `pnpm build`를 먼저 수행한 뒤 `pnpm test:e2e`를 실행하도록 수정
- [x] [apps/frontend/playwright.config.ts](cci:7://file:///f:/ssafy/prj/Peekle/apps/frontend/playwright.config.ts:0:0-0:0): 테스트 동작 시 임시 개발 서버(`pnpm dev --port 3001`) 대신 프로덕션 빌드 서버(`pnpm start --port 3001`)를 띄우도록 원복시켜 개발 환경과 캐시를 분리

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: Closes #123) -->
- Closes #21 

## 🖼️ 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요. -->


## 🧪 테스트 방법
<!-- 이 PR이 어떻게 테스트되었는지, 리뷰어가 어떻게 테스트해 볼 수 있는지 적어주세요. -->
- [ ] 로컬 터미널 A에서 `pnpm run dev` (프론트엔드) 실행 상태 유지
- [ ] 로컬 터미널 B에서 임의의 커밋을 생성 후 `git push` 실행
- [ ] pre-push 단계에서 테스트가 정상 통과되는지 확인하고, 통과 이후에도 터미널 A의 3000 포트 개발 서버가 꺼지거나 고장나지 않고 새로고침 시 잘 동작하는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
<!-- 같이 리뷰받고 싶은 부분이나 특별히 확인해야 할 사항이 있다면 적어주세요. -->