### PR TITLE
feat: 확장프로그램 ui 개선

### DIFF
--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Peekle: Baekjoon Track Submission",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "description": "힐끔힐끔코딩 - 백준 문제 풀이 자동 기록 및 알림",
     "permissions": [
         "storage",

--- a/apps/extension/popup.css
+++ b/apps/extension/popup.css
@@ -1,0 +1,227 @@
+:root {
+    --background: #f4f4f7;
+    --foreground: #09090b;
+    --card: #ffffff;
+    --card-foreground: #09090b;
+    --muted: #f3f4f6;
+    --muted-foreground: #71717a;
+    --border: #f3f4f6;
+    --primary: #e24ea0;
+    --primary-foreground: #ffffff;
+}
+
+body {
+    width: 300px;
+    padding: 16px;
+    font-family: 'Pretendard', sans-serif;
+    background-color: var(--background);
+    color: var(--foreground);
+    margin: 0;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+h3 {
+    margin: 0 0 12px 0;
+    font-size: 18px;
+    color: var(--foreground);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.brand-color {
+    color: var(--primary);
+}
+
+.local-badge {
+    display: none;
+    font-size: 10px;
+    background: #ff4444;
+    color: #ffffff;
+    padding: 2px 6px;
+    border-radius: 4px;
+    vertical-align: middle;
+    margin-left: 4px;
+}
+
+.user-card {
+    background: var(--card);
+    padding: 16px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    margin-bottom: 12px;
+    border: 1px solid var(--border);
+    color: var(--card-foreground);
+}
+
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.tier-badge {
+    width: 48px;
+    height: 48px;
+    background: var(--muted);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+}
+
+.tier-badge img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.tier-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+    background-color: #eeeeee;
+}
+
+.nickname {
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: -0.025em;
+    color: var(--card-foreground);
+    line-height: 1.2;
+}
+
+.league-name {
+    font-size: 12px;
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.boj-id {
+    font-size: 11px;
+    color: var(--muted-foreground);
+    margin-top: 2px;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.stat-item {
+    background: var(--muted);
+    padding: 10px;
+    border-radius: 8px;
+    text-align: center;
+    border: 1px solid var(--border);
+}
+
+.stat-item-wide {
+    grid-column: 1 / -1;
+}
+
+.stat-label {
+    font-size: 11px;
+    color: var(--muted-foreground);
+    margin-bottom: 4px;
+}
+
+.stat-value {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--card-foreground);
+}
+
+.context-status {
+    font-size: 15px;
+    color: var(--primary);
+}
+
+.streak-row {
+    font-size: 11px;
+    color: var(--muted-foreground);
+    margin-bottom: 4px;
+}
+
+.user-streak {
+    color: var(--card-foreground);
+    font-weight: 700;
+}
+
+.today-status {
+    font-size: 15px;
+}
+
+.btn-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.is-hidden-initial {
+    display: none;
+}
+
+button {
+    padding: 12px;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-weight: 700;
+    font-size: 14px;
+    transition: opacity 0.2s, background-color 0.2s, color 0.2s;
+}
+
+button:active {
+    opacity: 0.8;
+}
+
+.icon-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0;
+}
+
+.btn-primary {
+    background-color: var(--primary);
+    color: var(--primary-foreground);
+}
+
+#logout-btn {
+    font-size: 12px;
+    color: var(--muted-foreground);
+    text-decoration: underline;
+    background: none;
+    padding: 4px;
+    margin-top: 8px;
+}
+
+#status {
+    font-size: 11px;
+    text-align: center;
+    color: var(--muted-foreground);
+    opacity: 0.7;
+}
+
+.rank-wait {
+    font-size: 12px;
+    color: var(--muted-foreground);
+}
+
+.rank-main {
+    font-weight: 700;
+}
+
+.rank-status {
+    font-size: 10px;
+    color: var(--rank-status-color, var(--muted-foreground));
+}

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -1,164 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="ko">
 
 <head>
     <meta charset="UTF-8" />
