### PR TITLE
chore: redirect-uri 환경변수화 및 user에서 500에러 수정

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/user/controller/UserController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.peekle.domain.user.controller;
 
+import com.peekle.domain.submission.dto.SubmissionLogResponse;
 import com.peekle.domain.user.dto.ExtensionStatusResponse;
 import com.peekle.domain.user.dto.TokenValidationRequest;
 import com.peekle.domain.user.dto.TokenValidationResponse;
@@ -7,13 +8,21 @@ import com.peekle.domain.user.dto.UserProfileResponse;
 import com.peekle.domain.user.dto.UserUpdateRequest;
 import com.peekle.domain.user.service.UserService;
 import com.peekle.global.dto.ApiResponse;
+import com.peekle.global.exception.BusinessException;
+import com.peekle.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
-import com.peekle.domain.submission.dto.SubmissionLogResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +36,7 @@ public class UserController {
 
     @GetMapping("/me")
     public ApiResponse<Map<String, Object>> getCurrentUser(@AuthenticationPrincipal Long userId) {
-
+        requireAuthenticatedUserId(userId);
         Map<String, Object> userInfo = userService.getUserInfo(userId);
         return ApiResponse.success(userInfo);
     }
@@ -36,6 +45,7 @@ public class UserController {
     public ApiResponse<Map<String, String>> generateExtensionToken(
             @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "false") boolean regenerate) {
+        requireAuthenticatedUserId(userId);
         String token = userService.generateExtensionToken(userId, regenerate);
         Map<String, String> response = new HashMap<>();
         response.put("extensionToken", token);
@@ -52,7 +62,7 @@ public class UserController {
 
     @GetMapping("/me/profile")
     public ApiResponse<UserProfileResponse> getMyProfile(@AuthenticationPrincipal Long userId) {
-        // 자신의 프로필 조회 (isMe = true)
+        requireAuthenticatedUserId(userId);
         UserProfileResponse response = userService.getUserProfile(userId, userId);
         return ApiResponse.success(response);
     }
@@ -61,6 +71,7 @@ public class UserController {
     public ApiResponse<Void> updateProfile(
             @AuthenticationPrincipal Long userId,
             @RequestBody UserUpdateRequest request) {
+        requireAuthenticatedUserId(userId);
         userService.updateUserProfile(userId, request);
         return ApiResponse.success(null);
     }
@@ -69,6 +80,7 @@ public class UserController {
     public ApiResponse<Map<String, String>> getProfileImagePresignedUrl(
             @AuthenticationPrincipal Long userId,
             @RequestBody Map<String, String> request) {
+        requireAuthenticatedUserId(userId);
         String fileName = request.get("fileName");
         String contentType = request.get("contentType");
 
@@ -80,7 +92,7 @@ public class UserController {
     public ApiResponse<TokenValidationResponse> validateToken(
             @AuthenticationPrincipal Long userId,
             @RequestBody TokenValidationRequest request) {
-
+        requireAuthenticatedUserId(userId);
         boolean isValidUserToken = userService.validateExtensionToken(userId, request.token(), request.bojId());
         return ApiResponse.success(new TokenValidationResponse(isValidUserToken));
     }
@@ -88,6 +100,7 @@ public class UserController {
     @GetMapping("/me/streak")
     public ApiResponse<java.util.List<com.peekle.domain.user.dto.ActivityStreakDto>> getActivityStreak(
             @AuthenticationPrincipal Long userId) {
+        requireAuthenticatedUserId(userId);
         return ApiResponse.success(userService.getUserActivityStreak(userId));
     }
 
@@ -99,34 +112,31 @@ public class UserController {
 
     @GetMapping("/check-nickname")
     public ApiResponse<Map<String, Object>> checkNickname(@RequestParam String nickname) {
-        // 닉네임 형식 검증: 2~12자, 한글/영문/숫자만 허용
-        Pattern pattern = Pattern.compile("^[가-힣a-zA-Z0-9]{2,12}$");
+        Pattern pattern = Pattern.compile("^[\\uAC00-\\uD7A3a-zA-Z0-9]{2,12}$");
         if (!pattern.matcher(nickname).matches()) {
             return ApiResponse.success(Map.of(
                     "available", false,
-                    "message", "닉네임은 2~12자, 한글/영문/숫자만 사용할 수 있습니다."));
+                    "message", "\uB2C9\uB124\uC784\uC740 2~12\uC790, \uD55C\uAE00/\uC601\uBB38/\uC22B\uC790\uB9CC \uC0AC\uC6A9\uD560 \uC218 \uC788\uC2B5\uB2C8\uB2E4."));
         }
 
-        // 중복 검증
         boolean exists = userService.existsByNickname(nickname);
         if (exists) {
             return ApiResponse.success(Map.of(
                     "available", false,
-                    "message", "이미 사용중인 닉네임입니다."));
+                    "message", "\uC774\uBBF8 \uC0AC\uC6A9\uC911\uC778 \uB2C9\uB124\uC784\uC785\uB2C8\uB2E4."));
         }
 
         return ApiResponse.success(Map.of(
                 "available", true,
-                "message", "사용 가능한 닉네임입니다."));
+                "message", "\uC0AC\uC6A9 \uAC00\uB2A5\uD55C \uB2C9\uB124\uC784\uC785\uB2C8\uB2E4."));
     }
 
     @GetMapping("/check-boj-id")
     public ApiResponse<Map<String, Object>> checkBojId(@RequestParam String bojId) {
-        // Validating format first (optional, but good practice)
         if (bojId == null || bojId.trim().isEmpty()) {
             return ApiResponse.success(Map.of(
                     "valid", false,
-                    "message", "백준 아이디를 입력해주세요."));
+                    "message", "\uBC31\uC900 \uC544\uC774\uB514\uB97C \uC785\uB825\uD574\uC8FC\uC138\uC694."));
         }
 
         boolean isValid = userService.validateBojId(bojId);
@@ -134,11 +144,11 @@ public class UserController {
         if (isValid) {
             return ApiResponse.success(Map.of(
                     "valid", true,
-                    "message", "확인되었습니다."));
+                    "message", "\uD655\uC778\uB418\uC5C8\uC2B5\uB2C8\uB2E4."));
         } else {
             return ApiResponse.success(Map.of(
                     "valid", false,
-                    "message", "존재하지 않는 백준 아이디입니다."));
+                    "message", "\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uBC31\uC900 \uC544\uC774\uB514\uC785\uB2C8\uB2E4."));
         }
     }
 
