### PR TITLE
feat: 회원가입할때 max_league를 stone으로 설정

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/user/entity/User.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/entity/User.java
@@ -56,6 +56,7 @@ public class User extends BaseTimeEntity {
         this.profileImg = defaultImg;
         this.profileImgThumb = defaultImg;
         this.profileImgType = ProfileImgType.DEFAULT;
+        this.maxLeague = LeagueTier.STONE;
     }
 
     private String generateDefaultProfileImg(String nickname) {
@@ -98,6 +99,7 @@ public class User extends BaseTimeEntity {
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
     private LeagueTier maxLeague = LeagueTier.STONE;
 
     @Builder.Default

--- a/apps/backend/src/main/resources/db/migration/V12__add_max_league_default_and_not_null.sql
+++ b/apps/backend/src/main/resources/db/migration/V12__add_max_league_default_and_not_null.sql
@@ -1,0 +1,6 @@
+-- V12__add_max_league_default_and_not_null.sql
+-- 1. 기존에 max_league가 NULL인 유저들의 값을 'STONE'으로 업데이트
+UPDATE users SET max_league = 'STONE' WHERE max_league IS NULL;
+
+-- 2. max_league 컬럼을 NOT NULL로 변경하고 기본값 설정 (MariaDB/MySQL)
+ALTER TABLE users MODIFY COLUMN max_league VARCHAR(255) NOT NULL DEFAULT 'STONE';


### PR DESCRIPTION
## 💡 의도 / 배경
<!-- 무엇을, 왜 변경했는지 설명해주세요. 배경 및 문제를 적어주세요. -->
- 기존에는 회원가입 시나리오 등에서 최상위 달성 리그(`max_league`) 값이 NULL로 삽입되거나 초기화가 누락되는 문제가 있었습니다.
- 데이터 정합성을 보장하고 프론트엔드/백엔드 로직에서 NullPointerException 등의 오류를 방지하기 위해, 모든 신규 유저가 기본적으로 'STONE' 티어의 값을 갖도록 DB와 엔티티 레벨에서 엄격하게 제한을 추가했습니다.

## 🛠️ 작업 내용
<!-- 주요 구현 사항, 로직 변경, 추가된 기능 등을 리스트업 해주세요. -->
- [x] **JPA Entity ([User.java](cci:7://file:///f:/ssafy/prj/Peekle/apps/backend/src/main/java/com/peekle/domain/user/entity/User.java:0:0-0:0)) 수정**
  - `maxLeague` 필드에 `@Column(nullable = false, length = 20)` 어노테이션 추가
  - [User](cci:2://file:///f:/ssafy/prj/Peekle/apps/backend/src/main/java/com/peekle/domain/user/entity/User.java:12:0-201:1) 신규 생성자 파라미터 내부에 `this.maxLeague = LeagueTier.STONE;` 명시적 초기화 로직 추가
- [x] **Flyway DB 마이그레이션 ([V12__add_max_league_default_and_not_null.sql](cci:7://file:///f:/ssafy/prj/Peekle/apps/backend/src/main/resources/db/migration/V12__add_max_league_default_and_not_null.sql:0:0-0:0)) 추가**
  - 기존 레거시 데이터 중 `max_league`가 `NULL`인 유저들을 모두 `'STONE'`으로 일괄 업데이트 (`UPDATE`)
  - `max_league` 컬럼 자체에 `NOT NULL DEFAULT 'STONE'` 조건 강제 (`ALTER TABLE`)

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: Closes #123) -->
- Closes #37 

## 🖼️ 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요. -->


## 🧪 테스트 방법
<!-- 이 PR이 어떻게 테스트되었는지, 리뷰어가 어떻게 테스트해 볼 수 있는지 적어주세요. -->
- [x] 새로운 계정으로 회원가입 후 DB의 `user` 테이블에 접속하여 `max_league` 레코드가 정상적으로 `STONE`으로 찍혀 있는지 확인합니다. 
- [x] 기존에 존재하던 유저들의 `max_league` 빈 값이 마이그레이션을 통해 `STONE`으로 잘 갱신되었는지 확인합니다.

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
<!-- 같이 리뷰받고 싶은 부분이나 특별히 확인해야 할 사항이 있다면 적어주세요. -->
- DB 마이그레이션 스크립트(V12)가 포함되어 있습니다. 풀 전/후 로컬 백엔드를 재실행하여 마이그레이션이 정상 적용되는지 확인 후 개발해 주세요!