-    <style>
-        :root {
-            /* Default Light Mode Colors (will be overridden by popup.js) */
-            --background: #f4f4f7;
-            --foreground: #09090b;
-            --card: #ffffff;
-            --card-foreground: #09090b;
-            --muted: #f3f4f6;
-            --muted-foreground: #71717a;
-            --border: #f3f4f6;
-            --primary: #E24EA0;
-            --primary-foreground: #ffffff;
-        }
-
-        body {
-            width: 300px;
-            padding: 16px;
-            font-family: 'Pretendard', sans-serif;
-            background-color: var(--background);
-            color: var(--foreground);
-            margin: 0;
-            transition: background-color 0.2s, color 0.2s;
-        }
-
-        h3 {
-            margin: 0 0 12px 0;
-            font-size: 18px;
-            color: var(--foreground);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .brand-color {
-            color: var(--primary);
-        }
-
-        .user-card {
-            background: var(--card);
-            padding: 16px;
-            border-radius: 12px;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-            margin-bottom: 12px;
-            border: 1px solid var(--border);
-            color: var(--card-foreground);
-        }
-
-        .user-info {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            margin-bottom: 16px;
-        }
-
-        .tier-badge {
-            width: 48px;
-            height: 48px;
-            background: var(--muted);
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 20px;
-            overflow: hidden;
-            border: 1px solid var(--border);
-        }
-
-        .tier-badge img {
-            width: 100%;
-            height: 100%;
-            object-fit: contain;
-        }
-
-        .nickname {
-            font-size: 18px;
-            font-weight: 700;
-            letter-spacing: -0.025em;
-            color: var(--card-foreground);
-            line-height: 1.2;
-        }
-
-        .stats-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 8px;
-            margin-bottom: 16px;
-        }
-
-        .stat-item {
-            background: var(--muted);
-            padding: 10px;
-            border-radius: 8px;
-            text-align: center;
-            border: 1px solid var(--border);
-        }
-
-        .stat-label {
-            font-size: 11px;
-            color: var(--muted-foreground);
-            margin-bottom: 4px;
-        }
-
-        .stat-value {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--card-foreground);
-        }
-
-        .btn-group {
-            display: flex;
-            flex-direction: column;
-            gap: 8px;
-        }
-
-        button {
-            padding: 12px;
-            border: none;
-            border-radius: 8px;
-            cursor: pointer;
-            font-weight: 700;
-            font-size: 14px;
-            transition: opacity 0.2s, background-color 0.2s, color 0.2s;
-        }
-
-        button:active {
-            opacity: 0.8;
-        }
-
-        .btn-primary {
-            background-color: var(--primary);
-            color: var(--primary-foreground);
-        }
-
-        #logout-btn {
-            font-size: 12px;
-            color: var(--muted-foreground);
-            text-decoration: underline;
-            background: none;
-            padding: 4px;
-            margin-top: 8px;
-        }
-
-        #status {
-            font-size: 11px;
-            text-align: center;
-            color: var(--muted-foreground);
-            opacity: 0.7;
-        }
-    </style>
+    <link rel="stylesheet" href="popup.css" />
 </head>
 
 <body>
     <h3>
-        <span>Peekle <span class="brand-color">.</span> <span id="local-badge"
-                style="display:none; font-size:10px; background:#ff4444; color:white; padding:2px 6px; border-radius:4px; vertical-align:middle; margin-left:4px;">LOCAL</span></span>
-        <button id="refresh-btn" style="background:none; border:none; cursor:pointer; font-size:14px;">🔄</button>
+        <span>Peekle <span class="brand-color">.</span> <span id="local-badge" class="local-badge">LOCAL</span></span>
     </h3>
 
     <div class="user-card">
@@ -166,39 +16,39 @@
             <div class="tier-badge" id="tier-icon">💎</div>
             <div>
                 <div class="nickname" id="nickname">연동 확인 중...</div>
