### PR TITLE
fix: turbo build에 환경변수 추가

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
+  "globalEnv": [
+    "BACKEND_API_URL",
+    "NEXT_PUBLIC_API_URL",
+    "NEXT_PUBLIC_SOCKET_URL",
+    "NEXT_PUBLIC_LIVEKIT_URL",
+    "NEXT_PUBLIC_GA_ID"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## 💡 의도 / 배경
Vercel 배포 시 `turbo build`가 `BACKEND_API_URL`을 전달받지 못해, Next.js rewrite가 fallback(`http://localhost:8080`)을 사용했습니다.
그 결과 Vercel 런타임에서 private 대상 접근으로 판단되어 `DNS_HOSTNAME_RESOLVED_PRIVATE / NOT_FOUND` 오류가 발생했습니다.

## 🛠️ 작업 내용
- [x] `turbo.json`에 `globalEnv` 항목 추가
- [x] `BACKEND_API_URL`, `NEXT_PUBLIC_*` 변수를 Turbo 빌드에 명시적으로 전달되도록 설정

## 🔗 관련 이슈
- Closes #72 

## 🖼️ 스크린샷 (선택)
해당 없음 (빌드 설정 수정)

## 🧪 테스트 방법
- [x] `turbo.json` 변경 후 GitHub Actions/Vercel 배포 재실행
- [x] 빌드 로그에서 `BACKEND_API_URL missing from turbo.json` 경고 제거 확인
- [x] `https://app.peekle.today/api/users/me` 요청 시 rewrite 정상 동작 여부 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
이번 변경은 Turbo 환경변수 전달 누락으로 인한 배포 장애를 해결하는 hotfix입니다.
Vercel 환경변수 값(`BACKEND_API_URL=https://peekle.today`)은 기존과 동일하며,
핵심은 Turbo가 해당 값을 빌드 시 인식하도록 만든 점입니다.