### PR TITLE
chore: ai-server 배포할 때 환경변수를 ec2의 ai-server/.env에서 받게 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,12 +147,46 @@ jobs:
             export CI_REGISTRY_IMAGE=ghcr.io/peek-a-chu/peekle
             # For simplicity, we just use 'main' or 'master' tag. In a real scenario, you can pass SHA.
             export CI_COMMIT_SHORT_SHA=main
-            export DOMAIN_NAME=${{ secrets.DOMAIN_NAME }}
             
             # (Create dummy .env if doesn't exist to avoid compose errors)
             if [ ! -f .env ]; then
               touch .env
             fi
+            # AI 서버 전용 env 파일
+            if [ ! -f ../apps/ai-server/.env ]; then
+              touch ../apps/ai-server/.env
+            fi
+            
+            # 파일별 env를 통일 관리
+            upsert_env_file() {
+              FILE="$1"
+              KEY="$2"
+              VALUE="$3"
+              if [ -z "$VALUE" ]; then
+                return 0
+              fi
+              ESCAPED_VALUE=$(printf '%s\n' "$VALUE" | sed -e 's/[\/&]/\\&/g')
+              if grep -q "^${KEY}=" "$FILE"; then
+                sed -i "s|^${KEY}=.*|${KEY}=${ESCAPED_VALUE}|" "$FILE"
+              else
+                echo "${KEY}=${VALUE}" >> "$FILE"
+              fi
+            }
+
+            upsert_env() {
+              KEY="$1"
+              VALUE="$2"
+              upsert_env_file .env "$KEY" "$VALUE"
+            }
+
+            upsert_env DOMAIN_NAME "${{ secrets.DOMAIN_NAME }}"
+            upsert_env POSTGRES_DB "${{ secrets.POSTGRES_DB }}"
+            upsert_env POSTGRES_USER "${{ secrets.POSTGRES_USER }}"
+            upsert_env POSTGRES_PASSWORD "${{ secrets.POSTGRES_PASSWORD }}"
+            upsert_env_file ../apps/ai-server/.env GEMINI_API_KEY "${{ secrets.GEMINI_API_KEY }}"
+            upsert_env_file ../apps/ai-server/.env GEMINI_BASE_URL "${{ secrets.GEMINI_BASE_URL }}"
+            upsert_env_file ../apps/ai-server/.env GEMINI_CHAT_MODEL "${{ secrets.GEMINI_CHAT_MODEL }}"
+            upsert_env_file ../apps/ai-server/.env EMBEDDING_MODEL "${{ secrets.EMBEDDING_MODEL }}"
 
             BACKEND_CHANGED=${{ needs.changes.outputs.backend }}
             AI_CHANGED=${{ needs.changes.outputs.ai_server }}
@@ -169,17 +203,17 @@ jobs:
             # 5. Deploy strategy
             if [ "$DOCKER_CHANGED" = "true" ]; then
               # docker/** changed => full infra redeploy
-              docker compose -f docker-compose.prod.yml up -d backend ai-server redis chroma livekit certbot
-              docker compose -f docker-compose.prod.yml up -d --force-recreate nginx
+              docker compose -f docker-compose.prod.yml up -d --remove-orphans backend ai-server redis postgres-vector livekit certbot
+              docker compose -f docker-compose.prod.yml up -d --remove-orphans --force-recreate nginx
               docker exec peekle-nginx nginx -t
               docker exec peekle-nginx nginx -s reload
             else
               # App-only changes => only changed services
               if [ "$BACKEND_CHANGED" = "true" ]; then
-                docker compose -f docker-compose.prod.yml up -d backend
+                docker compose -f docker-compose.prod.yml up -d --remove-orphans backend
               fi
               if [ "$AI_CHANGED" = "true" ]; then