-                <div style="font-size:12px; color:var(--primary); font-weight:600;" id="league-name">-</div>
-                <div id="boj-id" style="font-size:11px; color:var(--muted-foreground); margin-top: 2px;"></div>
+                <div class="league-name" id="league-name">-</div>
+                <div class="boj-id" id="boj-id"></div>
             </div>
         </div>
 
         <div class="stats-grid">
             <div class="stat-item">
-                <div class="stat-label">내 점수</div>
+                <div class="stat-label">점수</div>
                 <div class="stat-value" id="user-score">-</div>
             </div>
             <div class="stat-item">
-                <div class="stat-label">현재 순위</div>
+                <div class="stat-label">순위 상태</div>
                 <div class="stat-value" id="user-rank">-</div>
             </div>
-            <div class="stat-item" style="grid-column: 1 / -1;">
+            <div class="stat-item stat-item-wide">
                 <div class="stat-label">현재 상태</div>
-                <div class="stat-value" id="context-status" style="font-size: 15px; color: var(--primary);">일반 모드</div>
+                <div class="stat-value context-status" id="context-status">일반 모드</div>
             </div>
-            <div class="stat-item" style="grid-column: 1 / -1;">
-                <div style="font-size: 11px; color: var(--muted-foreground); margin-bottom: 4px;">
-                    🔥 <span id="user-streak" style="color: var(--card-foreground); font-weight: 700;">-</span> 연속 도전 중
+            <div class="stat-item stat-item-wide">
+                <div class="streak-row">
+                    🔥 <span id="user-streak" class="user-streak">-</span> 연속 도전 중
                 </div>
-                <div class="stat-value" id="today-status" style="font-size: 15px;">-</div>
+                <div class="stat-value today-status" id="today-status">-</div>
             </div>
         </div>
 
-        <div class="btn-group" id="logged-in-btns" style="display: none;">
-            <button class="btn-primary" id="go-site-btn">내 대시보드 바로가기</button>
-            <button id="logout-btn">로그아웃 (토큰 해제)</button>
+        <div class="btn-group is-hidden-initial" id="logged-in-btns">
+            <button class="btn-primary" id="go-site-btn">대시보드 열기</button>
+            <button id="logout-btn">로그아웃</button>
         </div>
 
-        <div class="btn-group" id="logged-out-btns" style="display: none;">
-            <button class="btn-primary" id="link-site-btn">서비스 연동하러 가기</button>
+        <div class="btn-group is-hidden-initial" id="logged-out-btns">
+            <button class="btn-primary" id="link-site-btn">서비스 연결하러 가기</button>
         </div>
     </div>
 

--- a/apps/extension/popup.js
+++ b/apps/extension/popup.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     // [Check Env]
     let frontendBaseUrl = 'https://peekle.today'; // Default to prod
-    let apiBaseUrl = 'https://peekle.today';     // Default to prod
+    let apiBaseUrl = 'https://peekle.today'; // Default to prod
 
     chrome.runtime.sendMessage({ type: 'CHECK_ENV' }, (response) => {
         if (response) {
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const goSiteBtn = document.getElementById('go-site-btn');
     if (goSiteBtn) {
         goSiteBtn.onclick = () => {
-            chrome.tabs.create({ url: `${frontendBaseUrl}/profile/me` });
+            chrome.tabs.create({ url: `${frontendBaseUrl}/home` });
         };
     }
 
@@ -68,10 +68,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 loggedInBtns.style.display = 'none';
                 loggedOutBtns.style.display = 'flex';
 
-                nicknameEl.innerText = "로그인이 필요해요";
-                document.getElementById('league-name').innerText = "-";
-                document.getElementById('tier-icon').innerText = "❓";
-                statusEl.innerText = "사이트에서 계정을 연동해 주세요.";
+                nicknameEl.innerText = '로그인이 필요해요';
+                document.getElementById('league-name').innerText = '-';
+                document.getElementById('tier-icon').innerText = '❓';
+                statusEl.innerText = '사이트에서 계정을 연결해 주세요.';
             }
         });
     }
