### PR TITLE
feat: 댓글 ui 개선

### DIFF
--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -341,3 +341,53 @@ div[class*='monaco-editor-overlaymessage'],
     /* Firefox */
   }
 }
+
+.monaco-editor .peekle-comment-glyph {
+  position: relative;
+  cursor: pointer;
+  pointer-events: auto !important;
+}
+
+.monaco-editor .peekle-comment-glyph::before {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 5px;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: hsl(var(--primary));
+  box-shadow: 0 0 0 1px hsl(var(--background));
+}
+
+.monaco-editor .peekle-comment-inline-badge {
+  color: hsl(var(--muted-foreground));
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  pointer-events: auto !important;
+}
+
+.monaco-editor .peekle-comment-inline-dot {
+  color: hsl(var(--primary));
+  font-weight: 700;
+  cursor: pointer;
+  pointer-events: auto !important;
+}
+
+.monaco-editor .peekle-comment-line-number {
+  position: relative;
+  cursor: pointer;
+}
+
+.monaco-editor .peekle-comment-line-number::after {
+  content: '';
+  position: absolute;
+  right: -9px;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: hsl(var(--primary));
+  transform: translateY(-50%);
+}

--- a/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
@@ -16,7 +16,7 @@ import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
 import { apiFetch } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-import { ChevronUp, ChevronDown, Lock, MessageSquare, Send, CornerDownRight, Plus } from 'lucide-react';
+import { ChevronUp, ChevronDown, Lock, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 
 interface CCCenterPanelProps {
@@ -139,11 +139,17 @@ print("Hello World!")`;
   const selectedProblemExternalId = useRoomStore((state) => state.selectedProblemExternalId);
   const isWhiteboardOverlayOpen = useRoomStore((state) => state.isWhiteboardOverlayOpen);
   const socket = useSocket(roomId, currentUserId);
+  const setRightPanelActiveTab = useRoomStore((state) => state.setRightPanelActiveTab);
+  const setIsRightPanelFolded = useRoomStore((state) => state.setIsRightPanelFolded);
   const targetSubmissionId = targetSubmission?.submissionId;
 
   const savedEditorRef = useRef<any>(null);
   const inlineZoneIdsRef = useRef<string[]>([]);
   const inlineDraftZoneIdRef = useRef<string | null>(null);
+  const inlineMarkerDecorationIdsRef = useRef<string[]>([]);
+  const inlineGlyphCountStyleRef = useRef<HTMLStyleElement | null>(null);
+  const savedEditorContainerRef = useRef<HTMLElement | null>(null);
+  const marginPointerListenerRef = useRef<((event: PointerEvent) => void) | null>(null);
   const hoveredLineRef = useRef<number | null>(null);
   const hoverHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isHoveringAddButtonRef = useRef(false);
@@ -308,6 +314,87 @@ print("Hello World!")`;
     return map;
   }, [generalComments]);
 
