### PR TITLE
doc: readme 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# Peekle
-힐끔힐끔코딩
+﻿# 힐끔힐끔코딩
+
+AI 기반 코딩 스터디 플랫폼입니다.  
+문제 풀이, 스터디 협업, 실시간 소통, AI 추천 기능을 하나의 서비스로 제공합니다.
+
+## 프로젝트 소개
+
+힐끔힐끔코딩은 알고리즘 학습을 혼자서 끝내지 않고, 스터디 단위로 함께 지속할 수 있게 설계된 서비스입니다.
+
+- 스터디룸 기반 문제 관리 및 제출 흐름
+- 실시간 채팅/웹소켓 기반 협업
+- LiveKit 기반 실시간 커뮤니케이션
+- Gemini + pgvector 기반 문제 임베딩/추천
+
+## 주요 기능
+
+- 스터디룸 생성/참여 및 멤버 관리
+- 날짜별 스터디 문제 등록(기존 문제/커스텀 링크)
+- 제출 로그 및 코멘트 기반 피드백
+- 태그/티어 기반 AI 문제 추천
+- 리그/포인트 기반 학습 동기 부여
+
+## Tech Stack
+
+| 영역 | 기술 |
+| --- | --- |
+| Frontend | Next.js 15, React 19, TypeScript, Tailwind |
+| Backend | Spring Boot 3, JPA, Flyway, Redis |
+| AI Server | FastAPI, OpenAI-compatible Gemini API, pgvector |
+| Infra | Docker Compose, Nginx, LiveKit, PostgreSQL |
+| Realtime | WebSocket(STOMP), LiveKit |
+
+## 프로젝트 구조
+
+```text
+Peekle/
+  apps/
+    frontend/      # Next.js
+    backend/       # Spring Boot
+    ai-server/     # FastAPI + embeddings
+    extension/     # browser extension
+  docker/
+    docker-compose.dev.yml
+    docker-compose.prod.yml
+```
+
+## 개발 문서
+
+실행 가이드, 환경 변수, 운영/트러블슈팅 문서는 내부 Notion(Private)에서 관리합니다.


### PR DESCRIPTION
doc: readme 추가

## 💡 의도 / 배경
기존 README 내용이 매우 간단해 프로젝트 성격과 구성 파악이 어려웠습니다.  
레포 첫 진입 시 이해도를 높이기 위해 소개 중심 README를 보강했습니다.

## 🛠️ 작업 내용
- [x] 프로젝트 소개/주요 기능/기술 스택/구조 섹션 추가
- [x] 실행 가이드/트러블슈팅은 내부 Notion 문서로 안내하도록 정리

## 🔗 관련 이슈
- 관련 이슈 없음

## 🖼️ 스크린샷 (선택)
- 문서 변경으로 스크린샷 없음

## 🧪 테스트 방법
- [x] GitHub/GitLab Markdown 렌더링에서 표/코드블록/섹션 구조 확인
- [x] README 링크/문구 오탈자 및 문맥 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가? (해당 없음으로 명시)
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가? (문서 변경만 해당)

## 💬 리뷰어에게 (선택)
README를 소개 중심으로 정리했습니다.  
필요하면 이후에 환경별 실행 문서 링크(Notion URL)만 추가하겠습니다.
