### PR TITLE
fix: 문제가 간헐적으로 안보이는 버그 수정

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/study/service/StudyCurriculumService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/study/service/StudyCurriculumService.java
@@ -71,8 +71,9 @@ public class StudyCurriculumService {
                 }
 
                 // 제약사항 1: 문제 날짜는 오늘이어야 함
-                LocalDate targetDate = (request.getProblemDate() != null) ? request.getProblemDate() : LocalDate.now();
-                if (!targetDate.equals(LocalDate.now())) {
+                LocalDate targetDate = (request.getProblemDate() != null) ? request.getProblemDate()
+                                : LocalDate.now(java.time.ZoneId.of("Asia/Seoul"));
+                if (!targetDate.equals(LocalDate.now(java.time.ZoneId.of("Asia/Seoul")))) {
                         throw new BusinessException(ErrorCode.PROBLEM_DATE_MISMATCH);
                 }
 
@@ -163,7 +164,7 @@ public class StudyCurriculumService {
                 // 2. Fallback to problemId and Today (for backward compatibility or existing
                 // logic)
                 else if (problemId != null) {
-                        LocalDate targetDate = LocalDate.now();
+                        LocalDate targetDate = LocalDate.now(java.time.ZoneId.of("Asia/Seoul"));
                         List<StudyProblem> candidates = studyProblemRepository.findByStudyIdAndProblemDate(studyId,
                                         targetDate);
                         target = candidates.stream()

--- a/apps/frontend/src/domains/study/hooks/useProblems.ts
+++ b/apps/frontend/src/domains/study/hooks/useProblems.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { apiFetch } from '@/lib/api';
+import { format } from 'date-fns';
 import { useStudySocketActions } from '@/domains/study/hooks/useStudySocket';
 import { getProblemIdByExternalId } from '@/domains/study/api/problemApi';
 
@@ -27,7 +28,7 @@ export function useProblems(studyId: number, dateString?: string) {
     if (!studyId) return;
     setIsLoading(true);
     try {
-      const targetDate = dateString || new Date().toISOString().split('T')[0];
+      const targetDate = dateString || format(new Date(), 'yyyy-MM-dd');
       const res = await apiFetch<any[]>(
         `/api/studies/${studyId}/curriculum/daily?date=${targetDate}`,
       );


### PR DESCRIPTION
## 💡 의도 / 배경
<!-- 무엇을, 왜 변경했는지 설명해주세요. 배경 및 문제를 적어주세요. -->
- 스터디 방에 문제를 추가할 때 오전 시간대(KST 기준)에 추가한 문제가 오늘 목록에 표시되지 않고 어제 날짜로 배정되거나 간헐적으로 사라지는 버그가 있었습니다.
- 백엔드와 프론트엔드의 기준 시간(타임존)이 서로 달라서 발생하는 문제였습니다. 프론트엔드는 `toISOString()` 사용으로 인해 UTC 기준으로 날짜를 계산했고, 백엔드 역시 `LocalDate.now()`를 타임존 지정 없이 사용하여 서버 시간에 따라 배정 날짜(`problem_date`)가 하루 전으로 밀리는 현상이 원인이었습니다.

## 🛠️ 작업 내용
<!-- 주요 구현 사항, 로직 변경, 추가된 기능 등을 리스트업 해주세요. -->
- [x] **백엔드 ([StudyCurriculumService.java](cci:7://file:///f:/ssafy/prj/Peekle/apps/backend/src/main/java/com/peekle/domain/study/service/StudyCurriculumService.java:0:0-0:0))**: 문제 추가([addProblem](cci:1://file:///f:/ssafy/prj/Peekle/apps/backend/src/main/java/com/peekle/domain/study/service/StudyCurriculumService.java:47:8-135:9)) 및 문제 삭제([removeProblem](cci:1://file:///f:/ssafy/prj/Peekle/apps/backend/src/main/java/com/peekle/domain/study/service/StudyCurriculumService.java:137:8-224:9)) 로직에서 오늘 날짜를 구할 때 `LocalDate.now(ZoneId.of("Asia/Seoul"))`를 명시하여 KST(한국 시간)를 고정적으로 사용하도록 수정
- [x] **프론트엔드 ([useProblems.ts](cci:7://file:///f:/ssafy/prj/Peekle/apps/frontend/src/domains/study/hooks/useProblems.ts:0:0-0:0))**: API 요청 시 전송하는 오늘 날짜 기준을 `new Date().toISOString().split('T')[0]`에서 `date-fns`의 `format(new Date(), 'yyyy-MM-dd')`로 변경하여 사용자 로컬 시간(KST)이 정확히 서버로 전달되도록 수정

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: Closes #123) -->
- Closes #31 

## 🖼️ 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요. -->

## 🧪 테스트 방법
<!-- 이 PR이 어떻게 테스트되었는지, 리뷰어가 어떻게 테스트해 볼 수 있는지 적어주세요. -->
- [x] 오전 9시 이전(UTC 기준 전날)에 스터디 방에서 문제를 새롭게 추가해 봅니다.
- [x] 추가된 문제가 어제 날짜로 넘어가지 않고 즉각적으로 "오늘의 문제" 리스트에 정상 표시되는지 확인합니다.
- [x] 새로고침 및 다른 유저의 화면에서도 추가한 문제가 동일한 날짜에 조회되는지 확인합니다.

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
<!-- 같이 리뷰받고 싶은 부분이나 특별히 확인해야 할 사항이 있다면 적어주세요. -->
이슈의 원인이 데이터베이스에 들어가는 날짜(`problem_date`) 자체가 잘못 저장되고 있었기 때문이었습니다.