### PR TITLE
fix: studyProblemDraft를 Lob대신 text로 변경

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/study/entity/StudyProblemDraft.java
+++ b/apps/backend/src/main/java/com/peekle/domain/study/entity/StudyProblemDraft.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 
@@ -34,7 +36,7 @@ public class StudyProblemDraft {
     @JoinColumn(name = "study_problem_id", nullable = false)
     private StudyProblem studyProblem;
 
-    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     @Column(name = "code")
     private String code;
 


### PR DESCRIPTION
```md
## 💡 의도 / 배경
- PostgreSQL 전환 후 백엔드 부팅 시 Hibernate 스키마 검증에서 `study_problem_drafts.code` 컬럼 타입 불일치로 애플리케이션이 실패했습니다.
- 원인은 엔티티 매핑이 `@Lob`/MySQL 전용 타입 관점으로 해석되어 PostgreSQL에서 `oid(CLOB)` 기대값이 생긴 것이었습니다.
- 실제 PostgreSQL 스키마(`TEXT`)와 엔티티 매핑을 일치시켜 부팅 실패를 해결하고자 수정했습니다.

## 🛠️ 작업 내용
- [x] `StudyProblemDraft.code` 필드에서 LOB 기반 매핑 제거
- [x] `code` 필드를 `TEXT` 문자열 컬럼으로 명시 매핑
- [x] PostgreSQL(`profile=postgres`) 환경에서 Flyway + Hibernate validate 경로 정합성 확보

## 🔗 관련 이슈
- Closes #

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] `./gradlew.bat compileJava` 컴파일 성공
- [x] PostgreSQL 프로필로 백엔드 재기동
- [x] 로그 확인
  - `Database: jdbc:postgresql://...`
  - `Flyway ... Successfully applied 1 migration`
  - `Schema-validation: wrong column type ... study_problem_drafts.code` 오류 미재현

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [ ] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- 이번 수정은 PostgreSQL 전환 장애를 막기 위한 최소 범위 타입 매핑 정합화입니다.
- 후속으로 엔티티 전반의 DB 벤더 종속 `columnDefinition` 점검/정리를 별도 PR로 진행할 수 있습니다.
```