### PR TITLE
fix: backend와 ai 둘다 빌드돼야 deploy 하던 문제 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,11 @@ jobs:
 
   deploy:
     needs: [changes, build-backend, build-ai-server]
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.ai_server == 'true' || needs.changes.outputs.docker == 'true'
+    if: |
+      always() &&
+      (needs.changes.outputs.backend == 'true' || needs.changes.outputs.ai_server == 'true' || needs.changes.outputs.docker == 'true') &&
+      (needs.build-backend.result == 'success' || needs.build-backend.result == 'skipped') &&
+      (needs.build-ai-server.result == 'success' || needs.build-ai-server.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to EC2


### PR DESCRIPTION

## 💡 의도 / 배경
- GitHub Actions에서 `build-backend`는 성공했지만 `build-ai-server`가 `skipped`일 때, `deploy` 잡이 함께 `skipped`되는 문제가 있었습니다.
- 결과적으로 실제 배포가 필요한 변경(backend 변경)에서도 배포가 누락되어 운영 반영이 지연되었습니다.

## 🛠️ 작업 내용
- [x] `deploy` 잡의 `if` 조건을 `always()` 기반으로 보강
- [x] `needs` 결과 조건에 `success`뿐 아니라 `skipped`도 허용 (`build-backend`, `build-ai-server`)
- [x] 빌드 실패(`failed`) 시에는 배포가 진행되지 않도록 안전장치 유지

## 🔗 관련 이슈
- Closes #82 

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] 워크플로우 조건식 확인: `deploy`가 아래 조건을 만족하면 실행되는지 검토
  - 변경 감지(`backend`/`ai_server`/`docker`)가 true
  - `build-backend` 결과가 `success` 또는 `skipped`
  - `build-ai-server` 결과가 `success` 또는 `skipped`
- [x] 시나리오 점검
  - backend만 변경: `build-backend=success`, `build-ai-server=skipped`, `deploy=run` 기대
  - ai-server만 변경: `build-backend=skipped`, `build-ai-server=success`, `deploy=run` 기대
  - docker 변경: 둘 다 실행 후 `deploy=run` 기대

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [ ] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- 이번 변경은 배포 누락 방지 목적의 CI 조건식 수정입니다.
- 선택적 빌드 잡이 스킵돼도 배포가 필요한 경우 정상 진행되며, 빌드 실패 케이스는 기존처럼 차단됩니다.