### PR TITLE
feat: 랜딩 페이지 SEO 기본 설정 추가

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,16 +1,62 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
+﻿import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Users, Gamepad2, Trophy, Target, ArrowRight, Code2, Zap } from 'lucide-react';
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://peekle.today';
+
+export const metadata: Metadata = {
+  title: '힐끔힐끔코딩 Peekle | Real-time Algorithm Study Platform',
+  description:
+    '힐끔힐끔코딩(Peekle)은 실시간 화상 스터디, 경쟁형 게임 모드, AI 문제 추천을 제공하는 알고리즘 학습 플랫폼입니다.',
+  keywords: [
+    '힐끔힐끔코딩',
+    '힐힐코',
+    'Peekle',
+    '알고리즘 스터디',
+    '코딩테스트',
+    'PS 스터디',
+    '백준',
+    'Baekjoon',
+    '프로그래머스',
+    'Programmers',
+    'SWEA',
+    '삼성 SW Expert Academy',
+  ],
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    title: '힐끔힐끔코딩 Peekle | Real-time Algorithm Study Platform',
+    description: '실시간 화상 스터디와 경쟁형 게임 모드로 알고리즘 실력을 빠르게 성장시키세요.',
+    url: siteUrl,
+    siteName: '힐끔힐끔코딩 Peekle',
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '힐끔힐끔코딩 Peekle',
+    description: '실시간 스터디, 게임 모드, AI 추천으로 알고리즘 학습을 더 재미있게.',
+  },
+};
 
 export default function Home() {
-  const router = useRouter();
+  const websiteJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: '힐끔힐끔코딩 Peekle',
+    alternateName: ['힐힐코', 'Peekle'],
+    url: siteUrl,
+    inLanguage: 'ko-KR',
+  };
 
   return (
     // 1. 전체 배경: config의 background (#F7F8FC)
     <div className="min-h-screen bg-background font-sans selection:bg-secondary selection:text-primary flex flex-col">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+      />
       {/* --- 헤더 --- */}
       <header className="sticky top-0 w-full flex justify-between items-center px-6 py-4 bg-background/80 backdrop-blur-md z-50 border-b border-border max-w-7xl mx-auto w-full">
         <div className="flex items-center gap-2">

--- a/apps/frontend/src/app/robots.ts
+++ b/apps/frontend/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://peekle.today';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://peekle.today';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+  ];
+}


### PR DESCRIPTION
feat: 랜딩 페이지 SEO 개선 (메타데이터/robots/sitemap/json-ld)

## 💡 의도 / 배경
랜딩 페이지의 SEO 기본 구성이 부족해 브랜드/서비스 검색 노출 품질이 낮았습니다.
특히 `힐끔힐끔코딩`, `힐힐코`, `Peekle` 및 도메인 키워드(백준/프로그래머스/SWEA) 관점에서 검색엔진 인식 강화를 목표로 개선했습니다.

## 🛠️ 작업 내용
- [x] 랜딩 페이지 메타데이터 강화
- [x] `title`, `description`, `keywords` 개선
- [x] `keywords`에 `백준`, `Baekjoon`, `프로그래머스`, `Programmers`, `SWEA`, `삼성 SW Expert Academy` 추가
- [x] `canonical` 설정
- [x] Open Graph / Twitter 메타 추가
- [x] JSON-LD(WebSite) 추가
- [x] `alternateName`에 `힐힐코` 포함
- [x] `robots` 라우트 추가 (`/robots.txt`)
- [x] `sitemap` 라우트 추가 (`/sitemap.xml`)

## 🔗 관련 이슈
- Closes #101 

## 🖼️ 스크린샷 (선택)
- 검색결과/공유카드 반영 후 첨부 예정

## 🧪 테스트 방법
- [x] `GET /robots.txt` 정상 응답 확인
- [x] `GET /sitemap.xml` 정상 응답 확인
- [x] 랜딩 페이지 head에 `title/description/canonical/og/twitter` 메타 생성 확인
- [x] 페이지 소스에 JSON-LD(WebSite, alternateName 포함) 확인
- [x] 타입체크 통과 (`pnpm --filter frontend exec tsc --noEmit`)

## ✅ 체크리스트
- [x] 코드 컨벤션과 일치
- [x] 셀프 리뷰 진행
- [x] 빌드/테스트 확인
- [ ] Closes 이슈 번호 최종 입력

## 💬 리뷰어에게
- 현재 랜딩 페이지 중심으로 SEO를 우선 적용했습니다.
- 배포 후 Search Console에서 랜딩 URL 색인 요청/검증까지 진행하면 반영 속도를 높일 수 있습니다.
