### PR TITLE
feat: shift+ enter 사용시 기존의 코드 안건드리고 줄바꿈하기 구현

### DIFF
--- a/apps/frontend/src/domains/study/components/CCIDEPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCIDEPanel.tsx
@@ -407,6 +407,11 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
 
       if (onEditorMount) onEditorMount(editor);
 
+      // Shift + Enter로 IntelliJ/Eclipse처럼 바로 아랫 줄에 빈 줄 삽입 후 이동
+      editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
+        editor.trigger('keyboard', 'editor.action.insertLineAfter', null);
+      });
+
       // [핵심 해결책 2] 마운트 시점에 state에 있는 값을 강제로 주입
       // 위에서 setCode로 업데이트된 상태가 여기(value prop)에 반영되겠지만,
       // 확실한 동기화를 위해 한 번 더 설정합니다.


### PR DESCRIPTION
## 💡 의도 / 배경
<!-- 무엇을, 왜 변경했는지 설명해주세요. 배경 및 문제를 적어주세요. -->
- 스터디/IDE 화면에서 코드를 작성할 때, `Shift + Enter`를 누르면 현재 커서 위치와 상관없이 바로 아랫줄에 빈 줄을 삽입하고 커서가 이동하는 기능(Eclipse, IntelliJ 단축키 동작)이 필요했습니다.
- 이를 통해 사용자(개발자)에게 더 빠르고 익숙한 코드 에디팅 경험을 제공하고자 합니다.

## 🛠️ 작업 내용
<!-- 주요 구현 사항, 로직 변경, 추가된 기능 등을 리스트업 해주세요. -->
- [x] [CCIDEPanel.tsx](cci:7://file:///f:/ssafy/prj/Peekle/apps/frontend/src/domains/study/components/CCIDEPanel.tsx:0:0-0:0)의 Monaco Editor 인스턴스에 `editor.addCommand`를 사용하여 커스텀 단축키 이벤트 추가
- [x] 단축키 `Shift + Enter` 바인딩 및 이벤트로 `editor.action.insertLineAfter` 액션 연결
- [x] (테스트용) 정상 발동 여부를 확인할 수 있는 console.log 로깅 코드 추가

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: Closes #123) -->
- Closes #15

## 🖼️ 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요. -->
![Honeycam 2026-03-03 19-51-31](https://github.com/user-attachments/assets/666f24ce-9fba-4cb8-ad53-8bf7a7c6ecb2)

## 🧪 테스트 방법
<!-- 이 PR이 어떻게 테스트되었는지, 리뷰어가 어떻게 테스트해 볼 수 있는지 적어주세요. -->
- [x] 로컬 환경에서 로딩된 IDE 패널에 포커스를 맞춥니다.
- [x] 코드의 아무 위치에 커서를 두고 `Shift + Enter`를 누릅니다.
- [x] 현재 줄 커서 위치에 무관하게, 바로 밑에 새 빈 줄이 생성되고 커서가 그곳으로 이동하는지 확인합니다.

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
<!-- 같이 리뷰받고 싶은 부분이나 특별히 확인해야 할 사항이 있다면 적어주세요. -->
