### PR TITLE
fix: 주소 중복된 문제 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,14 +75,12 @@ jobs:
         run: corepack enable
 
       - name: Pull Vercel project settings
-        working-directory: apps/frontend
         run: pnpm dlx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Deploy frontend to Vercel (production)
-        working-directory: apps/frontend
         run: pnpm dlx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
fix: 주소 중복된 문제 수정

## 💡 의도 / 배경
Vercel 배포 GitHub Actions 실행 시 경로가 `apps/frontend/apps/frontend`로 중복되어 배포가 실패했습니다.
원인은 Vercel 프로젝트의 Root Directory가 `apps/frontend`로 설정된 상태에서,
workflow에서도 `working-directory: apps/frontend`를 함께 사용해 경로가 이중 적용된 것입니다.

## 🛠️ 작업 내용
- [x] `.github/workflows/deploy.yml`의 Vercel `pull/deploy` 스텝에서 `working-directory: apps/frontend` 제거
- [x] Vercel CLI가 레포 루트 기준으로 실행되도록 수정하여 Root Directory 중복 해석 방지

## 🔗 관련 이슈
- Closes #72 

## 🖼️ 스크린샷 (선택)
해당 없음 (CI/CD 설정 수정)

## 🧪 테스트 방법
- [x] GitHub Actions에서 `deploy-frontend-vercel` 잡 재실행
- [x] `The provided path ".../apps/frontend/apps/frontend" does not exist` 에러가 재발하지 않는지 확인
- [x] Vercel production 배포 성공 여부 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
이번 PR은 CI hotfix 성격의 최소 수정입니다.
Vercel 프로젝트 Root Directory(`apps/frontend`) 설정은 유지해야 하며,
workflow 쪽 `working-directory`를 제거하는 방식으로 충돌을 해결했습니다.
