### PR TITLE
fix: 작성자 및 언어가 두번 나오는 문제 수정

### DIFF
--- a/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
@@ -249,11 +249,7 @@ print("Hello World!")`;
     : '저장 코드 문제';
   const otherProblemLabel =
     viewMode === 'SPLIT_SAVED'
-      ? (() => {
-          const title = (targetSubmission?.problemTitle || '저장된 코드').trim();
-          if (!savedCodeMetaLabel) return title;
-          return `${title} (${savedCodeMetaLabel})`;
-        })()
+      ? targetSubmission?.problemTitle || '저장된 코드'
       : (() => {
           const title = (realtimeProblemTitle || '').trim();
           if (!title) return '문제 선택 중';


### PR DESCRIPTION
## 💡 의도 / 배경
저장 코드 보기(SPLIT_SAVED) 화면에서 작성자/언어 정보가 상단 라벨과 문제 제목 라벨에 중복 노출되고 있었습니다.

예:
- 저장 코드 (프사사C · Java)
- A+B (프사사C · Java)

동일 정보가 두 번 보여 시각적으로 번잡하고 가독성이 떨어져, 정보 노출 위치를 한 곳으로 정리했습니다.

## 🛠️ 작업 내용
- [x] SPLIT_SAVED 문제 제목 라벨(`otherProblemLabel`)에서 작성자/언어 suffix 제거
- [x] 상단 라벨(`저장 코드 (작성자 · 언어)`)은 유지하여 핵심 메타 정보는 계속 노출
- [x] 타입체크로 회귀 여부 확인

## 🔗 관련 이슈
- Closes #56

## 🖼️ 스크린샷 (선택)
- 변경 전: `저장 코드 (작성자 · 언어)` + `문제명 (작성자 · 언어)` 중복 노출
- 변경 후: `저장 코드 (작성자 · 언어)` + `문제명` 단일 노출

## 🧪 테스트 방법
- [x] 스터디방 진입 후 문제보관함에서 저장 코드 열기
- [x] 우측 패널 상단 라벨은 작성자/언어가 보이고, 문제명 라벨에는 중복 표시가 없는지 확인
- [x] `pnpm --filter frontend run type-check` 통과

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
SPLIT_SAVED 헤더 정보 구조를 정리한 수정입니다.  
작성자/언어는 상단 라벨에서만 유지하고, 문제명 라벨은 순수 제목만 보여주도록 통일했습니다.
