### PR TITLE
chore: 도커에서 frontend 관련 제거, 인증서 api.peekle.today로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,77 +15,6 @@ env:
   IMAGE_NAME: peek-a-chu/peekle
 
 jobs:
-  build-frontend:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata for Frontend
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend
-
-      - name: Build and push Frontend image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: apps/frontend/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            NEXT_PUBLIC_API_URL=https://${{ secrets.DOMAIN_NAME }}
-            NEXT_PUBLIC_SOCKET_URL=https://${{ secrets.DOMAIN_NAME }}
-            NEXT_PUBLIC_BACKEND_URL=https://${{ secrets.DOMAIN_NAME }}
-            NEXT_PUBLIC_LIVEKIT_URL=wss://${{ secrets.DOMAIN_NAME }}
-            BACKEND_API_URL=https://${{ secrets.DOMAIN_NAME }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend:buildcache,mode=max
-
-  deploy-frontend-vercel:
-    needs: [build-frontend]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Pull Vercel project settings
-        run: pnpm dlx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Deploy frontend to Vercel (production)
-        run: pnpm dlx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
   build-backend:
     runs-on: ubuntu-latest
     permissions:
@@ -159,7 +88,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ai-server:buildcache,mode=max
 
   deploy:
-    needs: [build-frontend, build-backend, build-ai-server]
+    needs: [build-backend, build-ai-server]
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to EC2
@@ -195,13 +124,15 @@ jobs:
             fi
             
             # 4. Pull new images
-            docker compose -f docker-compose.prod.yml pull frontend backend ai-server
+            docker compose -f docker-compose.prod.yml pull backend ai-server nginx
             
-            # 5. Restart containers
-            docker compose -f docker-compose.prod.yml up -d
-            
-            # 5.1 Reload Nginx to clear upstream IP cache (prevents 502 Bad Gateway)
-            docker exec peekle-nginx nginx -s reload || true
-            
-            # 6. Clean up unused loose images
+            # 5. Restart application containers
+            docker compose -f docker-compose.prod.yml up -d backend ai-server redis chroma livekit certbot
+
+            # 6. Recreate nginx so updated config files are always applied
+            docker compose -f docker-compose.prod.yml up -d --force-recreate nginx
+            docker exec peekle-nginx nginx -t
+            docker exec peekle-nginx nginx -s reload
+
+            # 7. Clean up unused loose images
             docker image prune -f

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -27,7 +27,6 @@ services:
       - "host.docker.internal:host-gateway"
       # - "livekit:host-gateway"
     depends_on:
-      - frontend
       - backend
     restart: unless-stopped
     networks:
@@ -42,32 +41,6 @@ services:
       - nginx-certs:/etc/letsencrypt
       - certbot-www:/var/www/certbot
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
-    networks:
-      - peekle-network
-    logging: *default-logging
-
-  # Frontend (Next.js)
-  frontend:
-    image: ${CI_REGISTRY_IMAGE:-peekle}/frontend:${CI_COMMIT_SHORT_SHA:-latest}
-    build:
-      context: ../
-      dockerfile: apps/frontend/Dockerfile
-      args:
-        - NEXT_PUBLIC_API_URL=https://peekle.today
-        - NEXT_PUBLIC_SOCKET_URL=https://peekle.today
-        - NEXT_PUBLIC_BACKEND_URL=https://peekle.today
-        - NEXT_PUBLIC_LIVEKIT_URL=wss://peekle.today:8880
-      cache_from:
-        - ${CI_REGISTRY_IMAGE:-peekle}/frontend:latest
-    container_name: peekle-frontend
-    env_file:
-      - ../apps/frontend/.env
-    environment:
-      - NODE_ENV=production
-      - BACKEND_API_URL=http://backend:8080
-    expose:
-      - "3000"
-    restart: unless-stopped
     networks:
       - peekle-network
     logging: *default-logging

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache certbot certbot-nginx openssl curl socat
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Create directories for certificates and certbot
-RUN mkdir -p /etc/letsencrypt/live/peekle.today
+RUN mkdir -p /etc/letsencrypt/live
 RUN mkdir -p /var/www/certbot
 
 # Script to handle certificate setup

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -1,8 +1,4 @@
 # Upstream definitions
-upstream frontend {
-    server frontend:3000;
-}
-
 upstream backend {
     server backend:8080;
 }
@@ -31,11 +27,11 @@ server {
 server {
     listen 4443 ssl;
     http2 on;
-    server_name peekle.today;
+    server_name api.peekle.today;
 
     # SSL certificates
-    ssl_certificate /etc/letsencrypt/live/peekle.today/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/peekle.today/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/api.peekle.today/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.peekle.today/privkey.pem;
 
     # SSL settings
     ssl_protocols TLSv1.2 TLSv1.3;
@@ -128,21 +124,19 @@ server {
         proxy_pass http://backend;
     }
 
-    # Frontend
+    # API-only domain fallback
     location / {
-        proxy_pass http://frontend;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
+        return 404;
     }
 }
 
 # LiveKit Direct WSS (Port 8880)
 server {
     listen 8880 ssl;
-    server_name peekle.today;
+    server_name api.peekle.today;
 
-    ssl_certificate /etc/letsencrypt/live/peekle.today/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/peekle.today/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/api.peekle.today/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.peekle.today/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;


### PR DESCRIPTION

## 💡 의도 / 배경
프론트 배포를 Vercel로 이관하면서 EC2 Docker 스택에서 프론트 컨테이너를 더 이상 운영하지 않도록 정리했습니다.  
기존에는 nginx/compose/CI에 frontend 경로가 남아 있어 불필요한 배포 및 라우팅 혼선 가능성이 있었고, 인증서도 `peekle.today` 기준 하드코딩이 남아 있어 `api.peekle.today` 분리 운영에 맞지 않았습니다.

이를 `api.peekle.today` API 전용 구성으로 통일해 운영 단순화와 배포 안정성을 확보했습니다.

## 🛠️ 작업 내용
- [x] Docker prod 스택에서 frontend 서비스 및 의존성 제거
- [x] nginx API 전용화(프론트 upstream 제거, `/` fallback 404 처리)
- [x] nginx TLS 설정을 `api.peekle.today` 인증서 경로로 변경
- [x] EC2 GitHub Actions 배포 파이프라인에서 frontend build/deploy 단계 제거
- [x] deploy 단계에서 nginx 강제 재생성 + `nginx -t` 검증 + reload 적용

## 🔗 관련 이슈
- Closes #72 

## 🖼️ 스크린샷 (선택)
- N/A (인프라/배포 설정 변경)

## 🧪 테스트 방법
- [x] `docker compose -f docker/docker-compose.prod.yml config --quiet` 로 compose 유효성 확인
- [x] `docker exec peekle-nginx nginx -t` 로 nginx 설정 문법 확인
- [x] `docker exec peekle-nginx sh -lc "nginx -T 2>/dev/null | grep -nE 'server_name|ssl_certificate|api\\.peekle\\.today'"` 로 적용 설정 확인
- [x] `curl -vk "https://api.peekle.today/api/ranks?page=0&size=1"` 정상 응답 확인
- [x] `docker ps`에서 `peekle-frontend` 비실행 상태 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
이번 PR은 **EC2를 API/미디어 전용**으로 명확히 분리하고, 프론트는 Vercel 단일 배포 경로로 정리하는 목적입니다.  
추가로 DNS/환경변수가 아래처럼 맞는지 함께 확인 부탁드립니다.
- `@` → Vercel
- `api.peekle.today` → EC2
- Vercel backend 관련 env → `https://api.peekle.today`