-                docker compose -f docker-compose.prod.yml up -d ai-server
+                docker compose -f docker-compose.prod.yml up -d --remove-orphans ai-server
               fi
             fi
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -147,10 +147,6 @@ services:
       - PGVECTOR_DB=${POSTGRES_DB:-peekle}
       - PGVECTOR_USER=${POSTGRES_USER:-peekle}
       - PGVECTOR_PASSWORD=${POSTGRES_PASSWORD:-peekle-password}
-      - GEMINI_API_KEY=${GEMINI_API_KEY}
-      - GEMINI_BASE_URL=${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai/}
-      - GEMINI_CHAT_MODEL=${GEMINI_CHAT_MODEL:-gemini-2.5-flash}
-      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-text-embedding-004}
     ports:
       - "8000:8000"
     volumes:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -138,10 +138,6 @@ services:
       - PGVECTOR_DB=${POSTGRES_DB:-peekle}
       - PGVECTOR_USER=${POSTGRES_USER:-peekle}
       - PGVECTOR_PASSWORD=${POSTGRES_PASSWORD:-peekle-password}
-      - GEMINI_API_KEY=${GEMINI_API_KEY}
-      - GEMINI_BASE_URL=${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai/}
-      - GEMINI_CHAT_MODEL=${GEMINI_CHAT_MODEL:-gemini-2.5-flash}
-      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-text-embedding-004}
     expose:
       - "8000"
     depends_on:


### PR DESCRIPTION
## 💡 의도 / 배경
AI 서버 배포 시 `docker-compose`의 변수 치환과 `env_file`이 혼재되어 `GEMINI_API_KEY`가 빈 값으로 덮어써지는 문제가 있었습니다.  
이로 인해 런타임에서 AI 인증 헤더 누락(`Missing or invalid Authorization header`) 오류가 발생하여 추천 API가 실패했습니다.  
배포 환경에서 AI 관련 키/모델 설정을 EC2의 `apps/ai-server/.env` 기준으로 단일화해 주입 충돌을 방지하고자 했습니다.

## 🛠️ 작업 내용
- [x] `docker-compose.prod.yml`, `docker-compose.dev.yml`의 `ai-server.environment`에서 `GEMINI_*`, `EMBEDDING_MODEL` 제거
- [x] AI 관련 설정은 `env_file: ../apps/ai-server/.env`만 사용하도록 통일
- [x] deploy workflow에서 `GEMINI_*`, `EMBEDDING_MODEL`을 `docker/.env`가 아닌 `../apps/ai-server/.env`에 upsert하도록 변경
- [x] deploy workflow의 env upsert 로직을 공통 함수화(`upsert_env_file`)하고 특수문자(`/`, `&`) escape 처리 추가
- [x] 배포 명령에서 제거된 서비스(`chroma`) 참조를 `postgres-vector`로 정리
- [x] `--remove-orphans` 옵션 추가로 고아 컨테이너 자동 정리

## 🔗 관련 이슈
- Closes #82

## 🖼️ 스크린샷 (선택)
- UI 변경 없음

## 🧪 테스트 방법
- [x] 워크플로우 파일 변경 후 `deploy.yml` 스크립트 로직 점검 (AI env 파일 생성/갱신 경로 확인)
- [ ] GitHub Actions `Deploy to EC2` 수동 실행
- [ ] EC2에서 `~/peekle/apps/ai-server/.env`에 `GEMINI_*` 값 반영 여부 확인
- [ ] `docker inspect peekle-ai-server`로 `GEMINI_*` 주입 확인
- [ ] 추천 API 호출 시 400/401 인증 오류 미발생 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
AI 관련 환경변수는 이제 EC2의 `apps/ai-server/.env`를 단일 소스로 사용합니다.  
GitHub Secrets에 `GEMINI_API_KEY`, `GEMINI_BASE_URL`, `GEMINI_CHAT_MODEL`, `EMBEDDING_MODEL`이 설정되어 있어야 하며, 누락 시 ai-server 인증 오류가 재발할 수 있습니다.