### PR TITLE
fix: 그룹이 있지만 배치 대기 중으로 뜨는 문제 수정, 확장프로그램 업데이트 문구 수정

### DIFF
--- a/apps/extension/popup.js
+++ b/apps/extension/popup.js
@@ -159,7 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // 순위와 상태 함께 표시
         const rankEl = document.getElementById('user-rank');
-        if (!data.isGroupAssigned) {
+        if (data.isGroupAssigned === false) {
             // 그룹 미배정: 리그명이 stone이면 배치 대기, 아니면 쉬는 중
             const leagueName = (data.leagueName || '').toLowerCase();
             const waitMsg = leagueName === 'stone' ? '배치 대기' : '이번주 쉬는 중';

--- a/apps/frontend/src/domains/home/components/LeagueRanking.tsx
+++ b/apps/frontend/src/domains/home/components/LeagueRanking.tsx
@@ -22,7 +22,7 @@ const LeagueRanking = ({ initialData }: LeagueRankingProps) => {
   const rules = data.rule;
 
   // 그룹 나누기 (배정된 경우에만 의미있음)
-  const isAssigned = data.isGroupAssigned;
+  const isAssigned = data.isGroupAssigned !== false;
   const promotionZone = isAssigned ? data.members.filter((m) => m.status === 'PROMOTE') : [];
   const maintenanceZone = isAssigned ? data.members.filter((m) => m.status === 'STAY') : data.members;
   const demotionZone = isAssigned ? data.members.filter((m) => m.status === 'DEMOTE') : [];
@@ -44,7 +44,7 @@ const LeagueRanking = ({ initialData }: LeagueRankingProps) => {
           <div className="flex items-center gap-3 min-w-0">
             <LeagueIcon league={data.myLeague} size={40} />
             <div className="flex flex-col min-w-0">
-              {data.isGroupAssigned ? (
+              {data.isGroupAssigned !== false ? (
                 <>
                   <span className="text-[10px] font-semibold text-primary block mb-0">
                     나의 현재 순위

--- a/apps/frontend/src/domains/league/components/CCLeagueMyStatus.tsx
+++ b/apps/frontend/src/domains/league/components/CCLeagueMyStatus.tsx
@@ -133,7 +133,7 @@ const CCLeagueMyStatus = ({ initialLeagueRanking, initialWeeklyScore }: CCLeague
 
   const isStone = rankingData.myLeague === 'stone';
 
-  if (!rankingData.isGroupAssigned) {
+  if (rankingData.isGroupAssigned === false) {
     statusMessage = isStone ? '배치 대기 중' : '이번 주는 쉬어가기';
     statusDetail = isStone
       ? '이번 주 해당 티어의 참가 인원이 부족해 리그 그룹이 배정되지 않았습니다.'
@@ -222,7 +222,7 @@ const CCLeagueMyStatus = ({ initialLeagueRanking, initialWeeklyScore }: CCLeague
             <div>
               <span className="text-sm text-muted-foreground font-medium block mb-1">내 순위</span>
               {/* 미배정 시 순위 대신 메시지 표시 */}
-              {rankingData.isGroupAssigned ? (
+              {rankingData.isGroupAssigned !== false ? (
                 <span className="text-3xl font-black text-foreground">
                   {myRank}
                   <span className="text-sm font-medium text-muted-foreground ml-1">

--- a/apps/frontend/src/domains/league/components/CCLeagueRankingList.tsx
+++ b/apps/frontend/src/domains/league/components/CCLeagueRankingList.tsx
@@ -80,7 +80,7 @@ const CCLeagueRankingList = ({ initialData }: CCLeagueRankingListProps) => {
     );
   }
   // 그룹 나누기 (배정된 경우에만 의미있음)
-  const isAssigned = data.isGroupAssigned;
+  const isAssigned = data.isGroupAssigned !== false;
   const promotionZone = isAssigned ? data.members.filter((m) => m.status === 'PROMOTE') : [];
   const maintenanceZone = isAssigned ? data.members.filter((m) => m.status === 'STAY') : data.members;
   const demotionZone = isAssigned ? data.members.filter((m) => m.status === 'DEMOTE') : [];


### PR DESCRIPTION
## 💡 의도 / 배경
- 확장 프로그램 최초 로드 시 버전 정보 통신 지연으로 인해 일시적으로 '버전 업데이트 필요' 경고가 깜빡이는 문제를 해결했습니다.
- 리그 그룹에 정상적으로 배정된 유저(특히 Stone 티어)임에도 불구하고 초기 로딩 스피너 혹은 캐시 상태에서 "배치 대기 중"으로 잘못 표기되는 UI 버그를 수정했습니다.
- 프론트엔드와 확장 프로그램이 유저의 미배정 상태를 정확히 알 수 있도록 백엔드 응답 DTO에 누락되었던 `isGroupAssigned` 필드를 추가했습니다.

## 🛠️ 작업 내용
- **버전 체크 로직 반짝임(깜빡임) 수정**
  - [CCExtensionGuide.tsx](cci:7://file:///f:/ssafy/prj/Peekle/apps/frontend/src/domains/profile/components/CCExtensionGuide.tsx:0:0-0:0) 내에서 `versionInfo` 데이터 로딩이 끝난 이후(`!isVersionLoading`)에만 버전 불일치 여부를 판단하도록 조건 강화
- **백엔드 리그 API 응답 개선**
  - [LeagueStatusResponse](cci:2://file:///f:/ssafy/prj/Peekle/apps/frontend/src/api/leagueApi.ts:21:0-33:1) DTO에 `isGroupAssigned` boolean 필드 추가
  - [LeagueService.java](cci:7://file:///f:/ssafy/prj/Peekle/apps/backend/src/main/java/com/peekle/domain/league/service/LeagueService.java:0:0-0:0)에서 응답 생성 시 `user.getLeagueGroupId() != null` 여부를 담아 반환하도록 처리
- **프론트엔드/확장프로그램 '배치 대기' 상태 오작동 수정**
  - 캐시 상태나 API 응답 전 `data.isGroupAssigned`가 `undefined`일 때 자바스크립트의 falsy 평가로 인해 "배치 대기"가 뜨던 문제를 해결
  - [CCLeagueMyStatus.tsx](cci:7://file:///f:/ssafy/prj/Peekle/apps/frontend/src/domains/league/components/CCLeagueMyStatus.tsx:0:0-0:0), [LeagueRanking.tsx](cci:7://file:///f:/ssafy/prj/Peekle/apps/frontend/src/domains/home/components/LeagueRanking.tsx:0:0-0:0), [CCLeagueRankingList.tsx](cci:7://file:///f:/ssafy/prj/Peekle/apps/frontend/src/domains/league/components/CCLeagueRankingList.tsx:0:0-0:0), [popup.js](cci:7://file:///f:/ssafy/prj/Peekle/apps/extension/popup.js:0:0-0:0)에서 조건문을 단순 `!isGroupAssigned`에서 엄격한 `!== false` 또는 `=== false` 비교로 변경

## 🔗 관련 이슈
- Closes #36
- Closes #39 

## 🧪 테스트 방법
- 브라우저를 새로고침하고 내 리그 랭킹 탭을 확인했을 때 배정된 스톤 유저가 '배치 대기 중'이 아닌 랭킹 숫자가 정상 표시되는지 확인합니다.
- 마이페이지 내의 확장프로그램 탭 진입 시 버전을 확인하는 동안 빨간색 경고 배너가 나타났다가 사라지는지(반짝이는지) 확인합니다. (더 이상 반짝이지 않아야 함)
- 확장프로그램 팝업 창을 열었을 때 소속된 그룹이 있는 경우 정상적인 랭크가 노출되는지 확인합니다.

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게
- 컴포넌트별로 `undefined` 상태를 처리하는 조건식(`=== false`)을 추가했는데 시각적으로 문제없는지만 가볍게 확인 부탁드립니다!
