### PR TITLE
fix: 프로필 이미지 깨지는 문제 수정

### DIFF
--- a/apps/extension/popup.js
+++ b/apps/extension/popup.js
@@ -189,18 +189,14 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
 
-        // 프로필 이미지 표시 (없으면 DiceBear API 사용)
+        // 프로필 이미지 표시
         const tierIconEl = document.getElementById('tier-icon');
         const rawImgUrl = data.profileImg || data.profileImage;
-        let imgUrl;
+        if (!rawImgUrl) return;
 
-        if (rawImgUrl) {
-            // URL에 공백 등이 있을 수 있으므로 인코딩 후 Next.js Image Proxy 사용
-            const encodedUrl = encodeURIComponent(rawImgUrl);
-            imgUrl = `${frontendBaseUrl}/_next/image?url=${encodedUrl}&w=256&q=75`;
-        } else {
-            imgUrl = `https://api.dicebear.com/9.x/bottts-neutral/svg?seed=${encodeURIComponent(data.nickname || 'user')}`;
-        }
+        // URL에 공백 등이 있을 수 있으므로 인코딩 후 Next.js Image Proxy 사용
+        const encodedUrl = encodeURIComponent(rawImgUrl);
+        const imgUrl = `${frontendBaseUrl}/_next/image?url=${encodedUrl}&w=256&q=75`;
 
         tierIconEl.innerHTML = `<img src="${imgUrl}" alt="Profile Image" style="width:100%; height:100%; object-fit:cover; border-radius:50%; background-color:#eee;">`;
 

--- a/apps/frontend/src/components/UserIcon.tsx
+++ b/apps/frontend/src/components/UserIcon.tsx
@@ -1,7 +1,5 @@
 import Image from 'next/image';
-import { getDefaultProfileImgUrl } from '@/lib/utils';
 import { cn } from '@/lib/utils';
