### PR TITLE
fix: mysql에만 있던 문법 수정

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/study/entity/StudyProblemDraft.java
+++ b/apps/backend/src/main/java/com/peekle/domain/study/entity/StudyProblemDraft.java
@@ -35,7 +35,7 @@ public class StudyProblemDraft {
     private StudyProblem studyProblem;
 
     @Lob
-    @Column(name = "code", columnDefinition = "LONGTEXT")
+    @Column(name = "code")
     private String code;
 
     @Column(name = "language", length = 50)

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -59,7 +59,7 @@ services:
     env_file:
       - ../apps/backend/.env
     environment:
-      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-prod}
       - SERVER_PORT=8080
       - REDIS_HOST=redis
       - SPRING_DATA_REDIS_HOST=redis


### PR DESCRIPTION
## 💡 의도 / 배경
- PostgreSQL 전환 후 백엔드 부팅 시 Hibernate `ddl-auto=validate` 단계에서 컬럼 타입 불일치로 애플리케이션이 실패했습니다.
- 원인은 `study_problem_drafts.code` 필드가 엔티티에서 MySQL 전용 `LONGTEXT`로 고정되어 있었기 때문입니다.
- 멀티 DB(PostgreSQL 포함) 호환성을 확보하기 위해 DB 벤더 종속 타입 지정을 제거했습니다.

## 🛠️ 작업 내용
- [x] `StudyProblemDraft.code`의 `@Column(columnDefinition = "LONGTEXT")` 제거
- [x] `@Lob` 기반의 DB 벤더 중립 매핑으로 변경
- [x] PostgreSQL 환경에서 Flyway 이후 Hibernate validate 통과 가능하도록 정합성 확보

## 🔗 관련 이슈
- Closes #82 

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] 컴파일 확인: `./gradlew.bat compileJava`
- [x] PostgreSQL 프로필로 백엔드 기동 후 로그 확인
  - Flyway `migration-postgres` 적용
  - 기존 `wrong column type ... expecting [longtext]` 오류 미발생 확인
- [x] 컨테이너 재기동 후 `peekle-backend` 로그로 애플리케이션 정상 부팅 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [ ] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- 이번 수정은 MySQL 전용 DDL 힌트 제거로, PostgreSQL 전환 안정화 목적의 최소 변경입니다.
- 유사한 벤더 종속 `columnDefinition`은 추가 점검 완료했으며, 현재 장애를 유발한 항목은 본 필드 1건입니다.