+  const inlineLineSummaries = useMemo(() => {
+    const groupedByLine = new Map<number, { lineNumber: number; commentCount: number }>();
+
+    inlineRootComments.forEach((comment) => {
+      const lineNumber = Math.max(1, comment.lineStart || 1);
+      const replyCount = (inlineRepliesByParent.get(comment.id) || []).length;
+      const previous = groupedByLine.get(lineNumber);
+
+      if (!previous) {
+        groupedByLine.set(lineNumber, { lineNumber, commentCount: 1 + replyCount });
+        return;
+      }
+
+      previous.commentCount += 1 + replyCount;
+    });
+
+    return Array.from(groupedByLine.values()).sort((a, b) => a.lineNumber - b.lineNumber);
+  }, [inlineRootComments, inlineRepliesByParent]);
+
+  const inlineCommentLineSet = useMemo(
+    () => new Set(inlineLineSummaries.map((summary) => summary.lineNumber)),
+    [inlineLineSummaries],
+  );
+
+  const clearInlineMarkers = useCallback(() => {
+    const editor = savedEditorRef.current;
+    if (!editor) return;
+
+    inlineMarkerDecorationIdsRef.current = editor.deltaDecorations(
+      inlineMarkerDecorationIdsRef.current,
+      [],
+    );
+  }, []);
+
+  const syncInlineGlyphCountStyles = useCallback((summaries: Array<{ commentCount: number }>) => {
+    if (typeof document === 'undefined') return;
+
+    const labelsByKey = new Map<string, string>();
+    summaries.forEach((summary) => {
+      const count = Math.max(1, summary.commentCount || 1);
+      const key = count > 99 ? '99p' : String(count);
+      const label = count > 99 ? '99+' : String(count);
+      labelsByKey.set(key, label);
+    });
+
+    if (!inlineGlyphCountStyleRef.current) {
+      const styleEl = document.createElement('style');
+      styleEl.setAttribute('data-peekle-inline-glyph-count', 'true');
+      document.head.appendChild(styleEl);
+      inlineGlyphCountStyleRef.current = styleEl;
+    }
+
+    const rules = Array.from(labelsByKey.entries())
+      .map(([key, label]) => `
+.monaco-editor .peekle-comment-glyph--count-${key}::after {
+  content: '${label}';
+  position: absolute;
+  left: 16px;
+  top: 1px;
+  min-width: 14px;
+  height: 12px;
+  padding: 0 3px;
+  border-radius: 999px;
+  background: hsl(var(--primary) / 0.14);
+  color: hsl(var(--foreground));
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 12px;
+  text-align: center;
+  pointer-events: none;
+}
+`)
+      .join('\n');
+
+    inlineGlyphCountStyleRef.current.textContent = rules;
+  }, []);
+
+  const logCommentDebug = useCallback((label: string, payload?: unknown) => {
+    console.info('[peekle-comments]', label, payload ?? '');
+  }, []);
+
   const handleCreateInlineComment = useCallback(async (
     lineNumber: number,
     content: string,
@@ -347,6 +434,7 @@ print("Hello World!")`;
       setInlineEditingCommentId(null);
       setInlineEditingContent('');
       await fetchSubmissionComments();
+      window.dispatchEvent(new CustomEvent('peekle:refresh-submission-comments'));
     } catch {
       toast.error('댓글 저장 중 오류가 발생했습니다.');
     } finally {
@@ -429,6 +517,7 @@ print("Hello World!")`;
       }
 
       await fetchSubmissionComments();
+      window.dispatchEvent(new CustomEvent('peekle:refresh-submission-comments'));
     } catch {
       toast.error('댓글 삭제 중 오류가 발생했습니다.');
     } finally {
@@ -470,6 +559,7 @@ print("Hello World!")`;
       }
 
       await fetchSubmissionComments();
+      window.dispatchEvent(new CustomEvent('peekle:refresh-submission-comments'));
       return true;
     } catch {
       toast.error('댓글 수정 중 오류가 발생했습니다.');
@@ -520,7 +610,9 @@ print("Hello World!")`;
       inlineZoneIdsRef.current = [];
       inlineDraftZoneIdRef.current = null;
 
-      inlineRootComments.forEach((comment) => {
+      const showExpandedInlineThreads = false;
+      if (showExpandedInlineThreads) {
+        inlineRootComments.forEach((comment) => {
         const replies = inlineRepliesByParent.get(comment.id) || [];
         const wrap = document.createElement('div');
         wrap.classList.add('peekle-inline-zone');
@@ -713,8 +805,9 @@ print("Hello World!")`;
           heightInPx: Math.max(104, 104 + replies.length * 42),
           domNode: wrap,
         });
-        inlineZoneIdsRef.current.push(zoneId);
-      });
+          inlineZoneIdsRef.current.push(zoneId);
+        });
+      }
 
       if (inlineDraftLine) {
         const draftWrap = document.createElement('div');
@@ -847,10 +940,93 @@ print("Hello World!")`;
     hideHoverAddButton,
   ]);
 
+  const renderInlineMarkers = useCallback(() => {
+    const editor = savedEditorRef.current;
+    if (!editor) return;
+
+    if (viewMode !== 'SPLIT_SAVED') {
+      clearInlineMarkers();
+      syncInlineGlyphCountStyles([]);
+      return;
+    }
+
+    const decorations = inlineLineSummaries.map((summary) => ({
+      range: {
+        startLineNumber: summary.lineNumber,
+        startColumn: 1,
+        endLineNumber: summary.lineNumber,
+        endColumn: 1,
+      },
+      options: {
+        isWholeLine: true,
+        glyphMarginClassName: `peekle-comment-glyph peekle-comment-glyph--count-${
+          summary.commentCount > 99 ? '99p' : Math.max(1, summary.commentCount || 1)
+        }`,
+        glyphMarginHoverMessage: {
+          value: `L${summary.lineNumber} 댓글 ${summary.commentCount}개`,
+        },
+      },
+    }));
+
+    syncInlineGlyphCountStyles(inlineLineSummaries);
+    inlineMarkerDecorationIdsRef.current = editor.deltaDecorations(
+      inlineMarkerDecorationIdsRef.current,
+      decorations,
+    );
+    logCommentDebug('render-markers', {
+      markerCount: decorations.length,
+      lines: inlineLineSummaries.map((item) => item.lineNumber),
+    });
+  }, [
+    viewMode,
+    inlineLineSummaries,
+    clearInlineMarkers,
+    logCommentDebug,
+    syncInlineGlyphCountStyles,
+  ]);
+
+  const getLineNumberFromMouseTarget = useCallback((target: any): number | null => {
+    const fromPosition = target?.position?.lineNumber;
+    if (Number.isFinite(fromPosition) && fromPosition > 0) return fromPosition;
+
+    const fromRange = target?.range?.startLineNumber;
+    if (Number.isFinite(fromRange) && fromRange > 0) return fromRange;
+
+    const fromDetail = target?.detail?.position?.lineNumber;
+    if (Number.isFinite(fromDetail) && fromDetail > 0) return fromDetail;
+
+    const fromDetailLine = target?.detail?.lineNumber;
+    if (Number.isFinite(fromDetailLine) && fromDetailLine > 0) return fromDetailLine;
+
+    return null;
+  }, []);
+
+  const openCommentsPanelAtLine = useCallback((lineNumber: number | null | undefined) => {
+    if (viewMode !== 'SPLIT_SAVED') return;
+
+    logCommentDebug('open-comments-panel', { lineNumber });
+    setRightPanelActiveTab('comments');
+    setIsRightPanelFolded(false);
+    window.dispatchEvent(
+      new CustomEvent('peekle:open-comments-panel', {
+        detail: { lineNumber },
+      }),
+    );
+    if (!lineNumber) return;
+
+    window.dispatchEvent(
+      new CustomEvent('peekle:select-comment-line', {
+        detail: { lineNumber },
+      }),
+    );
+    focusSavedLine(lineNumber);
+  }, [focusSavedLine, setIsRightPanelFolded, setRightPanelActiveTab, viewMode, logCommentDebug]);
+
   const handleSavedEditorMount = useCallback((editor: any) => {
     savedEditorRef.current = editor;
     const container = editor.getContainerDomNode?.();
     if (container instanceof HTMLElement) {
+      savedEditorContainerRef.current = container;
       container.classList.add('peekle-inline-interactive');
     }
 
@@ -868,13 +1044,97 @@ print("Hello World!")`;
         return;
       }
 
-      const lineNumber = event?.target?.position?.lineNumber;
+      const lineNumber = getLineNumberFromMouseTarget(event?.target);
       if (!lineNumber) {
         hideHoverAddButton();
         return;
       }
 
       updateHoverAddPosition(lineNumber);
+    });
+
+    editor.onMouseDown((event: any) => {
+      if (viewMode !== 'SPLIT_SAVED') return;
+      const targetElement = event?.target?.element as HTMLElement | undefined;
+      const targetType = event?.target?.type;
+      const isGutterTarget = targetType === 2 || targetType === 3 || targetType === 4;
+      const isGlyphTarget =
+        Boolean(targetElement?.classList?.contains('peekle-comment-glyph')) ||
+        Boolean(targetElement?.closest?.('.peekle-comment-glyph'));
+      const isInlineMarkerTarget =
+        Boolean(targetElement?.classList?.contains('peekle-comment-inline-badge')) ||
+        Boolean(targetElement?.closest?.('.peekle-comment-inline-badge')) ||
+        Boolean(targetElement?.classList?.contains('peekle-comment-inline-dot')) ||
+        Boolean(targetElement?.closest?.('.peekle-comment-inline-dot')) ||
+        isGlyphTarget;
+      let lineNumber = getLineNumberFromMouseTarget(event?.target);
+      if (
+        !lineNumber &&
+        (isInlineMarkerTarget || isGutterTarget)
+      ) {
+        lineNumber = hoveredLineRef.current;
+      }
+      if (!lineNumber) {
+        lineNumber = savedEditorRef.current?.getPosition?.()?.lineNumber ?? null;
+      }
+      if (!lineNumber && hoveredLineRef.current) {
+        lineNumber = hoveredLineRef.current;
+      }
+
+      logCommentDebug('mouse-down', {
+        targetType,
+        className: targetElement?.className,
+        isGutterTarget,
+        isGlyphTarget,
+        lineNumber,
+      });
+
+      if (isGutterTarget) {
+        openCommentsPanelAtLine(lineNumber ?? null);
+        return;
+      }
+      const isCommentLine = Boolean(lineNumber && inlineCommentLineSet.has(lineNumber));
+      if (!isCommentLine) return;
+      if (!lineNumber) return;
+      if (targetType === 8) return;
+      openCommentsPanelAtLine(lineNumber);
+    });
+
+    editor.onMouseUp((event: any) => {
+      if (viewMode !== 'SPLIT_SAVED') return;
+
+      const targetElement = event?.target?.element as HTMLElement | undefined;
+      const targetType = event?.target?.type;
+      const isGutterTarget = targetType === 2 || targetType === 3 || targetType === 4;
+      const isGlyphTarget =
+        Boolean(targetElement?.classList?.contains('peekle-comment-glyph')) ||
+        Boolean(targetElement?.closest?.('.peekle-comment-glyph'));
+      const isInlineMarkerTarget =
+        Boolean(targetElement?.classList?.contains('peekle-comment-inline-badge')) ||
+        Boolean(targetElement?.closest?.('.peekle-comment-inline-badge')) ||
+        Boolean(targetElement?.classList?.contains('peekle-comment-inline-dot')) ||
+        Boolean(targetElement?.closest?.('.peekle-comment-inline-dot')) ||
+        isGlyphTarget;
+      if (!isInlineMarkerTarget) return;
+
+      const lineNumber =
+        getLineNumberFromMouseTarget(event?.target) ??
+        savedEditorRef.current?.getPosition?.()?.lineNumber ??
+        hoveredLineRef.current;
+
+      logCommentDebug('mouse-up', {
+        targetType,
+        className: targetElement?.className,
+        isGutterTarget,
+        isGlyphTarget,
+        lineNumber,
+      });
+      if (isGutterTarget) {
+        openCommentsPanelAtLine(lineNumber ?? null);
+        return;
+      }
+      if (!lineNumber || !inlineCommentLineSet.has(lineNumber)) return;
+      openCommentsPanelAtLine(lineNumber);
     });
 
     editor.onMouseLeave(() => {
@@ -894,7 +1154,72 @@ print("Hello World!")`;
     });
 
     renderInlineZones();
-  }, [clearHoverHideTimer, hideHoverAddButton, renderInlineZones, updateHoverAddPosition, viewMode]);
+    renderInlineMarkers();
+  }, [
+    clearHoverHideTimer,
+    hideHoverAddButton,
+    renderInlineZones,
+    renderInlineMarkers,
+    updateHoverAddPosition,
+    viewMode,
+    focusSavedLine,
+    getLineNumberFromMouseTarget,
+    inlineCommentLineSet,
+    inlineLineSummaries,
+    openCommentsPanelAtLine,
+    logCommentDebug,
+  ]);
+
+  useEffect(() => {
+    const container = savedEditorContainerRef.current;
+    const editor = savedEditorRef.current;
+    if (!container || !editor) return;
+
+    if (marginPointerListenerRef.current) {
+      container.removeEventListener('pointerdown', marginPointerListenerRef.current, true);
+      marginPointerListenerRef.current = null;
+    }
+
+    const nativeMarginPointerDown = (nativeEvent: PointerEvent) => {
+      if (viewMode !== 'SPLIT_SAVED') return;
+      const target = nativeEvent.target as HTMLElement | null;
+      if (!target) return;
+
+      const isMarginClick = Boolean(
+        target.closest('.margin') ||
+        target.closest('.margin-view-overlays') ||
+        target.closest('.line-numbers') ||
+        target.closest('.peekle-comment-glyph') ||
+        target.classList.contains('cgmr'),
+      );
+      if (!isMarginClick) return;
+
+      const mouseTarget = editor.getTargetAtClientPoint?.(nativeEvent.clientX, nativeEvent.clientY);
+      const lineNumber =
+        getLineNumberFromMouseTarget(mouseTarget) ??
+        editor.getPosition?.()?.lineNumber ??
+        hoveredLineRef.current ??
+        null;
+
+      logCommentDebug('native-margin-pointerdown', {
+        className: target.className,
+        lineNumber,
+        hasInlineComments: inlineLineSummaries.length > 0,
+      });
+
+      openCommentsPanelAtLine(lineNumber);
+    };
+
+    marginPointerListenerRef.current = nativeMarginPointerDown;
+    container.addEventListener('pointerdown', nativeMarginPointerDown, true);
+
+    return () => {
+      container.removeEventListener('pointerdown', nativeMarginPointerDown, true);
+      if (marginPointerListenerRef.current === nativeMarginPointerDown) {
+        marginPointerListenerRef.current = null;
+      }
+    };
+  }, [viewMode, getLineNumberFromMouseTarget, inlineLineSummaries.length, logCommentDebug, openCommentsPanelAtLine]);
 
   const startResizingVideo = useCallback(
     (e: React.MouseEvent) => {
@@ -1245,8 +1570,47 @@ print("Hello World!")`;
   }, [fetchSubmissionComments]);
 
   useEffect(() => {
+    const handleRefreshComments = () => {
+      void fetchSubmissionComments();
+    };
+
+    const handleFocusSavedLine = (
+      event: Event,
+    ) => {
+      const customEvent = event as CustomEvent<{
+        lineNumber?: number;
+        openDraft?: boolean;
+        parentId?: number | null;
+      }>;
+      const lineNumber = customEvent.detail?.lineNumber;
+      if (!lineNumber || viewMode !== 'SPLIT_SAVED') return;
+
+      focusSavedLine(lineNumber);
+
+      if (customEvent.detail?.openDraft) {
+        setInlineDraftLine(lineNumber);
+        setInlineDraftParentId(customEvent.detail?.parentId ?? null);
+        setInlineEditingCommentId(null);
+        setInlineEditingContent('');
+      }
+    };
+
+    window.addEventListener('peekle:refresh-submission-comments', handleRefreshComments);
+    window.addEventListener('peekle:focus-saved-comment-line', handleFocusSavedLine as EventListener);
+
+    return () => {
+      window.removeEventListener('peekle:refresh-submission-comments', handleRefreshComments);
+      window.removeEventListener(
+        'peekle:focus-saved-comment-line',
+        handleFocusSavedLine as EventListener,
+      );
+    };
+  }, [fetchSubmissionComments, focusSavedLine, viewMode]);
+
+  useEffect(() => {
     if (viewMode !== 'SPLIT_SAVED') {
       clearInlineZones();
+      clearInlineMarkers();
       clearHoverHideTimer();
       isHoveringAddButtonRef.current = false;
       setGeneralCommentContent('');
@@ -1261,7 +1625,16 @@ print("Hello World!")`;
       return;
     }
     renderInlineZones();
-  }, [viewMode, clearHoverHideTimer, clearInlineZones, hideHoverAddButton, renderInlineZones]);
+    renderInlineMarkers();
+  }, [
+    viewMode,
+    clearHoverHideTimer,
+    clearInlineZones,
+    clearInlineMarkers,
+    hideHoverAddButton,
+    renderInlineZones,
+    renderInlineMarkers,
+  ]);
 
   useEffect(() => {
     clearHoverHideTimer();
@@ -1279,13 +1652,28 @@ print("Hello World!")`;
 
   useEffect(() => {
     renderInlineZones();
-  }, [renderInlineZones]);
+    renderInlineMarkers();
+  }, [renderInlineZones, renderInlineMarkers]);
 
   useEffect(() => () => {
     clearHoverHideTimer();
     isHoveringAddButtonRef.current = false;
+    if (savedEditorContainerRef.current && marginPointerListenerRef.current) {
+      savedEditorContainerRef.current.removeEventListener(
+        'pointerdown',
+        marginPointerListenerRef.current,
+        true,
+      );
+    }
+    marginPointerListenerRef.current = null;
+    savedEditorContainerRef.current = null;
+    if (inlineGlyphCountStyleRef.current) {
+      inlineGlyphCountStyleRef.current.remove();
+      inlineGlyphCountStyleRef.current = null;
+    }
     clearInlineZones();
-  }, [clearHoverHideTimer, clearInlineZones]);
+    clearInlineMarkers();
+  }, [clearHoverHideTimer, clearInlineZones, clearInlineMarkers]);
 
   return (
     <div className={cn('flex h-full flex-col min-w-0 min-h-0', className)}>
@@ -1529,8 +1917,11 @@ print("Hello World!")`;
                             <button
                               type="button"
                               title={`L${hoveredLineForAdd}에 인라인 댓글 추가`}
-                              className="absolute z-20 flex h-5 w-5 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-md ring-1 ring-primary/30 hover:opacity-90"
+                              className="absolute z-[80] flex h-5 w-5 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-md ring-1 ring-primary/30 hover:opacity-90"
                               style={{ top: hoverAddButtonTop, left: hoverAddButtonLeft }}
+                              onMouseDown={(event) => {
+                                event.stopPropagation();
+                              }}
                               onMouseEnter={() => {
                                 isHoveringAddButtonRef.current = true;
                                 clearHoverHideTimer();
@@ -1550,244 +1941,6 @@ print("Hello World!")`;
                               <Plus className="h-3.5 w-3.5" />
                             </button>
                           )}
-                        </div>
-                        <div className="h-64 border-t border-border bg-card/40">
-                          <div className="h-10 border-b border-border px-3 flex items-center justify-between">
-                            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                              <MessageSquare className="h-3.5 w-3.5" />
-                              <span>일반 댓글</span>
-                              <span className="text-foreground/80">
-                                인라인 {inlineComments.length} · 일반 {generalComments.length}
-                              </span>
-                            </div>
-                            <span className="text-[11px] text-muted-foreground">
-                              코드 라인 클릭 시 인라인 댓글 작성
-                            </span>
-                          </div>
-
-                          <div className="h-[calc(100%-40px)] grid grid-rows-[1fr_auto]">
-                            <div className="overflow-y-auto p-3 space-y-2">
-                              {isCommentsLoading ? (
-                                <p className="text-xs text-muted-foreground">댓글 불러오는 중...</p>
-                              ) : generalRootComments.length === 0 ? (
-                                <p className="text-xs text-muted-foreground">
-                                  아직 일반 댓글이 없습니다.
-                                </p>
-                              ) : (
-                                generalRootComments.map((comment) => (
-                                  <div key={comment.id} className="rounded-md border border-border bg-background">
-                                    <div className="px-2 py-1 border-b border-border/70 flex items-center justify-between gap-2">
-                                      <span className="text-[11px] text-muted-foreground truncate">
-                                        {comment.authorNickname} · {formatCommentDate(comment.createdAt)}
-                                      </span>
-                                      <div className="flex items-center gap-1">
-                                        {comment.authorId === currentUserId && !comment.isDeleted && (
-                                          <>
-                                            <button
-                                              type="button"
-                                              className="text-[11px] text-muted-foreground hover:text-foreground"
-                                              onClick={() => {
-                                                setGeneralEditingCommentId(comment.id);
-                                                setGeneralEditingContent(comment.content);
-                                                setGeneralReplyParentId(null);
-                                              }}
-                                            >
-                                              수정
-                                            </button>
-                                            <button
-                                              type="button"
-                                              className="text-[11px] text-muted-foreground hover:text-foreground"
-                                              onClick={() => void handleDeleteComment(comment.id)}
-                                            >
-                                              삭제
-                                            </button>
-                                          </>
-                                        )}
-                                      </div>
-                                    </div>
-                                    <div className="px-2 py-1.5">
-                                      {generalEditingCommentId === comment.id ? (
-                                        <div className="space-y-1.5">
-                                          <textarea
-                                            value={generalEditingContent}
-                                            onChange={(event) => setGeneralEditingContent(event.target.value)}
-                                            className="w-full h-16 resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs outline-none focus:ring-1 focus:ring-primary"
-                                          />
-                                          <div className="flex justify-end gap-1">
-                                            <button
-                                              type="button"
-                                              className="text-[11px] px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground"
-                                              onClick={() => {
-                                                setGeneralEditingCommentId(null);
-                                                setGeneralEditingContent('');
-                                              }}
-                                            >
-                                              취소
-                                            </button>
-                                            <button
-                                              type="button"
-                                              className="text-[11px] px-2 py-1 rounded border border-primary bg-primary text-primary-foreground disabled:opacity-60"
-                                              disabled={!generalEditingContent.trim() || isPostingGeneralComment}
-                                              onClick={() =>
-                                                void handleUpdateComment(comment.id, generalEditingContent).then((updated) => {
-                                                  if (updated) {
-                                                    setGeneralEditingCommentId(null);
-                                                    setGeneralEditingContent('');
-                                                  }
-                                                })
-                                              }
-                                            >
-                                              저장
-                                            </button>
-                                          </div>
-                                        </div>
-                                      ) : (
-                                        <>
-                                          <p
-                                            className={cn(
-                                              'text-xs whitespace-pre-wrap break-words',
-                                              comment.isDeleted && 'italic text-muted-foreground',
-                                            )}
-                                          >
-                                            {comment.content}
-                                          </p>
-                                          {!comment.isDeleted && (
-                                            <button
-                                              type="button"
-                                              className="mt-1 text-[11px] text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
-                                              onClick={() => {
-                                                setGeneralReplyParentId(comment.id);
-                                                setGeneralEditingCommentId(null);
-                                                setGeneralEditingContent('');
-                                              }}
-                                            >
-                                              <CornerDownRight className="h-3 w-3" />
-                                              답글
-                                            </button>
-                                          )}
-                                        </>
-                                      )}
-                                    </div>
-
-                                    {(generalRepliesByParent.get(comment.id) || []).map((reply) => (
-                                      <div
-                                        key={reply.id}
-                                        className="ml-3 mr-2 mb-2 rounded border border-border/70 bg-muted/20"
-                                      >
-                                        <div className="px-2 py-1 border-b border-border/60 text-[11px] text-muted-foreground flex items-center justify-between gap-2">
-                                          <span>
-                                            {reply.authorNickname} · {formatCommentDate(reply.createdAt)}
-                                          </span>
-                                          <div className="flex items-center gap-1">
-                                            {reply.authorId === currentUserId && !reply.isDeleted && (
-                                              <>
-                                                <button
-                                                  type="button"
-                                                  className="text-[11px] text-muted-foreground hover:text-foreground"
-                                                  onClick={() => {
-                                                    setGeneralEditingCommentId(reply.id);
-                                                    setGeneralEditingContent(reply.content);
-                                                    setGeneralReplyParentId(null);
-                                                  }}
-                                                >
-                                                  수정
-                                                </button>
-                                                <button
-                                                  type="button"
-                                                  className="text-[11px] text-muted-foreground hover:text-foreground"
-                                                  onClick={() => void handleDeleteComment(reply.id)}
-                                                >
-                                                  삭제
-                                                </button>
-                                              </>
-                                            )}
-                                          </div>
-                                        </div>
-                                        <div className="px-2 py-1.5">
-                                          {generalEditingCommentId === reply.id ? (
-                                            <div className="space-y-1.5">
-                                              <textarea
-                                                value={generalEditingContent}
-                                                onChange={(event) => setGeneralEditingContent(event.target.value)}
-                                                className="w-full h-16 resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs outline-none focus:ring-1 focus:ring-primary"
-                                              />
-                                              <div className="flex justify-end gap-1">
-                                                <button
-                                                  type="button"
-                                                  className="text-[11px] px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground"
-                                                  onClick={() => {
-                                                    setGeneralEditingCommentId(null);
-                                                    setGeneralEditingContent('');
-                                                  }}
-                                                >
-                                                  취소
-                                                </button>
-                                                <button
-                                                  type="button"
-                                                  className="text-[11px] px-2 py-1 rounded border border-primary bg-primary text-primary-foreground disabled:opacity-60"
-                                                  disabled={!generalEditingContent.trim() || isPostingGeneralComment}
-                                                  onClick={() =>
-                                                    void handleUpdateComment(reply.id, generalEditingContent).then((updated) => {
-                                                      if (updated) {
-                                                        setGeneralEditingCommentId(null);
-                                                        setGeneralEditingContent('');
-                                                      }
-                                                    })
-                                                  }
-                                                >
-                                                  저장
-                                                </button>
-                                              </div>
-                                            </div>
-                                          ) : (
-                                            <p
-                                              className={cn(
-                                                'text-xs whitespace-pre-wrap break-words',
-                                                reply.isDeleted && 'italic text-muted-foreground',
-                                              )}
-                                            >
-                                              {reply.content}
-                                            </p>
-                                          )}
-                                        </div>
-                                      </div>
-                                    ))}
-                                  </div>
-                                ))
-                              )}
-                            </div>
-
-                            <div className="border-t border-border px-3 py-2 space-y-2 bg-background/70">
-                              {generalReplyParentId && (
-                                <div className="flex items-center justify-between rounded bg-muted/70 px-2 py-1 text-[11px] text-muted-foreground">
-                                  <span>답글 작성 중</span>
-                                  <button
-                                    type="button"
-                                    className="hover:text-foreground"
-                                    onClick={() => setGeneralReplyParentId(null)}
-                                  >
-                                    취소
-                                  </button>
-                                </div>
-                              )}
-                              <div className="flex items-end gap-2">
-                                <textarea
-                                  value={generalCommentContent}
-                                  onChange={(event) => setGeneralCommentContent(event.target.value)}
-                                  placeholder="일반 댓글을 입력하세요"
-                                  className="w-full h-16 resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs outline-none focus:ring-1 focus:ring-primary"
-                                />
-                                <Button
-                                  size="sm"
-                                  className="h-8 px-2"
-                                  disabled={isPostingGeneralComment || !generalCommentContent.trim()}
-                                  onClick={() => void handleCreateGeneralComment()}
-                                >
-                                  <Send className="h-3.5 w-3.5" />
-                                </Button>
-                              </div>
-                            </div>
-                          </div>
                         </div>
                       </div>
                     ) : (

--- a/apps/frontend/src/domains/study/components/CCIDEPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCIDEPanel.tsx
@@ -638,6 +638,8 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
               fontFamily: "'D2Coding', 'Fira Code', Consolas, monospace",
               fontSize: fontSize,
               minimap: { enabled: false },
+              glyphMargin: true,
+              lineDecorationsWidth: 22,
               wordWrap: 'on',
               automaticLayout: true,
               scrollBeyondLastLine: false,

--- a/apps/frontend/src/domains/study/components/CCRightPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCRightPanel.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { useRoomStore, selectOnlineCount } from '@/domains/study/hooks/useRoomStore';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { ChevronRight } from 'lucide-react';
 import { StudyChatPanel } from './chat/StudyChatPanel';
 import { StudyParticipantPanel } from './StudyParticipantPanel';
+import { SubmissionCommentsPanel } from './comments/SubmissionCommentsPanel';
 
 interface CCRightPanelProps {
   chatContent?: ReactNode;
@@ -26,9 +27,12 @@ export function CCRightPanel({
   const onlineCount = useRoomStore(selectOnlineCount);
   const totalCount = useRoomStore((state) => state.participants.length);
 
+  useEffect(() => {
+    console.info('[peekle-comments] right-panel-active-tab', { activeTab });
+  }, [activeTab]);
+
   return (
     <div className={cn('flex h-full flex-col border-l border-border', className)} data-tour="right-panel">
-      {/* Tab Headers */}
       <div className="flex bg-card border-b border-border items-center h-14 shrink-0">
         <Button
           variant="ghost"
@@ -54,6 +58,18 @@ export function CCRightPanel({
         </button>
         <button
           type="button"
+          onClick={() => setActiveTab('comments')}
+          className={cn(
+            'flex-1 px-4 h-full flex items-center justify-center text-sm font-medium transition-colors',
+            activeTab === 'comments'
+              ? 'border-b-2 border-primary text-primary'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          댓글
+        </button>
+        <button
+          type="button"
           onClick={() => setActiveTab('participants')}
           className={cn(
             'flex-1 px-4 h-full flex items-center justify-center text-sm font-medium transition-colors',
@@ -67,10 +83,13 @@ export function CCRightPanel({
         </button>
       </div>
 
-      {/* Tab Content */}
       <div className="flex-1 overflow-hidden">
         {activeTab === 'chat' ? (
           <div className="h-full">{chatContent ?? <StudyChatPanel />}</div>
+        ) : activeTab === 'comments' ? (
+          <div className="h-full">
+            <SubmissionCommentsPanel />
+          </div>
         ) : (
           <div className="h-full">{participantsContent ?? <StudyParticipantPanel />}</div>
         )}

--- a/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
@@ -136,6 +136,7 @@ function StudyRoomContent({
   const isRightPanelFolded = useRoomStore((state) => state.isRightPanelFolded);
   const setIsLeftPanelFolded = useRoomStore((state) => state.setIsLeftPanelFolded);
   const setIsRightPanelFolded = useRoomStore((state) => state.setIsRightPanelFolded);
+  const setRightPanelActiveTab = useRoomStore((state) => state.setRightPanelActiveTab);
 
   // Auto-close sidebars if window is on the right half of the screen on load
   useEffect(() => {
@@ -254,6 +255,33 @@ function StudyRoomContent({
     prevLeftFolded.current = isLeftPanelFolded;
     prevRightFolded.current = isRightPanelFolded;
   }, [isCompact, isLeftPanelFolded, isRightPanelFolded, setIsLeftPanelFolded, setIsRightPanelFolded]);
+
+  useEffect(() => {
+    const handleOpenCommentsPanel = (event: Event) => {
+      const detail = (event as CustomEvent<{ lineNumber?: number | null }>).detail;
+      console.info('[peekle-comments] room-received-open-comments-panel', {
+        lineNumber: detail?.lineNumber ?? null,
+        isCompact,
+        isLeftPanelFolded,
+        isRightPanelFolded,
+      });
+      setRightPanelActiveTab('comments');
+      if (isCompact) {
+        setIsLeftPanelFolded(true);
+      }
+      setIsRightPanelFolded(false);
+    };
+
+    window.addEventListener('peekle:open-comments-panel', handleOpenCommentsPanel);
+    return () => window.removeEventListener('peekle:open-comments-panel', handleOpenCommentsPanel);
+  }, [
+    isCompact,
+    isLeftPanelFolded,
+    isRightPanelFolded,
+    setIsLeftPanelFolded,
+    setIsRightPanelFolded,
+    setRightPanelActiveTab,
+  ]);
 
   // Global state for selected problem
   const selectedStudyProblemId = useRoomStore((state) => state.selectedStudyProblemId);

--- a/apps/frontend/src/domains/study/components/comments/SubmissionCommentsPanel.tsx
+++ b/apps/frontend/src/domains/study/components/comments/SubmissionCommentsPanel.tsx
@@ -1,0 +1,646 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { MessageSquare, Send, ArrowDown, CornerDownRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { apiFetch } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
+
+interface SubmissionCommentItem {
+  id: number;
+  submissionId: number;
+  parentId: number | null;
+  type: 'INLINE' | 'GENERAL';
+  isDeleted: boolean;
+  authorId: number;
+  authorNickname: string;
+  authorProfileImage?: string | null;
+  lineStart: number;
+  lineEnd: number;
+  content: string;
+  createdAt: string;
+}
+
+function formatCommentDate(value?: string): string {
+  if (!value) return '';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return '';
+  return parsed.toLocaleString('ko-KR', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function SubmissionCommentsPanel() {
+  const roomId = useRoomStore((state) => state.roomId);
+  const currentUserId = useRoomStore((state) => state.currentUserId);
+  const viewMode = useRoomStore((state) => state.viewMode);
+  const targetSubmission = useRoomStore((state) => state.targetSubmission);
+
+  const submissionId = targetSubmission?.submissionId ?? null;
+  const canShowComments = viewMode === 'SPLIT_SAVED' && !!roomId && !!submissionId;
+
+  const [comments, setComments] = useState<SubmissionCommentItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedLine, setSelectedLine] = useState<number | null>(null);
+  const [inlineReplyParentId, setInlineReplyParentId] = useState<number | null>(null);
+  const [inlineReplyContent, setInlineReplyContent] = useState('');
+  const [isPostingInlineReply, setIsPostingInlineReply] = useState(false);
+  const [generalReplyParentId, setGeneralReplyParentId] = useState<number | null>(null);
+  const [generalReplyContent, setGeneralReplyContent] = useState('');
+  const [generalCommentContent, setGeneralCommentContent] = useState('');
+  const [isPostingGeneralComment, setIsPostingGeneralComment] = useState(false);
+  const [deletingCommentId, setDeletingCommentId] = useState<number | null>(null);
+  const [showOnlyMine, setShowOnlyMine] = useState(false);
+
+  const fetchComments = useCallback(async () => {
+    if (!canShowComments || !roomId || !submissionId) {
+      setComments([]);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await apiFetch<SubmissionCommentItem[]>(
+        `/api/studies/${roomId}/submissions/${submissionId}/comments`,
+      );
+
+      if (!response.success || !Array.isArray(response.data)) {
+        setComments([]);
+        return;
+      }
+
+      setComments(response.data);
+    } catch {
+      setComments([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [canShowComments, roomId, submissionId]);
+
+  useEffect(() => {
+    void fetchComments();
+  }, [fetchComments]);
+
+  useEffect(() => {
+    const handleLineSelected = (event: Event) => {
+      const detail = (event as CustomEvent<{ lineNumber?: number }>).detail;
+      if (!detail?.lineNumber) return;
+      setSelectedLine(detail.lineNumber);
+    };
+
+    const handleRefreshRequested = () => {
+      void fetchComments();
+    };
+
+    window.addEventListener('peekle:select-comment-line', handleLineSelected as EventListener);
+    window.addEventListener('peekle:refresh-submission-comments', handleRefreshRequested);
+
+    return () => {
+      window.removeEventListener('peekle:select-comment-line', handleLineSelected as EventListener);
+      window.removeEventListener('peekle:refresh-submission-comments', handleRefreshRequested);
+    };
+  }, [fetchComments]);
+
+  useEffect(() => {
+    if (!selectedLine) return;
+    const targetCard = document.querySelector<HTMLElement>(`[data-comment-line="${selectedLine}"]`);
+    if (!targetCard) return;
+    targetCard.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [selectedLine, comments.length]);
+
+  const filteredComments = useMemo(() => {
+    if (!showOnlyMine || !currentUserId) return comments;
+    return comments.filter((comment) => comment.authorId === currentUserId);
+  }, [comments, showOnlyMine, currentUserId]);
+
+  const inlineComments = useMemo(
+    () => filteredComments.filter((comment) => comment.type === 'INLINE'),
+    [filteredComments],
+  );
+
+  const inlineRootComments = useMemo(
+    () => inlineComments.filter((comment) => !comment.parentId),
+    [inlineComments],
+  );
+
+  const inlineRepliesByParent = useMemo(() => {
+    const map = new Map<number, SubmissionCommentItem[]>();
+    inlineComments.forEach((comment) => {
+      if (!comment.parentId) return;
+      const bucket = map.get(comment.parentId) || [];
+      bucket.push(comment);
+      map.set(comment.parentId, bucket);
+    });
+    return map;
+  }, [inlineComments]);
+
+  const generalComments = useMemo(
+    () => filteredComments.filter((comment) => comment.type === 'GENERAL'),
+    [filteredComments],
+  );
+
+  const generalRootComments = useMemo(
+    () => generalComments.filter((comment) => !comment.parentId),
+    [generalComments],
+  );
+
+  const generalRepliesByParent = useMemo(() => {
+    const map = new Map<number, SubmissionCommentItem[]>();
+    generalComments.forEach((comment) => {
+      if (!comment.parentId) return;
+      const bucket = map.get(comment.parentId) || [];
+      bucket.push(comment);
+      map.set(comment.parentId, bucket);
+    });
+    return map;
+  }, [generalComments]);
+
+  const sortedInlineLines = useMemo(() => {
+    const unique = new Set<number>();
+    inlineRootComments.forEach((comment) => {
+      unique.add(Math.max(1, comment.lineStart || 1));
+    });
+    return Array.from(unique).sort((a, b) => a - b);
+  }, [inlineRootComments]);
+
+  const jumpToLine = useCallback((lineNumber: number, openDraft = false, parentId?: number | null) => {
+    setSelectedLine(lineNumber);
+    window.dispatchEvent(
+      new CustomEvent('peekle:focus-saved-comment-line', {
+        detail: {
+          lineNumber,
+          openDraft,
+          parentId: parentId ?? null,
+        },
+      }),
+    );
+  }, []);
+
+  const moveToNextComment = useCallback(() => {
+    if (sortedInlineLines.length === 0) return;
+
+    if (!selectedLine) {
+      jumpToLine(sortedInlineLines[0]);
+      return;
+    }
+
+    const currentIndex = sortedInlineLines.findIndex((line) => line === selectedLine);
+    const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % sortedInlineLines.length;
+    jumpToLine(sortedInlineLines[nextIndex]);
+  }, [jumpToLine, selectedLine, sortedInlineLines]);
+
+  const handleCreateInlineReply = useCallback(async (parentComment: SubmissionCommentItem) => {
+    if (!canShowComments || !roomId || !submissionId) return;
+    if (parentComment.type !== 'INLINE') return;
+
+    const trimmed = inlineReplyContent.trim();
+    if (!trimmed) return;
+
+    const lineNumber = Math.max(1, parentComment.lineStart || 1);
+    setIsPostingInlineReply(true);
+    try {
+      const response = await apiFetch<SubmissionCommentItem>(
+        `/api/studies/${roomId}/submissions/${submissionId}/comments`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'INLINE',
+            parentId: parentComment.id,
+            lineStart: lineNumber,
+            lineEnd: lineNumber,
+            content: trimmed,
+          }),
+        },
+      );
+
+      if (!response.success) return;
+
+      setInlineReplyContent('');
+      setInlineReplyParentId(null);
+      await fetchComments();
+      window.dispatchEvent(new CustomEvent('peekle:refresh-submission-comments'));
+    } finally {
+      setIsPostingInlineReply(false);
+    }
+  }, [
+    canShowComments,
+    roomId,
+    submissionId,
+    inlineReplyContent,
+    fetchComments,
+  ]);
+
+  const handleCreateGeneralComment = useCallback(async () => {
+    if (!canShowComments || !roomId || !submissionId) return;
+
+    const trimmed = generalCommentContent.trim();
+    if (!trimmed) return;
+
+    setIsPostingGeneralComment(true);
+    try {
+      const response = await apiFetch<SubmissionCommentItem>(
+        `/api/studies/${roomId}/submissions/${submissionId}/comments`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'GENERAL',
+            parentId: null,
+            content: trimmed,
+          }),
+        },
+      );
+
+      if (!response.success) return;
+
+      setGeneralCommentContent('');
+      await fetchComments();
+      window.dispatchEvent(new CustomEvent('peekle:refresh-submission-comments'));
+    } finally {
+      setIsPostingGeneralComment(false);
+    }
+  }, [
+    canShowComments,
+    roomId,
+    submissionId,
+    generalCommentContent,
+    fetchComments,
+  ]);
+
+  const handleCreateGeneralReply = useCallback(async (parentComment: SubmissionCommentItem) => {
+    if (!canShowComments || !roomId || !submissionId) return;
+    if (parentComment.type !== 'GENERAL') return;
+
+    const trimmed = generalReplyContent.trim();
+    if (!trimmed) return;
+
+    setIsPostingGeneralComment(true);
+    try {
+      const response = await apiFetch<SubmissionCommentItem>(
+        `/api/studies/${roomId}/submissions/${submissionId}/comments`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'GENERAL',
+            parentId: parentComment.id,
+            content: trimmed,
+          }),
+        },
+      );
+
+      if (!response.success) return;
+
+      setGeneralReplyContent('');
+      setGeneralReplyParentId(null);
+      await fetchComments();
+      window.dispatchEvent(new CustomEvent('peekle:refresh-submission-comments'));
+    } finally {
+      setIsPostingGeneralComment(false);
+    }
+  }, [
+    canShowComments,
+    roomId,
+    submissionId,
+    generalReplyContent,
+    fetchComments,
+  ]);
+
+  const handleDeleteComment = useCallback(async (commentId: number) => {
+    if (!canShowComments || !roomId || !submissionId) return;
+
+    setDeletingCommentId(commentId);
+    try {
+      const response = await apiFetch<null>(
+        `/api/studies/${roomId}/submissions/${submissionId}/comments/${commentId}`,
+        {
+          method: 'DELETE',
+        },
+      );
+
+      if (!response.success) return;
+
+      if (inlineReplyParentId === commentId) {
+        setInlineReplyParentId(null);
+        setInlineReplyContent('');
+      }
+      if (generalReplyParentId === commentId) {
+        setGeneralReplyParentId(null);
+        setGeneralReplyContent('');
+      }
+
+      await fetchComments();
+      window.dispatchEvent(new CustomEvent('peekle:refresh-submission-comments'));
+    } finally {
+      setDeletingCommentId(null);
+    }
+  }, [
+    canShowComments,
+    roomId,
+    submissionId,
+    inlineReplyParentId,
+    generalReplyParentId,
+    fetchComments,
+  ]);
+
+  if (!canShowComments) {
+    return (
+      <div className="h-full flex items-center justify-center px-6 text-center">
+        <div className="space-y-2">
+          <MessageSquare className="mx-auto h-5 w-5 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">저장 코드 보기에서 댓글을 확인할 수 있어요.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="h-12 px-3 border-b border-border flex items-center justify-between">
+        <div className="text-xs text-muted-foreground">
+          인라인 {inlineComments.length} · 일반 {generalComments.length}
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className={cn(
+              'text-[11px] px-2 py-1 rounded border',
+              showOnlyMine
+                ? 'border-primary text-primary'
+                : 'border-border text-muted-foreground hover:text-foreground',
+            )}
+            onClick={() => setShowOnlyMine((prev) => !prev)}
+          >
+            내 댓글만
+          </button>
+          <button
+            type="button"
+            className="text-[11px] px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+            onClick={moveToNextComment}
+            disabled={sortedInlineLines.length === 0}
+          >
+            <ArrowDown className="h-3 w-3" />
+            다음 댓글
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-4">
+        {isLoading ? (
+          <p className="text-xs text-muted-foreground">댓글 불러오는 중...</p>
+        ) : (
+          <>
+            <section className="space-y-2">
+              <h4 className="text-xs font-semibold text-muted-foreground">라인 댓글</h4>
+              {inlineRootComments.length === 0 ? (
+                <p className="text-xs text-muted-foreground">라인 댓글이 없습니다.</p>
+              ) : (
+                inlineRootComments.map((comment) => {
+                  const replies = inlineRepliesByParent.get(comment.id) || [];
+                  const lineNumber = Math.max(1, comment.lineStart || 1);
+                  return (
+                    <div
+                      key={comment.id}
+                      data-comment-line={lineNumber}
+                      className={cn(
+                        'rounded-md border border-border bg-card px-2 py-2',
+                        selectedLine === lineNumber && 'border-primary/70 ring-1 ring-primary/40',
+                      )}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <button
+                          type="button"
+                          className="text-xs font-semibold text-foreground hover:text-primary"
+                          onClick={() => jumpToLine(lineNumber)}
+                        >
+                          L{lineNumber}
+                        </button>
+                        <div className="flex items-center gap-2">
+                          <span className="text-[11px] text-muted-foreground">
+                            {comment.authorNickname} · {formatCommentDate(comment.createdAt)}
+                          </span>
+                          {!comment.isDeleted && currentUserId === comment.authorId && (
+                            <button
+                              type="button"
+                              className="text-[11px] text-muted-foreground hover:text-foreground"
+                              disabled={deletingCommentId === comment.id}
+                              onClick={() => void handleDeleteComment(comment.id)}
+                            >
+                              삭제
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                      <p className="mt-1 text-xs text-foreground whitespace-pre-wrap break-words">
+                        {comment.content}
+                      </p>
+                      <div className="mt-1 flex items-center gap-2">
+                        <button
+                          type="button"
+                          className="text-[11px] text-muted-foreground hover:text-foreground"
+                          onClick={() => jumpToLine(lineNumber)}
+                        >
+                          코드로 이동
+                        </button>
+                        <button
+                          type="button"
+                          className="text-[11px] text-muted-foreground hover:text-foreground"
+                          onClick={() => {
+                            setInlineReplyParentId(comment.id);
+                            setInlineReplyContent('');
+                            jumpToLine(lineNumber);
+                          }}
+                        >
+                          답글 작성
+                        </button>
+                        {replies.length > 0 && (
+                          <span className="text-[11px] text-muted-foreground">
+                            답글 {replies.length}
+                          </span>
+                        )}
+                      </div>
+                      {inlineReplyParentId === comment.id && (
+                        <div className="mt-2 rounded border border-border/70 bg-muted/20 p-2 space-y-2">
+                          <textarea
+                            value={inlineReplyContent}
+                            onChange={(event) => setInlineReplyContent(event.target.value)}
+                            placeholder={`L${lineNumber} 답글을 입력하세요`}
+                            className="w-full h-16 resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs outline-none focus:ring-1 focus:ring-primary"
+                          />
+                          <div className="flex justify-end gap-1">
+                            <button
+                              type="button"
+                              className="text-[11px] px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground"
+                              onClick={() => {
+                                setInlineReplyParentId(null);
+                                setInlineReplyContent('');
+                              }}
+                            >
+                              취소
+                            </button>
+                            <button
+                              type="button"
+                              className="text-[11px] px-2 py-1 rounded border border-primary bg-primary text-primary-foreground disabled:opacity-60"
+                              disabled={isPostingInlineReply || !inlineReplyContent.trim()}
+                              onClick={() => void handleCreateInlineReply(comment)}
+                            >
+                              등록
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                      {replies.length > 0 && (
+                        <div className="mt-2 space-y-1.5">
+                          {replies.map((reply) => (
+                            <button
+                              key={reply.id}
+                              type="button"
+                              className="block w-full rounded border border-border/60 bg-muted/20 px-2 py-1.5 text-left hover:bg-muted/30"
+                              onClick={() => jumpToLine(lineNumber)}
+                            >
+                              <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+                                <span>{reply.authorNickname} · {formatCommentDate(reply.createdAt)}</span>
+                                {!reply.isDeleted && currentUserId === reply.authorId && (
+                                  <button
+                                    type="button"
+                                    className="text-[11px] text-muted-foreground hover:text-foreground"
+                                    disabled={deletingCommentId === reply.id}
+                                    onClick={(event) => {
+                                      event.stopPropagation();
+                                      void handleDeleteComment(reply.id);
+                                    }}
+                                  >
+                                    삭제
+                                  </button>
+                                )}
+                              </div>
+                              <p className="mt-1 text-xs whitespace-pre-wrap break-words text-foreground">
+                                {reply.content}
+                              </p>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </section>
+
+            <section className="space-y-2">
+              <h4 className="text-xs font-semibold text-muted-foreground">일반 댓글</h4>
+              {generalRootComments.length === 0 ? (
+                <p className="text-xs text-muted-foreground">일반 댓글이 없습니다.</p>
+              ) : (
+                generalRootComments.map((comment) => (
+                  <div key={comment.id} className="rounded-md border border-border bg-card p-2">
+                    <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+                      <span>{comment.authorNickname} · {formatCommentDate(comment.createdAt)}</span>
+                      {!comment.isDeleted && currentUserId === comment.authorId && (
+                        <button
+                          type="button"
+                          className="text-[11px] text-muted-foreground hover:text-foreground"
+                          disabled={deletingCommentId === comment.id}
+                          onClick={() => void handleDeleteComment(comment.id)}
+                        >
+                          삭제
+                        </button>
+                      )}
+                    </div>
+                    <p className="mt-1 text-xs whitespace-pre-wrap break-words text-foreground">
+                      {comment.content}
+                    </p>
+                    {!comment.isDeleted && (
+                      <button
+                        type="button"
+                        className="mt-1 text-[11px] text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+                        onClick={() => {
+                          setGeneralReplyParentId(comment.id);
+                          setGeneralReplyContent('');
+                        }}
+                      >
+                        <CornerDownRight className="h-3 w-3" />
+                        답글
+                      </button>
+                    )}
+                    {generalReplyParentId === comment.id && (
+                      <div className="mt-2 rounded border border-border/70 bg-muted/20 p-2 space-y-2">
+                        <textarea
+                          value={generalReplyContent}
+                          onChange={(event) => setGeneralReplyContent(event.target.value)}
+                          placeholder="답글을 입력하세요"
+                          className="w-full h-16 resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs outline-none focus:ring-1 focus:ring-primary"
+                        />
+                        <div className="flex justify-end gap-1">
+                          <button
+                            type="button"
+                            className="text-[11px] px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground"
+                            onClick={() => {
+                              setGeneralReplyParentId(null);
+                              setGeneralReplyContent('');
+                            }}
+                          >
+                            취소
+                          </button>
+                          <button
+                            type="button"
+                            className="text-[11px] px-2 py-1 rounded border border-primary bg-primary text-primary-foreground disabled:opacity-60"
+                            disabled={isPostingGeneralComment || !generalReplyContent.trim()}
+                            onClick={() => void handleCreateGeneralReply(comment)}
+                          >
+                            등록
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                    {(generalRepliesByParent.get(comment.id) || []).map((reply) => (
+                      <div key={reply.id} className="mt-2 ml-3 rounded border border-border/60 bg-muted/20 px-2 py-1.5">
+                        <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+                          <span>{reply.authorNickname} · {formatCommentDate(reply.createdAt)}</span>
+                          {!reply.isDeleted && currentUserId === reply.authorId && (
+                            <button
+                              type="button"
+                              className="text-[11px] text-muted-foreground hover:text-foreground"
+                              disabled={deletingCommentId === reply.id}
+                              onClick={() => void handleDeleteComment(reply.id)}
+                            >
+                              삭제
+                            </button>
+                          )}
+                        </div>
+                        <p className="mt-1 text-xs whitespace-pre-wrap break-words text-foreground">
+                          {reply.content}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                ))
+              )}
+            </section>
+          </>
+        )}
+      </div>
+
+      <div className="border-t border-border p-3 space-y-2">
+        <div className="flex items-end gap-2">
+          <textarea
+            value={generalCommentContent}
+            onChange={(event) => setGeneralCommentContent(event.target.value)}
+            placeholder="일반 댓글을 입력하세요"
+            className="w-full h-16 resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs outline-none focus:ring-1 focus:ring-primary"
+          />
+          <Button
+            size="sm"
+            className="h-8 px-2"
+            disabled={isPostingGeneralComment || !generalCommentContent.trim()}
+            onClick={() => void handleCreateGeneralComment()}
+          >
+            <Send className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION

## 💡 의도 / 배경
기존 댓글 UI에서 코드 리뷰 흐름이 끊기고(인라인 카드 상시 노출), 댓글 위치 탐색이 어렵고, 답글/삭제 같은 기본 작업이 분산되어 사용성이 떨어졌습니다.  
코드는 중앙에 집중하고, 댓글은 마커 + 우측 패널 중심으로 정리해 리뷰 경험을 개선했습니다.

## 🛠️ 작업 내용
- [x] 댓글 구조를 `코드 영역 + 우측 댓글 패널` 중심으로 재구성
- [x] 인라인 댓글 상시 확장 제거, 라인 마커 기반 탐색/이동 방식 적용
- [x] 마커 클릭 시 우측 `댓글` 탭 열기 및 해당 라인 포커스/하이라이트 연결
- [x] 동일 라인에 추가 댓글 작성 가능하도록 `+` 동작 개선
- [x] 마커 옆 댓글 개수 배지(말풍선 형태) 표시 추가
- [x] 답글 작성 UX 개선
- [x] 인라인/일반 댓글 모두 해당 댓글 하단에서 답글 작성 가능
- [x] 우측 댓글 패널에서 내 댓글/답글 삭제 기능 복구
- [x] 깨진 한글 문구(인코딩 이슈) 정리 및 UI 텍스트 정상화

## 🔗 관련 이슈
- Closes #30 

## 🖼️ 스크린샷 (선택)
<img width="1327" height="1272" alt="스크린샷 2026-03-10 001114" src="https://github.com/user-attachments/assets/3c2a71b8-b329-4a82-aeba-ce3243d40761" />

## 🧪 테스트 방법
- [x] 저장 코드 보기(SPLIT_SAVED) 진입 후 라인 마커 클릭 시 우측 댓글 탭이 열리는지 확인
- [x] `+` 클릭 시 우측 패널은 열리지 않고 인라인 입력만 열리는지 확인
- [x] 동일 라인에 댓글 추가 후 마커 개수 증가/표시 확인
- [x] 인라인/일반 댓글에서 답글 작성 시 해당 댓글 하단 입력창 동작 확인
- [x] 내 댓글/답글 삭제 후 목록 갱신 및 마커 상태 반영 확인
- [x] 타입체크 통과 확인 (`pnpm -C apps/frontend exec tsc --noEmit --pretty false`)

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
댓글 열기 경로가 여러 군데(거터 마커 클릭, `+` 버튼, 우측 패널 탭 전환)라 이벤트 흐름을 많이 정리했습니다.  
특히 “거터 클릭 시 우측 패널 오픈”과 “`+` 클릭 시 인라인 작성만”의 동작 분리를 중심으로 봐주시면 감사하겠습니다.
