### PR TITLE
fix: 코드가 수정되지 않아도 남의 코드 볼때 저장된 코드 보이게 수정

### DIFF
--- a/apps/frontend/src/domains/study/hooks/useRealtimeCode.ts
+++ b/apps/frontend/src/domains/study/hooks/useRealtimeCode.ts
@@ -7,6 +7,7 @@ export function useRealtimeCode(viewingUser: Participant | null) {
   const [language, setLanguage] = useState<string>('python'); // Default
   const roomId = useRoomStore((state) => state.roomId);
   const currentUserId = useRoomStore((state) => state.currentUserId);
+  const selectedStudyProblemId = useRoomStore((state) => state.selectedStudyProblemId);
 
   // Ensure we have a socket connection
   const socket = useSocket(roomId, currentUserId);
@@ -20,35 +21,51 @@ export function useRealtimeCode(viewingUser: Participant | null) {
 
     // Subscribe to the target user's IDE topic
     // Topic: /topic/studies/rooms/{id}/ide/{userId}
-    const topic = `/topic/studies/rooms/${roomId}/ide/${viewingUser.id}`;
+    const ideTopic = `/topic/studies/rooms/${roomId}/ide/${viewingUser.id}`;
 
-    // Also, we might want to request an initial snapshot?
-    // Spec table mentioned: /pub/ide/request-snapshot
-    // Verify if we need to request it. The user might not be broadcasting if they haven't typed.
-    // Ideally we subscribe first.
+    // Subscribe to snapshot response topic
+    // Topic: /topic/studies/rooms/{id}/ide/{myUserId}/snapshot
+    const snapshotTopic = `/topic/studies/rooms/${roomId}/ide/${currentUserId}/snapshot`;
 
-    const subscription = socket.subscribe(topic, (message) => {
+    const ideSubscription = socket.subscribe(ideTopic, (message) => {
       try {
         const body = JSON.parse(message.body);
-        // Payload: { type: "IDE", data: { problemId, code } } (Broadcasted by SocketService)
         if (body.type === 'IDE' && body.data) {
           setCode(body.data.code);
-          // language? The payload in SocketService only had code/problemId.
-          // If language is missing in backend broadcast, we can't update it.
-          // But let's check input of broadcast: it takes `data.code`.
+          if (body.data.lang) {
+            setLanguage(body.data.lang);
+          }
         }
       } catch (e) {
         console.error('Error parsing IDE message', e);
       }
     });
 
-    // Request snapshot logic (Optional, based on spec availability)
-    // socket.publish({ destination: '/pub/ide/request-snapshot', body: JSON.stringify({ ... }) })
+    const snapshotSubscription = socket.subscribe(snapshotTopic, (message) => {
+      try {
+        const body = JSON.parse(message.body);
+        if (body.type === 'IDE_SNAPSHOT' && body.data) {
+          setCode(body.data.code);
+          if (body.data.lang) {
+            setLanguage(body.data.lang);
+          }
+        }
+      } catch (e) {
+        console.error('Error parsing IDE snapshot message', e);
+      }
+    });
+
+    // Request initial snapshot of the user's code
+    socket.publish({
+      destination: '/pub/ide/request-snapshot',
+      body: JSON.stringify({ targetUserId: viewingUser.id, problemId: selectedStudyProblemId }),
+    });
 
     return () => {
-      subscription.unsubscribe();
+      ideSubscription.unsubscribe();
+      snapshotSubscription.unsubscribe();
     };
-  }, [socket, viewingUser, roomId]);
+  }, [socket, viewingUser, roomId, currentUserId, selectedStudyProblemId]);
 
   return { code, language };
 }


### PR DESCRIPTION
## 💡 의도 / 배경
남의 코드 보기를 시작할 때, 상대방이 코드를 수정하기 전까지 빈 화면으로 보이는 현상이 있었습니다. 
상대방이 코드를 계속 입력하지 않는 한 실시간 코드를 확인할 수 없는 불편함을 해결했습니다.

## 🛠️ 작업 내용
<!-- 주요 구현 사항, 로직 변경, 추가된 기능 등을 리스트업 해주세요. -->
- [x] 프론트엔드(`useRealtimeCode.ts`)에서 코드 열람을 시작할 때, 백엔드(`/pub/ide/request-snapshot`)로 현재 코드 스냅샷 명시적 요청
- [x] 스냅샷 요청 시, 조회 대상의 `problemId`를 올바르게 전달하도록 파라미터 보강 (기본값인 `0L`로 조회되던 오류 수정)
- [x] 백엔드에서 Redis에 캐시 되어 있는 대상 유저의 최신 코드를 불러와, 요청자에게 즉시 전달(`IDE` 토픽 전송)하도록 로직 연동

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: Closes #123) -->
- Closes #24 

## 🖼️ 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요. -->
![Honeycam 2026-03-03 20-25-45](https://github.com/user-attachments/assets/3c0d4d75-7e1e-488a-b33b-3fe76f88f216)


## 🧪 테스트 방법
1. A 유저가 특정 문제(예: 1000번)에 코드를 입력하다가 멈춤
2. B 유저가 A 유저의 코드 보기 패널 선택 (Shift + Enter 등)
3. **기대결과:** A 유저가 추가 입력하지 않아도, 방금 전까지 A가 작성했던 최신 코드가 직시 로드되어 화면에 나타남


## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
<!-- 같이 리뷰받고 싶은 부분이나 특별히 확인해야 할 사항이 있다면 적어주세요. -->
