### PR TITLE
feat: 리그 안내 문구 개선

### DIFF
--- a/apps/frontend/src/domains/league/components/CCLeagueMyStatus.tsx
+++ b/apps/frontend/src/domains/league/components/CCLeagueMyStatus.tsx
@@ -130,6 +130,7 @@ const CCLeagueMyStatus = ({ initialLeagueRanking, initialWeeklyScore }: CCLeague
   // 내 상태 파악
   const myStatusMember = rankingData.members.find((m) => m.me);
   const myCurrentStatus = myStatusMember?.status || 'STAY'; // Default fallback
+  const isPromotionBlockedByZeroScore = rankingData.members.length >= 4 && rankingData.myScore <= 0;
 
   const isStone = rankingData.myLeague === 'stone';
 
@@ -138,6 +139,9 @@ const CCLeagueMyStatus = ({ initialLeagueRanking, initialWeeklyScore }: CCLeague
     statusDetail = isStone
       ? '이번 주 해당 티어의 참가 인원이 부족해 리그 그룹이 배정되지 않았습니다.'
       : '이번 주는 같은 티어 인원이 부족해 리그가 운영되지 않습니다. 다음 주를 기다려 주세요!';
+  } else if (isPromotionBlockedByZeroScore) {
+    statusMessage = '승급 불가';
+    statusDetail = '아직 0점이라 승급할 수 없어요. 이번 주는 한 문제 이상 풀어보세요!';
   } else if (myCurrentStatus === 'PROMOTE') {
     statusMessage = '승급 안정권';
     statusDetail = '승급 구간에 속해있습니다!';

--- a/apps/frontend/src/domains/league/components/LeagueResultModal.tsx
+++ b/apps/frontend/src/domains/league/components/LeagueResultModal.tsx
@@ -94,6 +94,8 @@ function RankingView({
   const promotionZone = ranking.filter((m) => m.status === 'PROMOTE');
   const maintenanceZone = ranking.filter((m) => m.status === 'STAY');
   const demotionZone = ranking.filter((m) => m.status === 'DEMOTE');
+  const myMember = ranking.find((m) => m.me);
+  const isPromotionBlockedByZeroScore = !!myMember && myMember.score <= 0;
 
   return (
     <>
@@ -116,6 +118,12 @@ function RankingView({
           <div className="text-muted-foreground py-10">랭킹 불러오는 중...</div>
         ) : ranking.length > 0 ? (
           <>
+            {isPromotionBlockedByZeroScore && (
+              <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs font-medium text-amber-200">
+                아직 0점이라 승급할 수 없어요. 이번 주는 한 문제 이상 풀어보세요!
+              </div>
+            )}
+
             {/* 1. 승급 구간 */}
             {promotionZone.length > 0 && (
               <div className="space-y-2">

--- a/apps/frontend/src/domains/lnb/components/MyLeagueCard.tsx
+++ b/apps/frontend/src/domains/lnb/components/MyLeagueCard.tsx
@@ -10,7 +10,7 @@ interface LeagueInfo {
   score: number;
   rank: number;
   totalPlayers: number;
-  status: 'promotion' | 'maintenance' | 'demotion';
+  status: 'promotion' | 'maintenance' | 'demotion' | 'blocked';
 }
 
 interface Props {
@@ -41,6 +41,10 @@ const MyLeagueCard = ({ initialTier, initialScore }: Props) => {
     promotion: { label: '승급예정', color: 'text-success bg-success/10' },
     maintenance: { label: '유지', color: 'text-muted-foreground bg-muted' },
     demotion: { label: '강등위기', color: 'text-destructive bg-destructive/10' },
+    blocked: {
+      label: '승급준비(0점)',
+      color: 'text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-500/20',
+    },
   };
 
   // Determine what to show
@@ -70,12 +74,19 @@ const MyLeagueCard = ({ initialTier, initialScore }: Props) => {
   const isGroupAssigned = !isLoading ? data.members.length >= 4 : true;
   const displayRank = !isLoading ? data.myRank : 0;
   const displayTotal = !isLoading ? data.members.length : 0;
-  const displayStatusKey = !isLoading && isGroupAssigned ? getStatus(myMember?.status) : 'maintenance';
+  const displayStatusKey =
+    !isLoading && isGroupAssigned ? getStatus(myMember?.status) : 'maintenance';
+  const isPromotionBlockedByZeroScore = !isLoading && isGroupAssigned && displayScore <= 0;
   const displayStatus = isLoading
     ? statusMap.maintenance
     : !isGroupAssigned
-      ? { label: data.myLeague === 'stone' ? '배치대기' : '휴식중', color: 'text-muted-foreground bg-muted' }
-      : statusMap[displayStatusKey];
+      ? {
+          label: data.myLeague === 'stone' ? '배치대기' : '휴식중',
+          color: 'text-muted-foreground bg-muted',
+        }
+      : isPromotionBlockedByZeroScore
+        ? statusMap.blocked
+        : statusMap[displayStatusKey];
 
   if (showSkeleton) return <div className="h-20 bg-muted/30 rounded-xl animate-pulse" />;
 


### PR DESCRIPTION

## 💡 의도 / 배경
0점 사용자가 왜 승급되지 않는지 즉시 이해하기 어려워 혼란이 발생했습니다.
리그 UI에서 0점 승급 불가 사유를 명확하고 부드러운 톤으로 안내해,
불필요한 재시도/문의 비용을 줄이고자 했습니다.

## 🛠️ 작업 내용
- [x] 리그 상태 카드(League 페이지)에서 0점 사용자에게 안내 문구 노출
- [x] 수요일 정산 결과 모달에서 0점 사용자 안내 문구 노출
- [x] LNB 내 리그 카드 상태 뱃지 문구를 `승급준비(0점)`으로 개선
- [x] 1점 이상 사용자 기존 승급/유지/강등 플로우는 유지

## 🔗 관련 이슈
- Closes #91

## 🖼️ 스크린샷 (선택)
- UI 문구 변경 중심이라 필요 시 리뷰 중 캡처 추가하겠습니다.

## 🧪 테스트 방법
- [x] 0점 사용자로 League 페이지 진입 시 `승급 불가` + 안내 문구 확인
- [x] 0점 사용자로 정산 결과 모달 진입 시 동일 안내 문구 확인
- [x] LNB 내 리그 카드에 `승급준비(0점)` 뱃지 노출 확인
- [x] 1점 이상 사용자에서 기존 상태(승급/유지/강등) 표시 정상 동작 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?
## 💬 리뷰어에게 (선택)