### PR TITLE
feat: 프로그래머스 관련 코드 제거

### DIFF
--- a/apps/frontend/src/domains/study/components/CCAddProblemModal.tsx
+++ b/apps/frontend/src/domains/study/components/CCAddProblemModal.tsx
@@ -32,7 +32,7 @@ interface CCAddProblemModalProps {
     problemId?: number,
     date?: string,
     customLink?: string,
-    problemType?: 'BOJ' | 'PGS' | 'CUSTOM',
+    problemType?: 'BOJ' | 'CUSTOM',
   ) => Promise<void>;
   onRemove: (problemId: number, studyProblemId?: number) => Promise<void>;
   currentProblems?: StudyProblem[]; // 현재 스터디에 추가된 문제 목록
@@ -55,7 +55,7 @@ export function CCAddProblemModal({
   // Custom Problem State
   const [customTitle, setCustomTitle] = useState('');
   const [customLink, setCustomLink] = useState('');
-  const [customType, setCustomType] = useState<'BOJ' | 'PGS' | 'CUSTOM'>('PGS');
+  const [customType, setCustomType] = useState<'BOJ' | 'CUSTOM'>('CUSTOM');
 
   const debouncedQuery = useDebounce(query, 300);
 
@@ -96,7 +96,7 @@ export function CCAddProblemModal({
       setSelectedWorkbookProblemIds(new Set());
       setCustomTitle('');
       setCustomLink('');
-      setCustomType('PGS');
+      setCustomType('CUSTOM');
     }
   }, [isOpen]);
 
@@ -198,7 +198,7 @@ export function CCAddProblemModal({
         await onAdd(customTitle, null, [], undefined, undefined, customLink, customType); // Pass customType
         setCustomTitle('');
         setCustomLink('');
-        setCustomType('PGS');
+        setCustomType('CUSTOM');
         onClose();
       } catch (error) {
         console.error(error);
@@ -582,7 +582,7 @@ export function CCAddProblemModal({
                 <input
                   value={customTitle}
                   onChange={(e) => setCustomTitle(e.target.value)}
-                  placeholder="예: 프로그래머스 - 신고 결과 받기"
+                  placeholder="예: LeetCode - Two Sum"
                   className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 />
               </div>
@@ -590,10 +590,9 @@ export function CCAddProblemModal({
                 <label className="text-sm font-medium">문제 출처</label>
                 <select
                   value={customType}
-                  onChange={(e) => setCustomType(e.target.value as 'BOJ' | 'PGS' | 'CUSTOM')}
+                  onChange={(e) => setCustomType(e.target.value as 'BOJ' | 'CUSTOM')}
                   className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring"
                 >
-                  <option value="PGS">프로그래머스</option>
                   <option value="BOJ">백준</option>
                   <option value="CUSTOM">기타</option>
                 </select>
@@ -606,11 +605,11 @@ export function CCAddProblemModal({
                 <input
                   value={customLink}
                   onChange={(e) => setCustomLink(e.target.value)}
-                  placeholder="https://school.programmers.co.kr/..."
+                  placeholder="https://www.acmicpc.net/problem/1000"
                   className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 />
                 <p className="text-xs text-muted-foreground">
-                  프로그래머스 등 외부 문제 링크를 입력해주세요.
+                  외부 문제 링크를 입력해주세요.
                 </p>
               </div>
             </div>

--- a/apps/frontend/src/domains/study/components/CCProblemCard.tsx
+++ b/apps/frontend/src/domains/study/components/CCProblemCard.tsx
@@ -97,9 +97,8 @@ export function CCProblemCard({
 
   const getBadgeText = () => {
     if (problem.type === 'BOJ') return '[BOJ]';
-    if (problem.type === 'PGS') return '[PGS]';
     if (problem.type === 'CUSTOM') return '[Custom]';
-    return '[BOJ]'; // fallback
+    return '[Custom]'; // fallback
   };
 
   return (


### PR DESCRIPTION
## 💡 의도 / 배경
스터디의 문제 검색/직접 추가 플로우에서 프로그래머스를 더 이상 사용하지 않기로 하여,
모달 UI와 표시 로직에서 프로그래머스 관련 선택지/문구를 제거했습니다.

## 🛠️ 작업 내용
- [x] `CCAddProblemModal`에서 프로그래머스(`PGS`) 선택 옵션 제거
- [x] 커스텀 문제 기본 타입을 `CUSTOM`으로 변경하고 관련 안내 문구/placeholder 정리
- [x] `CCProblemCard`에서 `[PGS]` 뱃지 분기 제거 (레거시 fallback은 `[Custom]`)

## 🔗 관련 이슈
- Closes #95 

## 🖼️ 스크린샷 (선택)
UI 텍스트/옵션 제거 중심 변경으로 생략했습니다.

## 🧪 테스트 방법
- [x] `pnpm -C apps/frontend exec tsc --noEmit --pretty false`
- [x] `.\apps\backend\gradlew.bat -p apps/backend compileJava -x test`

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)