### PR TITLE
refactor: 확장프로그램 설치를 스토어에서 하게 변경

### DIFF
--- a/apps/extension/background.js
+++ b/apps/extension/background.js
@@ -433,11 +433,11 @@ chrome.runtime.onInstalled.addListener(async () => {
 
     // 타겟 URL 패턴 (프론트엔드 도메인)
     // manifest.json의 host_permissions에 해당 도메인이 있어야 함
-    const targetPattern = IS_LOCAL ? 'http://localhost:3000/*' : 'https://peekle.today/*';
+    const targetPatterns = ['http://localhost:3000/*', 'https://peekle.today/*'];
 
     try {
         // 프론트엔드 탭 찾기
-        const tabs = await chrome.tabs.query({ url: targetPattern });
+        const tabs = await chrome.tabs.query({ url: targetPatterns });
 
         for (const tab of tabs) {
             if (tab.id) {

--- a/apps/frontend/src/components/common/CCPreJoinModal.tsx
+++ b/apps/frontend/src/components/common/CCPreJoinModal.tsx
@@ -119,15 +119,10 @@ export const CCPreJoinModal = ({
     // Actually, if I click "Install", it opens window. If I come back and it's not detected, I click again.
     // Maybe I should separate "Check" from "Install"?
     // For now, simplicity: Clicking button opens window AND starts polling.
-    // [Temp] Manual installation guide instead of direct store link
-    setShowManualModal(true);
-
-    /* Original store link preserved
     window.open(
       'https://chromewebstore.google.com/detail/lgcgoodhgjalkdncpnhnjaffnnpmmcjn?utm_source=item-share-cb',
       '_blank',
     );
-    */
 
     setIsPolling(true);
     checkInstallation(); // Immediate
@@ -869,11 +864,13 @@ export const CCPreJoinModal = ({
                 </div>
               ) : extensionStatus === 'VERSION_MISMATCH' ? (
                 <Button
-                  onClick={() => setShowManualModal(true)}
+                  onClick={() => {
+                    window.open('https://chromewebstore.google.com/detail/lgcgoodhgjalkdncpnhnjaffnnpmmcjn?utm_source=item-share-cb', '_blank');
+                  }}
                   className="bg-red-600 hover:bg-red-700 text-white font-bold h-11 px-6 rounded-lg shadow-lg shadow-red-900/20 transition-all hover:scale-[1.02] active:scale-[0.98]"
                 >
                   <AlertCircle size={18} className="mr-2" />
-                  업데이트 가이드 확인하기
+                  스토어에서 업데이트하기
                 </Button>
               ) : !isBojLinked ? (
                 <Button

--- a/apps/frontend/src/domains/profile/components/CCExtensionGuide.tsx
+++ b/apps/frontend/src/domains/profile/components/CCExtensionGuide.tsx
@@ -281,10 +281,13 @@ export function CCExtensionGuide({
             </p>
           </div>
           <button
-            onClick={() => setShowManualModal(true)}
+            onClick={() => {
+              window.open('https://chromewebstore.google.com/detail/lgcgoodhgjalkdncpnhnjaffnnpmmcjn?utm_source=item-share-cb', '_blank');
+              handleInstallClick();
+            }}
             className="px-3 py-1.5 bg-red-600 text-white rounded-md text-xs font-bold hover:bg-red-700"
           >
-            업데이트 가이드
+            스토어에서 업데이트
           </button>
         </div>
       )}
@@ -379,15 +382,6 @@ export function CCExtensionGuide({
         {status === 'NOT_INSTALLED' && (
           <div className="flex flex-col gap-4 w-full items-center">
             <div className="flex gap-3">
-              {/* [Temp] Manual Installation Guide replacing directly store link */}
-              <button
-                onClick={() => setShowManualModal(true)}
-                className="px-5 py-2.5 bg-blue-600 text-white rounded-lg text-sm font-bold hover:bg-blue-700 flex items-center gap-2 shadow-sm"
-              >
-                📥 확장 프로그램 수동 설치 가이드
-              </button>
-
-              {/* Original code preserved for future restoration
               <button
                 onClick={() => {
                   window.open('https://chromewebstore.google.com/detail/lgcgoodhgjalkdncpnhnjaffnnpmmcjn?utm_source=item-share-cb', '_blank');
@@ -397,7 +391,6 @@ export function CCExtensionGuide({
               >
                 {isPolling ? '⏳ 확인 중...' : '📥 스토어에서 다운로드'}
               </button>
-              */}
             </div>
             {isPolling && (
               <p className="text-xs text-muted-foreground animate-pulse">


### PR DESCRIPTION
## 💡 의도 / 배경
- 기존 기능에서는 수동 설치 가이드 모달을 띄우고 사용자가 직접 압축을 해제하여 확장 프로그램을 설치하도록 유도했습니다. 크롬 웹 스토어 심사가 지연되어 임시로 적용된 방식이었습니다.
- 하지만 현재 스토어 심사가 완료되었기 때문에, 사용성 향상을 위해 스토어 링크로 직접 이동하여 설치/업데이트할 수 있도록 기존 코드를 제거하고 개선했습니다.
- 추가로, 확장 프로그램 설치 시 기존에는 `peekle.today` 환경에만 스크립트가 자동 주입되도록 하드코딩 되어있어 로컬(`localhost:3000`) 환경 테스트 시 새로고침이 필수였던 문제를 발견하여 함께 수정했습니다.

## 🛠️ 작업 내용
- [x] 프리조인 팝업([CCPreJoinModal.tsx](cci:7://file:///c:/ssafy/prj/Peekle/apps/frontend/src/components/common/CCPreJoinModal.tsx:0:0-0:0))에서 "수동 설치 가이드" 모달을 제거하고 "스토어에서 설치/업데이트" 버튼으로 변경
- [x] 프로필 확장 프로그램 안내 페이지([CCExtensionGuide.tsx](cci:7://file:///c:/ssafy/prj/Peekle/apps/frontend/src/domains/profile/components/CCExtensionGuide.tsx:0:0-0:0))에서 수동 설치 모달을 제거하고 스토어 링크로 연결되도록 변경
- [x] [background.js](cci:7://file:///c:/ssafy/prj/Peekle/apps/extension/background.js:0:0-0:0)의 `onInstalled` 이벤트에서 스크립트 자동 주입 대상(`targetPattern`)에 `localhost:3000`도 포함되도록 배열 형태로 변경

## 🔗 관련 이슈
- Closes #25 

## 🖼️ 스크린샷 (선택)
<!-- 스토어로 정상 이동하는 화면 또는 모달이 사라진 버튼 UI 캡처본을 첨부하시면 좋습니다. -->

## 🧪 테스트 방법
- [ ] 로컬 또는 브라우저에서 스터디/미팅 방 진입 시 프리조인 모달에서 "확장 프로그램 설치" 혹은 "업데이트" 버튼을 클릭하면 크롬 웹 스토어 페이지 새 탭이 열리는지 확인합니다.
- [ ] 내 프로필 -> 백준 확장 프로그램 섹션에서 설치 버튼을 눌렀을 때 동일하게 동작하는지 확인합니다.
- [ ] `localhost:3000`에서 개발 중일 때 확장 프로그램 설치(혹은 업데이트) 직후, 프론트엔드 새로고침 없이 확장 프로그램 연동/설치 감지가 이뤄지는지 확인합니다.

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- [background.js](cci:7://file:///c:/ssafy/prj/Peekle/apps/extension/background.js:0:0-0:0) 수정으로 인해 이 PR이 머지된 이후, 새로운 버전의 확장 프로그램 빌드 및 웹 스토어 재배포(업데이트 심사)가 필요합니다!
