### PR TITLE
 feat: 테스트케이스 개선

### DIFF
--- a/apps/frontend/src/domains/study/components/CCTestcaseRunnerModal.tsx
+++ b/apps/frontend/src/domains/study/components/CCTestcaseRunnerModal.tsx
@@ -47,6 +47,11 @@ interface CCTestcaseRunnerModalProps {
     onClose: () => void;
 }
 
+interface SaveTestcaseOptions {
+    showSuccessToast?: boolean;
+    showErrorToast?: boolean;
+}
+
 export function CCTestcaseRunnerModal({
     roomId,
     studyProblemId,
@@ -122,8 +127,14 @@ export function CCTestcaseRunnerModal({
         setTestcases(prev => [...prev, { id: newId, input: '', expectedOutput: '' }]);
     };
 
-    const handleSaveTestcase = async () => {
-        if (!roomId || !studyProblemId || testcases.length === 0) return;
+    const saveTestcases = useCallback(async ({
+        showSuccessToast = true,
+        showErrorToast = true
+    }: SaveTestcaseOptions = {}) => {
+        if (!roomId || !studyProblemId || testcases.length === 0) {
+            return false;
+        }
+
         try {
             const response = await apiFetch(`/api/studies/${roomId}/problems/${studyProblemId}/testcases`, {
                 method: 'POST',
@@ -131,13 +142,26 @@ export function CCTestcaseRunnerModal({
             });
 
             if (response.success) {
-                toast.success('테스트 케이스가 저장되었습니다.');
+                if (showSuccessToast) {
+                    toast.success('테스트 케이스가 저장되었습니다.');
+                }
+                return true;
             } else {
-                toast.error(response.error?.message || '테스트 케이스 저장에 실패했습니다.');
+                if (showErrorToast) {
+                    toast.error(response.error?.message || '테스트 케이스 저장에 실패했습니다.');
+                }
+                return false;
             }
-        } catch (error) {
-            toast.error('테스트 케이스 저장 중 오류가 발생했습니다.');
+        } catch {
+            if (showErrorToast) {
+                toast.error('테스트 케이스 저장 중 오류가 발생했습니다.');
+            }
+            return false;
         }
+    }, [roomId, studyProblemId, testcases]);
+
+    const handleSaveTestcase = async () => {
+        await saveTestcases();
     };
 
     const handleDeleteTestcase = (id: string) => {
@@ -155,6 +179,13 @@ export function CCTestcaseRunnerModal({
 
     const runAllTestcases = async () => {
         if (testcases.length === 0) return;
+
+        if (roomId && studyProblemId) {
+            void saveTestcases({
+                showSuccessToast: false,
+                showErrorToast: false
+            });
+        }
 
         // 1. Request current code from IDE
         let currentCode = '';


### PR DESCRIPTION
## 💡 의도 / 배경
`전체 실행` 전에 테스트케이스를 수동 저장해야 하는 불편이 있어, 실행 시점에 자동 저장 요청이 함께 발생하도록 개선했습니다.  
또한 저장 API 응답 지연으로 실행이 늦어지는 문제를 피하기 위해 저장과 실행을 분리했습니다.

## 🛠️ 작업 내용
- [x] 테스트케이스 저장 로직을 공통 함수로 정리
- [x] `전체 실행` 클릭 시 저장 요청을 비동기(fire-and-forget)로 트리거하고, 실행은 즉시 진행되도록 변경
- [x] 기존 개별 저장 버튼은 동일한 저장 로직을 재사용하도록 유지

## 🔗 관련 이슈
- Closes #116

## 🖼️ 스크린샷 (선택)
UI 변경 없음 (동작 변경)

## 🧪 테스트 방법
- [x] `pnpm -C apps/frontend type-check` 통과
- [x] 수동 테스트
  - 테스트케이스 입력/수정 후 `전체 실행` 클릭
  - 실행이 저장 응답 대기 없이 즉시 시작되는지 확인
  - 이후 재진입 또는 동기화 시 저장 반영 여부 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가? (`type-check`만 확인)

## 💬 리뷰어에게 (선택)
저장 실패 여부와 무관하게 실행이 항상 즉시 진행되는 점을 의도한 동작으로 확인 부탁드립니다.