### PR TITLE
feat: 푸터 추가 및 화면 개선

### DIFF
--- a/apps/frontend/src/app/(main)/home/HomeClient.tsx
+++ b/apps/frontend/src/app/(main)/home/HomeClient.tsx
@@ -100,6 +100,25 @@ export default function HomeClient({
           </div>
         </div>
       </div>
+
+      {/* 홈 화면 전용 푸터 */}
+      <footer className="mt-24 py-10 flex flex-col items-center justify-center gap-4 text-[#6B7280] text-sm">
+        <div className="flex items-center gap-4 font-medium">
+          <span className="flex items-center gap-1">
+            Contact : taesun4767@gmail.com
+          </span>
+          <span className="text-border/50">|</span>
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLScGhVj0MPivuyxrjrWQQaEMZzWqU9p-k-A-lnJJ7Q4cWh9bVg/viewform?usp=publish-editor"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors flex items-center gap-1 underline underline-offset-4"
+          >
+            피드백 및 건의사항 남기기
+          </a>
+        </div>
+        <p>© 2026 Peekle. All rights reserved.</p>
+      </footer>
     </div>
   );
 }

--- a/apps/frontend/src/app/(main)/layout.tsx
+++ b/apps/frontend/src/app/(main)/layout.tsx
@@ -14,7 +14,7 @@ export default async function MainLayout({
   return (
     <div className="flex min-h-screen">
       <Sidebar user={user} />
-      <main className="flex-1 ml-[240px] px-8 py-0 w-full">{children}</main>
+      <main className="flex-1 ml-[240px] px-8 py-0 w-full max-w-7xl mx-auto">{children}</main>
       <LeagueResultModal />
     </div>
   );

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,4 +1,4 @@
-﻿import type { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Users, Gamepad2, Trophy, Target, ArrowRight, Code2, Zap } from 'lucide-react';
@@ -58,19 +58,21 @@ export default function Home() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
       />
       {/* --- 헤더 --- */}
-      <header className="sticky top-0 w-full flex justify-between items-center px-6 py-4 bg-background/80 backdrop-blur-md z-50 border-b border-border max-w-7xl mx-auto w-full">
-        <div className="flex items-center gap-2">
-          <Code2 className="text-primary w-6 h-6" />
-          <span className="text-xl font-bold tracking-tight text-foreground">
-            힐끔힐끔코딩 <span className="text-primary">Peekle</span>
-          </span>
-        </div>
-        <div>
-          <Button asChild className="font-bold rounded-md px-6">
-            <Link href="/login">로그인</Link>
-          </Button>
-        </div>
-      </header>
+      <div className="sticky top-0 w-full bg-background/80 backdrop-blur-md z-50 border-b border-border">
+        <header className="flex justify-between items-center px-6 py-4 max-w-7xl mx-auto w-full">
+          <div className="flex items-center gap-2">
+            <Code2 className="text-primary w-6 h-6" />
+            <span className="text-xl font-bold tracking-tight text-foreground">
+              힐끔힐끔코딩 <span className="text-primary">Peekle</span>
+            </span>
+          </div>
+          <div>
+            <Button asChild className="font-bold rounded-md px-6">
+              <Link href="/login">로그인</Link>
+            </Button>
+          </div>
+        </header>
+      </div>
 
       <main className="flex-1 w-full">
         {/* --- 메인 히어로 섹션 --- */}
@@ -187,7 +189,21 @@ export default function Home() {
       </main>
 
       {/* --- 푸터 --- */}
-      <footer className="py-10 text-center text-[#6B7280] text-sm bg-background border-t border-border">
+      <footer className="py-10 flex flex-col items-center justify-center gap-4 text-[#6B7280] text-sm bg-background">
+        <div className="flex items-center gap-4 font-medium">
+          <span className="flex items-center gap-1">
+            Contact : taesun4767@gmail.com
+          </span>
+          <span className="text-border/50">|</span>
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLScGhVj0MPivuyxrjrWQQaEMZzWqU9p-k-A-lnJJ7Q4cWh9bVg/viewform?usp=publish-editor"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors flex items-center gap-1 underline underline-offset-4"
+          >
+            피드백 및 건의사항 남기기
+          </a>
+        </div>
         <p>© 2026 Peekle. All rights reserved.</p>
       </footer>
     </div>


### PR DESCRIPTION

## 💡 의도 / 배경
<!-- 무엇을, 왜 변경했는지 설명해주세요. 배경 및 문제를 적어주세요. -->
메인/홈 화면의 레이아웃 완성도를 높이고 사용자 피드백 동선을 만들기 위해 푸터를 추가하고 화면 정렬 구조를 개선했습니다.  
## 🛠️ 작업 내용
<!-- 주요 구현 사항, 로직 변경, 추가된 기능 등을 리스트업 해주세요. -->
- [x] 홈 화면(`HomeClient`)에 전용 푸터 추가 (Contact 이메일, 피드백 폼 링크, 저작권 문구)
- [x] 랜딩 페이지(`/app/page.tsx`) 헤더 sticky 구조 정리 및 푸터 UI 개선
- [x] 메인 레이아웃(`(main)/layout.tsx`)에 `max-w-7xl mx-auto` 적용하여 콘텐츠 정렬/가독성 개선

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: Closes #123) -->
- Closes #105
- Relates #103

## 🖼️ 스크린샷 (선택)
## 🧪 테스트 방법
<!-- 이 PR이 어떻게 테스트되었는지, 리뷰어가 어떻게 테스트해 볼 수 있는지 적어주세요. -->
- [x] 메인 홈 화면 진입 후 푸터(Contact/피드백 링크/저작권)가 정상 노출되는지 확인
- [x] 피드백 링크 클릭 시 새 탭으로 구글 폼이 열리는지 확인
- [x] 스크롤 시 랜딩 헤더 sticky 동작 및 레이아웃 정렬(max width)이 깨지지 않는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
<!-- 같이 리뷰받고 싶은 부분이나 특별히 확인해야 할 사항이 있다면 적어주세요. -->
푸터를 홈 화면(`HomeClient`)과 랜딩 페이지 양쪽에 추가했습니다.  
의도한 노출 위치/스타일 일관성과 링크 접근성 위주로 확인 부탁드립니다.