@@ -83,8 +83,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 // UI 즉시 반영
                 loggedInBtns.style.display = 'none';
                 loggedOutBtns.style.display = 'flex';
-                nicknameEl.innerText = "로그인이 필요해요";
-                statusEl.innerText = "연동이 해제되었습니다.";
+                nicknameEl.innerText = '로그인이 필요해요';
+                statusEl.innerText = '연결이 해제되었습니다.';
                 // 팝업을 닫거나 새로고침
                 location.reload();
             });
@@ -94,18 +94,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // 3. 버튼 이벤트 리스너 (Moved to top with dynamic URL)
     document.getElementById('logout-btn').onclick = handleLogout;
 
-    // Refresh 버튼 (새로고침)
-    const refreshBtn = document.getElementById('refresh-btn');
-    if (refreshBtn) {
-        refreshBtn.onclick = () => {
-            location.reload();
-        };
-    }
-
     // 4. 데이터 갱신 (Backend API Call)
     async function fetchFreshData(token) {
         try {
-            statusEl.innerText = "최신 정보를 가져오는 중...";
+            statusEl.innerText = '최신 정보 가져오는 중';
             const response = await fetch(`${apiBaseUrl}/api/users/me/profile`, {
                 headers: { 'X-Peekle-Token': token }
             });
@@ -129,23 +121,24 @@ document.addEventListener('DOMContentLoaded', () => {
                             userData.leagueStatus = statusJson.data.leagueStatus;
                             userData.bojId = statusJson.data.bojId;
                             userData.leagueGroupId = statusJson.data.leagueGroupId;
+                            userData.totalGroupMembers = statusJson.data.totalGroupMembers;
                         }
                     }
 
                     // 캐싱
                     chrome.storage.local.set({ userData: userData });
                     updateUI(userData);
-                    statusEl.innerText = "최신 데이터로 업데이트되었습니다.";
+                    statusEl.innerText = '방금 업데이트';
                 } else {
                     // 토큰이 만료되었거나 유효하지 않은 경우 처리
-                    statusEl.innerText = "정보를 가져오는데 실패했습니다.";
+                    statusEl.innerText = '프로필 정보를 불러오지 못했어요';
                 }
             } else {
-                statusEl.innerText = "서버와 통신이 원활하지 않습니다.";
+                statusEl.innerText = '서버와 통신할 수 없어요';
             }
         } catch (e) {
             console.error(e);
-            statusEl.innerText = "네트워크 오류가 발생했습니다.";
+            statusEl.innerText = '네트워크 오류가 발생했어요';
         }
     }
 
