### PR TITLE
fix: nginx.conf에서 turn_backend로 가던거 수정

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -45,15 +45,12 @@ stream {
     map $ssl_preread_alpn_protocols $upstream_pool {
         ~\bh2\b           web_backend;
         ~\bhttp/1.1\b     web_backend;
-        default           turn_backend;
+        # When using Metered TURN, route default 443 traffic to HTTPS web backend.
+        default           web_backend;
     }
 
     upstream web_backend {
         server 127.0.0.1:4443;
-    }
-
-    upstream turn_backend {
-        server host.docker.internal:5349;
     }
 
     server {


### PR DESCRIPTION
## 💡 의도 / 배경
Vercel 프론트에서 `https://peekle.today/api/*`로 프록시될 때, nginx `stream` 기본 upstream이 `turn_backend(5349)`로 잡혀 있어 일부 요청이 TURN 쪽으로 잘못 라우팅되었습니다.  
그 결과 `ROUTER_EXTERNAL_TARGET_HANDSHAKE_ERROR`, `connect() failed (111) ... upstream: 172.17.0.1:5349` 오류가 발생했습니다.

Metered TURN을 사용 중이므로, 443 기본 트래픽은 웹 HTTPS 백엔드로 보내는 구성이 맞아 해당 부분을 수정했습니다.

## 🛠️ 작업 내용
- [x] `docker/nginx/nginx.conf`의 `stream map` 기본 라우팅을 `turn_backend` → `web_backend`로 변경
- [x] 사용되지 않는 `turn_backend (host.docker.internal:5349)` upstream 제거

## 🔗 관련 이슈
- Closes #72 
## 🖼️ 스크린샷 (선택)
- N/A (인프라/설정 변경)

## 🧪 테스트 방법
- [x] `docker exec peekle-nginx nginx -t`로 설정 문법 확인
- [x] nginx reload 후 `https://app.peekle.today/api/ranks?page=0&size=1` 정상 응답 확인
- [x] 로그인 상태에서 `https://app.peekle.today/api/users/me` 호출 시 기존 handshake 오류 미발생 확인
- [x] nginx 에러 로그에서 `upstream ...:5349 connect() failed` 재발 여부 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
이번 수정은 TURN 경로 자체를 제거한 것이 아니라, **443 기본 라우팅 오동작**을 막는 변경입니다.  
Metered TURN을 계속 사용할 예정이라면 현재 방향이 맞고, 추후 자체 TURN 복구 시에는 SNI/별도 포트 기반으로 분리하는 방식으로 재구성하는 것이 안전합니다.