@@ -146,6 +156,7 @@ public class UserController {
     public ApiResponse<java.util.List<com.peekle.domain.user.dto.TimelineItemDto>> getDailyTimeline(
             @AuthenticationPrincipal Long userId,
             @RequestParam String date) {
+        requireAuthenticatedUserId(userId);
         return ApiResponse.success(userService.getDailyTimeline(userId, date));
     }
 
@@ -159,6 +170,7 @@ public class UserController {
     @GetMapping("/me/extension-status")
     public ApiResponse<ExtensionStatusResponse> getExtensionStatus(
             @AuthenticationPrincipal Long userId) {
+        requireAuthenticatedUserId(userId);
         return ApiResponse.success(userService.getExtensionStatus(userId));
     }
 
@@ -182,6 +194,13 @@ public class UserController {
             @RequestParam(required = false) String tier,
             @RequestParam(required = false) String sourceType,
             @RequestParam(required = false) String status) {
+        requireAuthenticatedUserId(userId);
         return ApiResponse.success(userService.getUserSubmissions(userId, pageable, date, tier, sourceType, status));
+    }
+
+    private void requireAuthenticatedUserId(Long userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
     }
 }

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "${app.frontend-url}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope:
@@ -45,7 +45,7 @@ spring:
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "${app.frontend-url}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope: name, profile_image
@@ -53,7 +53,7 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "${app.frontend-url}/login/oauth2/code/{registrationId}"
             scope: profile, email
         provider:
           kakao:


### PR DESCRIPTION
## 💡 의도 / 배경
도메인 분리(`peekle.today` 프론트, `api.peekle.today` 백엔드) 이후 OAuth 로그인 과정에서 `redirect_uri` 기준이 환경마다 달라질 수 있어 인증 실패(`authorization_request_not_found`, provider redirect mismatch)가 발생했습니다.  
또한 인증되지 않은 상태에서 `/api/users/me` 계열 호출 시 `userId`가 null인데 서비스 로직에서 `findById(null)`이 실행되어 500이 발생하는 문제가 있었습니다.

이번 변경으로 OAuth redirect URI를 환경변수 기반으로 통일하고, `/me` 계열 요청의 인증 누락 시 500 대신 401로 응답하도록 수정했습니다.

## 🛠️ 작업 내용
- [x] OAuth redirect URI를 `{baseUrl}` 방식에서 `FRONTEND_URL` 기반으로 변경
- [x] `application.yml`의 kakao/naver/google `redirect-uri`를 `${app.frontend-url}/login/oauth2/code/{registrationId}`로 통일
- [x] `UserController`의 `/me` 계열 엔드포인트에 공통 인증 가드(`requireAuthenticatedUserId`) 추가
- [x] 인증 주체 누락(null) 시 `BusinessException(ErrorCode.UNAUTHORIZED)` 발생하도록 처리하여 500 → 401로 전환

## 🔗 관련 이슈
- Closes #72 

## 🖼️ 스크린샷 (선택)
- N/A (백엔드 설정/로직 변경)

## 🧪 테스트 방법
- [x] `apps/backend`에서 `./gradlew.bat compileJava` 성공 확인
- [x] 인증 없이 `GET /api/users/me` 호출 시 401 응답 확인
- [x] 인증 없이 `/api/users/me/*` 계열 호출 시 500 미발생 확인
- [x] `FRONTEND_URL=https://peekle.today` 설정 후 OAuth redirect URI가 `https://peekle.today/login/oauth2/code/{provider}`로 생성되는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
OAuth provider 콘솔(구글/카카오/네이버)의 Redirect URI도 아래 형식으로 맞춰야 정상 동작합니다.
- `https://peekle.today/login/oauth2/code/google`
- `https://peekle.today/login/oauth2/code/kakao`
- `https://peekle.today/login/oauth2/code/naver`

운영 환경변수 `FRONTEND_URL` 값이 실제 프론트 도메인과 다르면 로그인 실패가 재발할 수 있어 함께 확인 부탁드립니다.
