### PR TITLE
fix: 로그인 페이지로 계속 리다이렉트 되던 문제 수정

### DIFF
--- a/apps/frontend/src/components/providers/ClientSessionManager.tsx
+++ b/apps/frontend/src/components/providers/ClientSessionManager.tsx
@@ -1,28 +1,33 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useAuthStore } from '@/store/auth-store';
 
+const AUTH_OR_PUBLIC_ROUTES = new Set(['/login', '/signup', '/']);
+
 export function ClientSessionManager() {
-    const router = useRouter();
-    const { checkAuth } = useAuthStore();
+  const router = useRouter();
+  const pathname = usePathname();
+  const { checkAuth } = useAuthStore();
 
-    useEffect(() => {
-        // 앱 초기 진입 시 인증 상태 확인
-        checkAuth();
+  useEffect(() => {
+    if (!pathname || AUTH_OR_PUBLIC_ROUTES.has(pathname)) {
+      return;
+    }
 
-        const handleAuthRefreshed = () => {
-            // 토큰 갱신됨 -> 서버 컴포넌트(데이터) 새로고침
-            router.refresh();
-        };
+    checkAuth();
 
-        window.addEventListener('auth:refreshed', handleAuthRefreshed);
+    const handleAuthRefreshed = () => {
+      router.refresh();
+    };
 
-        return () => {
-            window.removeEventListener('auth:refreshed', handleAuthRefreshed);
-        };
-    }, [router, checkAuth]);
+    window.addEventListener('auth:refreshed', handleAuthRefreshed);
 
-    return null;
+    return () => {
+      window.removeEventListener('auth:refreshed', handleAuthRefreshed);
+    };
+  }, [pathname, router, checkAuth]);
+
+  return null;
 }

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -202,11 +202,23 @@ async function retryOriginalRequest<T>(url: string, fetchOptions: RequestInit): 
   }
 }
 
+function isAuthOrPublicRoute(pathname: string): boolean {
+  return (
+    pathname === '/' ||
+    pathname.startsWith('/login') ||
+    pathname.startsWith('/signup')
+  );
+}
+
 function handleAuthFailure<T>(): ApiResponse<T> {
   if (typeof window !== 'undefined') {
-    // Call logout API to clear cookies before redirecting
+    const shouldRedirectToLogin = !isAuthOrPublicRoute(window.location.pathname);
+
+    // Clear auth cookies. Redirect only when not already on auth/public routes.
     fetch('/api/auth/logout', { method: 'POST' }).finally(() => {
-      window.location.href = '/login';
+      if (shouldRedirectToLogin) {
+        window.location.replace('/login');
+      }
     });
   }
   return {

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -7,34 +7,25 @@ const authRoutes = ['/login', '/signup'];
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get('access_token')?.value;
-  // refresh_token은 path=/api/auth/refresh 로 설정되어 있어 미들웨어에서 접근 불가할 수 있음
-  // 대신 is_authenticated 쿠키를 확인하여 로그인 세션이 유지되고 있는지 판단
-  const isAuthenticated = request.cookies.get('is_authenticated')?.value; // "true"
+  const isAuthenticated = request.cookies.get('is_authenticated')?.value;
 
   const isProtectedRoute = protectedRoutes.some((route) => pathname.startsWith(route));
   const isAuthRoute = authRoutes.some((route) => pathname.startsWith(route));
 
-  // 1. 보호된 라우트 접근 시
+  // Protected routes: allow when access token exists or refresh session marker exists.
   if (isProtectedRoute) {
-    if (accessToken) {
-      // Access Token이 있으면 통과
+    if (accessToken || isAuthenticated) {
       return NextResponse.next();
     }
 
-    if (isAuthenticated) {
-      // Access Token은 없지만(만료됨) 인증 세션(Refresh Token 존재 가능성)이 있다면 통과
-      // 클라이언트(api.ts)에서 401 발생 시 자동으로 Refresh Token으로 갱신 시도함
-      return NextResponse.next();
-    }
-
-    // 둘 다 없으면 로그인 필요
     const loginUrl = new URL('/login', request.url);
     return NextResponse.redirect(loginUrl);
   }
 
-  // 2. 로그인된 상태에서 로그인/회원가입/랜딩 페이지 접근 시 홈으로 리다이렉트
+  // Auth/landing routes: redirect only when access token is present.
+  // This avoids redirect loops caused by stale is_authenticated cookies.
   const isLandingPage = pathname === '/';
-  if ((isAuthRoute || isLandingPage) && (accessToken || isAuthenticated)) {
+  if ((isAuthRoute || isLandingPage) && accessToken) {
     const homeUrl = new URL('/home', request.url);
     return NextResponse.redirect(homeUrl);
   }
@@ -53,7 +44,6 @@ export const config = {
     '/ranking/:path*',
     '/search/:path*',
     '/settings/:path*',
-    // '/api/:path*', API 라우트는 미들웨어 제외 (필요시)
     '/login',
     '/signup',
   ],


### PR DESCRIPTION

chore: OAuth redirect-uri 환경변수화 및 인증 리다이렉트 루프/500 에러 수정

## 💡 의도 / 배경
도메인 분리(`peekle.today`, `api.peekle.today`) 이후 OAuth redirect URI가 환경에 따라 달라져 로그인 실패가 발생할 수 있었고,  
인증 만료 상태에서 `/api/users/me` 계열 요청이 500으로 떨어지는 문제 및 로그인 페이지 리다이렉트 루프가 확인되었습니다.

## 🛠️ 작업 내용
- [x] Backend OAuth redirect-uri를 `{baseUrl}` 기반에서 `${app.frontend-url}` 기반으로 변경
- [x] `FRONTEND_URL` 환경변수 기준으로 provider(kakao/naver/google) redirect URI 통일
- [x] `/api/users/me*` 계열에서 `@AuthenticationPrincipal` null 방어 로직 추가
- [x] 인증 누락 시 500 대신 401(`UNAUTHORIZED`) 응답하도록 수정
- [x] Frontend 미들웨어/세션 처리에서 로그인 루프 방지
- [x] 실제 라우트 기준으로 auth 예외 경로를 `/login`, `/signup`, `/`로 정리 (`/register` 제거)

## 🔗 관련 이슈
- Closes #79 

## 🖼️ 스크린샷 (선택)
- N/A (백엔드/미들웨어 동작 수정)

## 🧪 테스트 방법
- [x] `apps/backend`에서 `./gradlew.bat compileJava` 성공
- [x] `pnpm --filter frontend build` 성공
- [x] 인증 없이 `/api/users/me` 호출 시 401 응답 확인
- [x] `/login`, `/signup` 진입 시 반복 리다이렉트(새로고침 루프) 미발생 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
운영 환경에서 아래 값 확인 부탁드립니다.
- `FRONTEND_URL=https://peekle.today`
- OAuth Provider Console Redirect URI:
  - `https://peekle.today/login/oauth2/code/google`
  - `https://peekle.today/login/oauth2/code/kakao`
  - `https://peekle.today/login/oauth2/code/naver`