### PR TITLE
chore: 환경변수로 db 변경할 수 있게 수정

### DIFF
--- a/apps/backend/src/main/resources/application-prod.yml
+++ b/apps/backend/src/main/resources/application-prod.yml
@@ -9,7 +9,7 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: ${DB_DRIVER_CLASS_NAME:com.mysql.cj.jdbc.Driver}
 
   jpa:
     hibernate:
@@ -18,12 +18,13 @@ spring:
       hibernate:
         format_sql: false
         show_sql: false
-    database-platform: org.hibernate.dialect.MySQLDialect
+    database-platform: ${DB_DIALECT:org.hibernate.dialect.MySQLDialect}
 
   flyway:
     enabled: true
     baseline-on-migrate: true
     validate-on-migrate: true
+    locations: ${FLYWAY_LOCATIONS:classpath:db/migration}
 
   data:
     redis:


### PR DESCRIPTION
## 💡 의도 / 배경
- PostgreSQL로 전환 테스트 중 `prod` 프로필에서 PostgreSQL URL을 사용했지만, MySQL 드라이버가 고정되어 애플리케이션이 부팅 실패했습니다.
- 운영 프로필(`prod`)을 유지한 채 DB 종류(MySQL/PostgreSQL)를 환경변수로 전환 가능하게 만들어, 마이그레이션/롤백을 안전하게 수행하기 위해 수정했습니다.

## 🛠️ 작업 내용
- [x] `application-prod.yml`의 DB 드라이버를 환경변수화  
  (`DB_DRIVER_CLASS_NAME`, 기본값 `com.mysql.cj.jdbc.Driver`)
- [x] `application-prod.yml`의 JPA Dialect를 환경변수화  
  (`DB_DIALECT`, 기본값 `org.hibernate.dialect.MySQLDialect`)
- [x] `application-prod.yml`의 Flyway 경로를 환경변수화  
  (`FLYWAY_LOCATIONS`, 기본값 `classpath:db/migration`)

## 🔗 관련 이슈
- Closes #82 

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] `apps/backend` 컴파일 확인
  - `./gradlew.bat compileJava`
- [x] 설정 검증
  - 기본값 미지정 시 기존 MySQL 설정 유지 확인
  - PostgreSQL 전환 시 아래 환경변수 조합으로 기동 가능함을 로그 기준 확인
    - `DB_DRIVER_CLASS_NAME=org.postgresql.Driver`
    - `DB_DIALECT=org.hibernate.dialect.PostgreSQLDialect`
    - `FLYWAY_LOCATIONS=classpath:db/migration-postgres`

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- 기존 운영(MySQL)에는 영향 없이 기본값으로 동일하게 동작합니다.
- PostgreSQL 전환은 환경변수만 변경해 적용 가능하며, 문제 발생 시 env 롤백만으로 즉시 복귀할 수 있습니다.