-import { useState } from 'react';
 
 interface UserIconProps {
   src?: string | null;
@@ -25,15 +23,10 @@ export function UserIcon({
   className,
   unoptimized = false,
 }: UserIconProps) {
-  const [error, setError] = useState(false);
-
   // user 객체가 있으면 거기서 정보를 가져옴
   const finalNickname = nickname || user?.nickname;
   const userImage = user?.profileImg || user?.profileImage; // Handle both likely property names if types vary
-  const sourceUrl = src || userImage;
-
-  const fallbackUrl = getDefaultProfileImgUrl(finalNickname);
-  const finalSrc = error || !sourceUrl ? fallbackUrl : sourceUrl;
+  const finalSrc = (src || userImage) as string;
 
   return (
     <div
@@ -49,8 +42,7 @@ export function UserIcon({
         width={size}
         height={size}
         className="w-full h-full object-cover"
-        onError={() => setError(true)}
-        unoptimized={unoptimized || finalSrc.includes('dicebear.com')}
+        unoptimized={unoptimized}
       />
     </div>
   );

--- a/apps/frontend/src/domains/profile/components/CCProfileHeader.tsx
+++ b/apps/frontend/src/domains/profile/components/CCProfileHeader.tsx
@@ -116,7 +116,7 @@ export function CCProfileHeader({
         {/* Profile Image (Placeholder based on nickname) */}
         <div className="relative w-24 h-24 md:w-28 md:h-28 rounded-full flex items-center justify-center shrink-0 overflow-hidden group">
           {/* 프로필 상세 페이지에서는 항상 고해상도 이미지(profileImg)를 우선 사용 */}
-          {/* profileImg가 없으면 썸네일(profileImgThumb) -> 둘 다 없으면 기본 이미지(DiceBear) */}
+          {/* profileImg가 없으면 썸네일(profileImgThumb)을 사용 */}
           <UserIcon
             src={user.profileImg || user.profileImgThumb}
             nickname={user.nickname}

--- a/apps/frontend/src/domains/ranking/components/StudyRankingList.tsx
+++ b/apps/frontend/src/domains/ranking/components/StudyRankingList.tsx
@@ -7,6 +7,7 @@ import type { RankResponse } from '@/api/rankingApi';
 import PeopleIcon from '@/assets/icons/people.svg';
 import TrophyIcon from '@/assets/icons/trophy.svg';
 import { CCUserProfileModal } from '@/components/common/CCUserProfileModal';
+import { UserIcon } from '@/components/UserIcon';
 
 interface StudyRankingListProps {
   rankings: RankResponse[];
@@ -226,7 +227,7 @@ export function StudyRankingList({
                       </h4>
                       <div className="grid gap-3">
                         {ranking.members.map((member) => {
-                          const displayImg = member.profileImgThumb || member.profileImg;
+                          const displayImg = member.profileImg || member.profileImgThumb;
                           return (
                             <div
                               key={member.userId}
@@ -234,17 +235,12 @@ export function StudyRankingList({
                               onClick={() => handleUserClick(member.nickname)}
                             >
                               <div className="flex items-center gap-3">
-                                {displayImg ? (
-                                  <img
-                                    src={encodeURI(displayImg)}
-                                    alt={member.nickname}
-                                    className="h-10 w-10 rounded-full bg-slate-100 border border-slate-100"
-                                  />
-                                ) : (
-                                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 border border-slate-100 text-sm font-bold text-slate-500">
-                                    {member.nickname.charAt(0)}
-                                  </div>
-                                )}
+                                <UserIcon
+                                  src={displayImg}
+                                  nickname={member.nickname}
+                                  size={40}
+                                  className="border-slate-100"
+                                />
                                 <div className="flex flex-col">
                                   <span className="font-bold text-slate-700 text-sm dark:text-card-foreground">
                                     {member.nickname}

--- a/apps/frontend/src/domains/ranking/components/TopThreePodium.tsx
+++ b/apps/frontend/src/domains/ranking/components/TopThreePodium.tsx
@@ -3,6 +3,7 @@
 import { Trophy, Medal, Award, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { RankResponse, StudyMemberResponse } from '@/api/rankingApi';
+import { UserIcon } from '@/components/UserIcon';
 
 interface TopThreePodiumProps {
   rankings: RankResponse[];
@@ -18,23 +19,15 @@ const MemberIcons = ({
 }): React.ReactNode => (
   <div className="flex items-center justify-center -space-x-2">
     {members.slice(0, limit).map((m) => {
-      const displayImg = m.profileImgThumb || m.profileImg;
-      return displayImg ? (
-        <img
+      const displayImg = m.profileImg || m.profileImgThumb;
+      return (
+        <UserIcon
           key={m.userId}
-          src={encodeURI(displayImg)}
-          alt={m.nickname}
-          className="h-6 w-6 rounded-full border-2 border-background bg-muted"
-          title={m.nickname}
+          src={displayImg}
+          nickname={m.nickname}
+          size={24}
+          className="border-2 border-background"
         />
-      ) : (
-        <div
-          key={m.userId}
-          className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-background bg-muted text-[10px] font-bold text-slate-500"
-          title={m.nickname}
-        >
-          {m.nickname.charAt(0)}
-        </div>
       );
     })}
     {members.length > limit && (

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -77,10 +77,3 @@ export function hexToHsl(hex: string): string {
   return `${Math.round(h * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
 }
 
-/**
- * 사용자 닉네임 기반으로 기본 아바타 (DiceBear Bottts Neutral) URL을 생성합니다.
- */
-export function getDefaultProfileImgUrl(nickname?: string): string {
-  const seed = nickname || 'peekle';
-  return `https://api.dicebear.com/9.x/bottts-neutral/svg?seed=${encodeURIComponent(seed)}`;
-}


### PR DESCRIPTION
## 💡 의도 / 배경
랭킹 페이지에서 일부 프로필 이미지가 깨져 보이는 이슈가 있었고, 이미지 렌더링 경로가 컴포넌트별로 달라 일관성이 부족했습니다.  
또한 기본 아바타(DiceBear) fallback 로직이 남아 있어, 현재 정책(가입 시 프로필 이미지 보장)과 맞지 않는 분기/의존 코드를 정리할 필요가 있었습니다.

## 🛠️ 작업 내용
- [x] 랭킹 페이지 프로필 이미지 렌더링을 `UserIcon`으로 통일
- [x] 랭킹 멤버 이미지 소스 우선순위를 `profileImg > profileImgThumb`으로 조정
- [x] `UserIcon`의 DiceBear fallback 및 null 분기 제거
- [x] `getDefaultProfileImgUrl` 유틸 제거 및 참조 정리
- [x] 확장 프로그램 popup의 DiceBear fallback 제거

## 🔗 관련 이슈
- Closes #34 

## 🖼️ 스크린샷 (선택)

## 🧪 테스트 방법
- [x] 랭킹 페이지 진입 후 Top3 카드/스터디 멤버 목록에서 프로필 이미지가 정상 렌더링되는지 확인
- [x] 깨졌던 계정(특수문자/인코딩 포함 URL 포함)으로 동일 현상 재현 여부 확인
- [x] 프로필 모달 진입 시 이미지가 정상 표시되는지 확인
- [x] 확장 프로그램 popup에서 프로필 이미지가 정상 표시되는지 확인
- [x] `node --check apps/extension/popup.js` 실행

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
`UserIcon` fallback 제거 전제는 “가입/프로필 변경 시 이미지 URL이 항상 보장된다”는 현재 정책입니다.  
랭킹(Top3 + 멤버 리스트) 중심으로 회귀 확인 부탁드립니다.