@@ -153,39 +146,43 @@ document.addEventListener('DOMContentLoaded', () => {
     function updateUI(data) {
         if (!data) return;
 
-        nicknameEl.innerText = data.nickname || "알 수 없음";
-        document.getElementById('boj-id').innerText = data.bojId ? `boj: ${data.bojId}` : "";
+        nicknameEl.innerText = data.nickname || '닉네임 없음';
+        document.getElementById('boj-id').innerText = data.bojId ? `BOJ: ${data.bojId}` : '';
         document.getElementById('league-name').innerText = getLeagueDisplayName(data.leagueName);
-        document.getElementById('user-score').innerText = (data.score || 0) + "점";
+        document.getElementById('user-score').innerText = (data.score || 0) + '점';
 
         // 순위와 상태 함께 표시
         const rankEl = document.getElementById('user-rank');
         if (data.totalGroupMembers < 4) {
             // 그룹 명수가 4명 미만이면: 리그명이 stone이면 배치 대기, 아니면 쉬는 중
             const leagueName = (data.leagueName || '').toLowerCase();
-            const waitMsg = leagueName === 'stone' ? '배치 대기' : '이번주 쉬는 중';
-            rankEl.innerHTML = `<span style="font-size: 12px; color: var(--muted-foreground);">${waitMsg}</span>`;
+            const waitMsg = leagueName === 'stone' ? '배치 대기' : '이번 주 쉬는 중';
+            rankEl.innerHTML = `<span class="rank-wait">${waitMsg}</span>`;
+            rankEl.style.removeProperty('--rank-status-color');
         } else if (data.groupRank) {
             const statusText = getStatusText(data.leagueStatus);
-            rankEl.innerHTML = `<span style="font-weight: 700;">${data.groupRank}위</span> <span style="font-size: 10px; color: ${getStatusColor(data.leagueStatus)};">${statusText}</span>`;
+            rankEl.style.setProperty('--rank-status-color', getStatusColor(data.leagueStatus));
+            rankEl.innerHTML = `<span class="rank-main">${data.groupRank}위</span> <span class="rank-status">${statusText}</span>`;
         } else if (data.rank) {
-            rankEl.innerText = data.rank + "위";
+            rankEl.innerText = data.rank + '위';
+            rankEl.style.removeProperty('--rank-status-color');
         } else {
-            rankEl.innerText = "-";
+            rankEl.innerText = '-';
+            rankEl.style.removeProperty('--rank-status-color');
         }
 
         // [New] 스트릭 및 오늘 문제 상태
         const streakEl = document.getElementById('user-streak');
-        if (streakEl) streakEl.innerText = (data.streakCurrent || 0) + "일";
+        if (streakEl) streakEl.innerText = (data.streakCurrent || 0) + '일';
 
         const todayStatusEl = document.getElementById('today-status');
         if (todayStatusEl) {
             if (data.isSolvedToday) {
-                todayStatusEl.innerText = "오늘의 문제 완료! 🎉";
-                todayStatusEl.style.color = "var(--primary)";
+                todayStatusEl.innerText = '오늘 문제 해결 완료';
+                todayStatusEl.style.color = 'var(--primary)';
             } else {
-                todayStatusEl.innerText = "아직 문제를 풀지 않았어요";
-                todayStatusEl.style.color = "var(--muted-foreground)";
+                todayStatusEl.innerText = '아직 문제를 풀지 않았어요';
+                todayStatusEl.style.color = 'var(--muted-foreground)';
             }
         }
 
@@ -198,16 +195,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const encodedUrl = encodeURIComponent(rawImgUrl);
         const imgUrl = `${frontendBaseUrl}/_next/image?url=${encodedUrl}&w=256&q=75`;
 
-        tierIconEl.innerHTML = `<img src="${imgUrl}" alt="Profile Image" style="width:100%; height:100%; object-fit:cover; border-radius:50%; background-color:#eee;">`;
-
+        tierIconEl.innerHTML = `<img src="${imgUrl}" alt="Profile Image" class="tier-image">`;
     }
 
     // Helper: Get status text
     function getStatusText(status) {
         const statusMap = {
-            'PROMOTE': '승급예정',
-            'STAY': '유지',
-            'DEMOTE': '강등위기'
+            PROMOTE: '승급 예정',
+            STAY: '유지',
+            DEMOTE: '강등 위기'
         };
         return statusMap[status] || '';
     }
@@ -215,9 +211,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Helper: Get status color
     function getStatusColor(status) {
         const colorMap = {
-            'PROMOTE': 'var(--primary)',
-            'STAY': 'var(--muted-foreground)',
-            'DEMOTE': '#ef4444'
+            PROMOTE: 'var(--primary)',
+            STAY: 'var(--muted-foreground)',
+            DEMOTE: '#ef4444'
         };
         return colorMap[status] || 'var(--muted-foreground)';
     }
@@ -288,7 +284,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         root.style.setProperty('--primary', primaryColor);
 
-        // 추가: 오늘 문제 완료 상태 텍스트 색상 실시간 반영용 (변수가 이미 설정되어 있으므로 명시적 호출 불필요할 수 있으나 안전장치)
+        // 추가: 오늘 문제 완료 상태 텍스트 색상 실시간 반영용
         const statusText = document.getElementById('today-status');
         if (statusText) {
             if (statusText.innerText.includes('완료')) {
@@ -308,21 +304,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 const type = task.sourceType || 'EXTENSION';
 
                 if (type === 'STUDY') {
-                    contextEl.innerText = `📚 스터디 진행 중`;
+                    contextEl.innerText = '📚 스터디 진행 중';
                     contextEl.style.color = 'var(--primary)';
                 } else if (type === 'GAME') {
-                    contextEl.innerText = `🎮 게임 진행 중`;
-                    contextEl.style.color = '#f97316'; // Orange
+                    contextEl.innerText = '🎮 게임 진행 중';
+                    contextEl.style.color = '#f97316';
                 } else {
-                    contextEl.innerText = `📝 문제 풀이 중`;
+                    contextEl.innerText = '📝 문제 풀이 중';
                     contextEl.style.color = 'var(--foreground)';
                 }
 
                 if (task.consumed) {
-                    contextEl.innerText += " (제출 대기)";
+                    contextEl.innerText += ' (제출 대기)';
                 }
             } else if (contextEl) {
-                contextEl.innerText = `대기 중인 작업 없음`;
+                contextEl.innerText = '대기 중인 작업 없음';
                 contextEl.style.color = 'var(--muted-foreground)';
             }
         });

--- a/apps/extension/version.json
+++ b/apps/extension/version.json
@@ -1,6 +1,6 @@
 {
-    "latestVersion": "0.2.2",
-    "minVersion": "0.2.2",
+    "latestVersion": "0.2.4",
+    "minVersion": "0.2.4",
     "downloadUrl": "https://pub-09a6ac9bff27427fabb6a07fc05033c0.r2.dev/extension/peekle-extension.zip",
-    "releaseNotes": "스터디 방 화면 분할 기능 추가"
+    "releaseNotes": "리그 진행 못하는 유저 알게 개선"
 }


### PR DESCRIPTION
## 💡 의도 / 배경
<!-- 무엇을, 왜 변경했는지 설명해주세요. 배경 및 문제를 적어주세요. -->
확장프로그램 팝업 UI에서 문구와 실제 동작이 일부 불일치하고(내 대시보드 바로가기, 로그아웃 (토큰 해제), boj: 표기 등), 인라인 스타일이 많아 유지보수 난이도가 높았습니다.
이번 변경은 기존 UI 구조는 유지하면서 문구/동작 일치와 스타일 분리를 통해 사용자 혼란을 줄이고 추후 수정 비용을 낮추기 위한 작업입니다.
## 🛠️ 작업 내용
<!-- 주요 구현 사항, 로직 변경, 추가된 기능 등을 리스트업 해주세요. -->
- [x]  팝업 스타일 인라인 CSS를 popup.css로 분리
- [x] 문구 개선 적용 (대시보드 열기, 로그아웃, BOJ
- [x] 불필요한 새로고침 버튼 제거
- [x] 대시보드 열기 버튼 이동 경로를 /home으로 수정
- [x] 기존 연동 버튼(/profile/me) 및 테마/데이터 로직은 유지
## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: Closes #123) -->
- Closes #67 

## 🖼️ 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요. -->
<img width="326" height="492" alt="image" src="https://github.com/user-attachments/assets/affb2aee-9a6f-4533-a63b-6c50239a9fa7" />


## 🧪 테스트 방법
<!-- 이 PR이 어떻게 테스트되었는지, 리뷰어가 어떻게 테스트해 볼 수 있는지 적어주세요. -->
- [x] 확장프로그램 로드 후 팝업 열기
- [x] 로그인 상태에서 버튼 문구 확인: 대시보드 열기, 로그아웃
- [x] 대시보드 열기 클릭 시 /home 이동 확인
- [x] BOJ ID 라벨이 BOJ:로 표시되는지 확인
- [x] 로그아웃/미로그인 상태 전환 시 버튼/문구 정상 노출 확인
- [x] 다크/라이트 및 accent 변경 시 스타일 정상 반영 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
<!-- 같이 리뷰받고 싶은 부분이나 특별히 확인해야 할 사항이 있다면 적어주세요. -->
