### PR TITLE
feat: 모바일 반응형 구현

### DIFF
--- a/apps/frontend/src/app/(main)/home/HomeClient.tsx
+++ b/apps/frontend/src/app/(main)/home/HomeClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { useAuthStore } from '@/store/auth-store';
 import { LeagueProgressData, WeeklyPointSummary } from '@/domains/league/types';
 import {
@@ -10,6 +11,8 @@ import {
   AIRecommendationData,
 } from '@/domains/home/mocks/dashboardMocks';
 import { LeagueRankingData } from '@/domains/league/types';
+import { CalendarDays, Sparkles, Trophy } from 'lucide-react';
+import { LEAGUE_NAMES } from '@/components/LeagueIcon';
 
 // Dynamic Imports with loading skeletons
 const LeagueProgressChart = dynamic(() => import('@/domains/home/components/LeagueProgressChart'), {
@@ -56,11 +59,64 @@ export default function HomeClient({
 }: HomeClientProps) {
   const [selectedDate, setSelectedDate] = useState<string | null>(initialDate);
   const user = useAuthStore((state) => state.user);
+  const formattedDate = (() => {
+    const [year, month, day] = initialDate.split('-');
+    return `${year}.${month}.${day}`;
+  })();
+  const leagueLabel = LEAGUE_NAMES[initialLeagueRanking.myLeague] || '스톤';
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 bg-background text-foreground transition-colors duration-300">
+      <section className="xl:hidden mb-5 overflow-hidden rounded-2xl border border-border bg-gradient-to-br from-primary/10 via-card to-card p-4 shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">오늘도 반가워요</p>
+            <h2 className="mt-1 text-lg font-bold text-foreground">
+              {user?.nickname ? `${user.nickname}님` : 'Peekler'}의 학습 대시보드
+            </h2>
+          </div>
+          <div className="rounded-full bg-card/80 px-2.5 py-1 text-xs font-semibold text-primary shadow-sm">
+            <Sparkles className="mr-1 inline h-3.5 w-3.5" />
+            Mobile
+          </div>
+        </div>
+        <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+          <CalendarDays className="h-3.5 w-3.5" />
+          {formattedDate}
+        </div>
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          <div className="rounded-xl border border-border bg-card/90 p-2.5">
+            <p className="text-[11px] text-muted-foreground">이번 주 포인트</p>
+            <p className="mt-1 text-base font-bold text-foreground">
+              {initialWeeklyScore?.totalScore?.toLocaleString() ?? 0}점
+            </p>
+          </div>
+          <div className="rounded-xl border border-border bg-card/90 p-2.5">
+            <p className="text-[11px] text-muted-foreground">현재 리그</p>
+            <p className="mt-1 text-base font-bold text-foreground">
+              <Trophy className="mr-1 inline h-3.5 w-3.5 text-yellow-500" />
+              {leagueLabel}
+            </p>
+          </div>
+        </div>
+        <div className="mt-3 flex gap-2">
+          <Link
+            href="/study"
+            className="flex-1 rounded-lg border border-border bg-card px-3 py-2 text-center text-xs font-semibold text-foreground hover:bg-muted transition-colors"
+          >
+            스터디 바로가기
+          </Link>
+          <Link
+            href="/search"
+            className="flex-1 rounded-lg bg-primary px-3 py-2 text-center text-xs font-semibold text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            문제 검색
+          </Link>
+        </div>
+      </section>
+
       <div>
-        <div className="grid grid-cols-1 xl:grid-cols-[1fr_320px] xl:gap-10 gap-6 pt-2">
+        <div className="grid grid-cols-1 xl:grid-cols-[1fr_320px] xl:gap-10 gap-6 pt-0 xl:pt-2">
           {/* 왼쪽 메인 영역 */}
           <div className="space-y-6 order-1 xl:order-1 min-w-0">
             {/* 리그 변화 추이 */}

--- a/apps/frontend/src/app/(main)/layout.tsx
+++ b/apps/frontend/src/app/(main)/layout.tsx
@@ -1,4 +1,5 @@
 import Sidebar from '@/domains/lnb/components/Sidebar';
+import MobileBottomNav from '@/domains/lnb/components/MobileBottomNav';
 import LeagueResultModal from '@/domains/league/components/LeagueResultModal';
 import { getMyProfile } from '@/domains/profile/actions/profile';
 
@@ -14,7 +15,10 @@ export default async function MainLayout({
   return (
     <div className="flex min-h-screen">
       <Sidebar user={user} />
-      <main className="flex-1 ml-[240px] px-8 py-0 w-full max-w-7xl mx-auto">{children}</main>
+      <main className="flex-1 w-full max-w-7xl mx-auto px-4 lg:px-8 py-0 pb-20 lg:pb-0 lg:ml-[240px]">
+        {children}
+      </main>
+      <MobileBottomNav />
       <LeagueResultModal />
     </div>
   );

--- a/apps/frontend/src/app/(main)/ranking/page.tsx
+++ b/apps/frontend/src/app/(main)/ranking/page.tsx
@@ -1,12 +1,13 @@
 import 'server-only';
 
 import { CCStudyRankingBoard } from '@/domains/ranking/components/CCStudyRankingBoard';
+import { CCMainPageHeader } from '@/components/common/CCMainPageHeader';
 
 export default function RankingPage(): React.ReactNode {
   return (
     <div className="mx-auto max-w-6xl px-4 py-8">
       <div className="flex-1 flex flex-col min-w-0 transition-all duration-200">
-        <h1 className="mb-6 text-2xl font-bold text-foreground">스터디 랭킹</h1>
+        <CCMainPageHeader title="스터디 랭킹" />
         <CCStudyRankingBoard />
       </div>
     </div>

--- a/apps/frontend/src/app/(main)/search/page.tsx
+++ b/apps/frontend/src/app/(main)/search/page.tsx
@@ -8,6 +8,7 @@ import { useSearch, MIN_SEARCH_LENGTH } from '@/hooks/useSearch';
 import { Search, AlertCircle, Loader2, Filter, RotateCcw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { SearchCategory, SearchResultItem as SearchResultItemType } from '@/api/searchApi';
+import { CCMainPageHeader } from '@/components/common/CCMainPageHeader';
 
 // Import extracted modules
 import { SearchResultSection } from './components/SearchResultSection';
@@ -166,7 +167,7 @@ function SearchPageContent() {
     <SearchErrorBoundary>
       <div className="mx-auto max-w-6xl px-4 py-8">
         <div className="flex-1 flex flex-col min-w-0 transition-all duration-200">
-          <h1 className="mb-6 text-2xl font-bold text-foreground">검색</h1>
+          <CCMainPageHeader title="검색" />
 
           <div className="mb-8">
             <GlobalSearchBar

--- a/apps/frontend/src/app/(main)/workbooks/page.tsx
+++ b/apps/frontend/src/app/(main)/workbooks/page.tsx
@@ -11,10 +11,13 @@ import {
 } from '@/domains/workbook/layout';
 import { WorkbookModal } from '@/domains/workbook/components/WorkbookModal';
 import type { WorkbookProblemItem } from '@/domains/workbook/types';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { cn } from '@/lib/utils';
 
 function WorkbooksContent() {
   const searchParams = useSearchParams();
   const initialId = searchParams.get('id');
+  const isMobile = useIsMobile();
 
   const {
     tab,
@@ -73,7 +76,10 @@ function WorkbooksContent() {
     <div className="mx-auto max-w-6xl px-4 py-8">
       <div className="flex-1 flex flex-col min-w-0 transition-all duration-200">
         <div
-          className={`h-full flex flex-col transition-all duration-200 ${selectedWorkbook ? 'pr-[476px]' : ''}`}
+          className={cn(
+            'h-full flex flex-col transition-all duration-200',
+            selectedWorkbook && !isMobile && 'pr-[476px]',
+          )}
         >
           {/* 헤더 */}
           <WorkbooksHeader onCreateClick={handleCreateClick} className="mb-4" />
@@ -101,20 +107,38 @@ function WorkbooksContent() {
               hasMore={hasMore}
               isLoading={isLoading}
               onLoadMore={loadMore}
+              isMobile={isMobile}
             />
           </div>
         </div>
 
         {/* 우측 패널 - 전체 높이 */}
         {selectedWorkbook && (
-          <WorkbooksRightPanel
-            workbook={selectedWorkbook}
-            problems={selectedProblems}
-            onClose={handleClosePanel}
-            onEdit={handleEditClick}
-            onDelete={() => selectedId && deleteWorkbook(selectedId)}
-            className="fixed top-0 right-0 bottom-0"
-          />
+          <>
+            {isMobile && (
+              <button
+                type="button"
+                className="fixed inset-x-0 top-0 bottom-[calc(4rem+env(safe-area-inset-bottom))] z-[59] bg-black/35"
+                onClick={handleClosePanel}
+                aria-label="문제집 상세 닫기"
+              />
+            )}
+            <WorkbooksRightPanel
+              workbook={selectedWorkbook}
+              problems={selectedProblems}
+              onClose={handleClosePanel}
+              onEdit={isMobile ? undefined : handleEditClick}
+              onDelete={isMobile ? undefined : () => selectedId && deleteWorkbook(selectedId)}
+              allowManage={!isMobile}
+              isMobile={isMobile}
+              className={cn(
+                'fixed z-[60]',
+                isMobile
+                  ? 'inset-x-0 top-0 bottom-[calc(4rem+env(safe-area-inset-bottom))] w-auto border-l-0 border-t-0 rounded-none'
+                  : 'top-0 right-0 bottom-0',
+              )}
+            />
+          </>
         )}
 
         {/* 문제집 생성/수정 모달 */}

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,12 +1,12 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import Script from 'next/script';
-import { Toaster } from 'sonner';
 import { ThemeProvider } from '@/domains/settings/components/ThemeProvider';
 import SettingsModal from '@/domains/settings/components/SettingsModal';
 import { QueryProvider } from '@/components/providers/QueryProvider';
 import GoogleAnalyticsTracker from '@/components/common/GoogleAnalyticsTracker';
 import { ClientSessionManager } from '@/components/providers/ClientSessionManager';
+import { ResponsiveToaster } from '@/components/providers/ResponsiveToaster';
 
 export const metadata: Metadata = {
   title: 'Peekle',
@@ -103,7 +103,7 @@ export default function RootLayout({
             <GoogleAnalyticsTracker />
             <SettingsModal isGlobal={true} />
           </ThemeProvider>
-          <Toaster />
+          <ResponsiveToaster />
         </QueryProvider>
       </body>
     </html>

--- a/apps/frontend/src/components/common/CCMainPageHeader.tsx
+++ b/apps/frontend/src/components/common/CCMainPageHeader.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/lib/utils';
+
+interface CCMainPageHeaderProps {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function CCMainPageHeader({
+  title,
+  description,
+  actions,
+  className,
+}: CCMainPageHeaderProps) {
+  return (
+    <div className={cn('mb-6', className)}>
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-xl sm:text-2xl font-bold text-foreground whitespace-nowrap shrink-0">
+          {title}
+        </h1>
+        {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
+      </div>
+      {description && <p className="mt-1 text-sm text-muted-foreground">{description}</p>}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/common/CCPreJoinModal.tsx
+++ b/apps/frontend/src/components/common/CCPreJoinModal.tsx
@@ -45,6 +45,7 @@ interface CCPreJoinModalProps {
   onCancel?: () => void;
   joinLabel?: string;
   isLoading?: boolean;
+  skipExtensionCheck?: boolean;
 }
 
 export const CCPreJoinModal = ({
@@ -54,6 +55,7 @@ export const CCPreJoinModal = ({
   onCancel,
   joinLabel,
   isLoading = false,
+  skipExtensionCheck = false,
 }: CCPreJoinModalProps) => {
   const router = useRouter();
   const { user, checkAuth, isLoading: isAuthLoading } = useAuthStore();
@@ -67,6 +69,7 @@ export const CCPreJoinModal = ({
   const [extensionStatus, setExtensionStatus] = useState<ExtensionStatus>('LOADING');
   const [isLinking, setIsLinking] = useState(false);
   const [showManualModal, setShowManualModal] = useState(false);
+  const isExtensionBypassed = skipExtensionCheck;
 
   // Polling State for Installation Check
   const [isPolling, setIsPolling] = useState(false);
@@ -119,6 +122,11 @@ export const CCPreJoinModal = ({
 
   // Check Extension Logic
   useEffect(() => {
+    if (isExtensionBypassed) {
+      setExtensionStatus('LINKED');
+      return;
+    }
+
     if (isAuthLoading) {
       setExtensionStatus('LOADING');
       return;
@@ -166,7 +174,7 @@ export const CCPreJoinModal = ({
     } else {
       setExtensionStatus('NOT_INSTALLED');
     }
-  }, [user, isAuthLoading, isInstalled, extensionToken, isChecking]);
+  }, [user, isAuthLoading, isInstalled, extensionToken, isChecking, isExtensionBypassed]);
 
   const handleLinkAccount = async () => {
     setIsLinking(true);
@@ -499,6 +507,7 @@ export const CCPreJoinModal = ({
   const handleJoinClick = () => {
     onJoin(isMicOn, isCamOn);
   };
+  const showExtensionGuide = !isExtensionBypassed;
 
   return (
     <TooltipProvider>
@@ -751,7 +760,7 @@ export const CCPreJoinModal = ({
             {/* Right: Actions */}
             <div className="flex items-center gap-3 relative">
               {/* Speech Bubble (말풍선) 안내 - Priority Fixed */}
-              {extensionStatus === 'LOADING' ? null : (
+              {showExtensionGuide && (extensionStatus === 'LOADING' ? null : (
                 <>
                   {extensionStatus === 'NOT_INSTALLED' ? (
                     <div className="absolute bottom-full right-0 mb-4 animate-bounce-subtle">
@@ -781,7 +790,7 @@ export const CCPreJoinModal = ({
                     )
                   )}
                 </>
-              )}
+              ))}
 
               <Button
                 variant="ghost"
@@ -792,7 +801,18 @@ export const CCPreJoinModal = ({
               </Button>
 
               {/* Dynamic Action Button based on Extension Status */}
-              {extensionStatus === 'LOADING' ? (
+              {isExtensionBypassed ? (
+                <Button
+                  onClick={handleJoinClick}
+                  disabled={isLoading}
+                  className="bg-primary hover:bg-primary/90 text-primary-foreground font-bold h-11 px-8 rounded-lg shadow-lg shadow-primary/20 transition-all hover:scale-[1.02] active:scale-[0.98]"
+                >
+                  {isLoading ? (
+                    <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                  ) : null}
+                  {joinLabel || '미팅 시작'}
+                </Button>
+              ) : extensionStatus === 'LOADING' ? (
                 <Button
                   disabled
                   className="bg-zinc-800 text-zinc-500 h-11 px-8 rounded-lg border border-zinc-700 w-[160px]"

--- a/apps/frontend/src/components/providers/ResponsiveToaster.tsx
+++ b/apps/frontend/src/components/providers/ResponsiveToaster.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { Toaster } from 'sonner';
+import { useIsMobile } from '@/hooks/useIsMobile';
+
+export function ResponsiveToaster() {
+  const isMobile = useIsMobile();
+
+  return <Toaster position={isMobile ? 'top-right' : 'bottom-right'} />;
+}

--- a/apps/frontend/src/domains/home/components/AIRecommendation.tsx
+++ b/apps/frontend/src/domains/home/components/AIRecommendation.tsx
@@ -193,16 +193,13 @@ const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
     }
   };
 
-  const handleSolveClick = async (problemId: string, title: string) => {
+  const handleOpenProblemLink = (problemId: string) => {
     const externalId = String(problemId || '').replace(/[^0-9]/g, '');
     if (!externalId) {
-      toast.error('문제 번호를 확인할 수 없어 스터디에 추가할 수 없습니다.');
+      toast.error('문제 번호를 확인할 수 없어 이동할 수 없습니다.');
       return;
     }
-
-    setSelectedStudyProblem({ externalId, title });
-    setIsStudyModalOpen(true);
-    await loadStudies();
+    window.open(`https://www.acmicpc.net/problem/${externalId}`, '_blank', 'noopener,noreferrer');
   };
 
   const handleSelectStudy = (studyId: number) => {
@@ -353,10 +350,10 @@ const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
                 <div className="flex flex-col items-stretch gap-2">
                   <Button
                     className="h-8 w-full px-2.5 text-xs gap-1 bg-primary hover:bg-primary"
-                    onClick={() => void handleSolveClick(item.problemId, item.title)}
+                    onClick={() => handleOpenProblemLink(item.problemId)}
                   >
                     <ExternalLink className="w-3 h-3" />
-                    풀러가기
+                    문제 보러가기
                   </Button>
                   <Button
                     variant="outline"

--- a/apps/frontend/src/domains/home/components/AIRecommendation.tsx
+++ b/apps/frontend/src/domains/home/components/AIRecommendation.tsx
@@ -22,6 +22,7 @@ import { AddToWorkbookModal } from '@/domains/workbook/components/AddToWorkbookM
 import { fetchMyStudies } from '@/domains/study/api/studyApi';
 import type { StudyListContent } from '@/domains/study/types';
 import { CCCreateStudyModal } from '@/domains/study/components/CCCreateStudyModal';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 interface AIRecommendationProps {
   initialData?: AIRecommendationData[];
@@ -29,6 +30,7 @@ interface AIRecommendationProps {
 
 const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
   const router = useRouter();
+  const isMobile = useIsMobile();
   const hasInitialData = Array.isArray(initialData) && initialData.length > 0;
   const [refreshKey, setRefreshKey] = useState(0);
   const { data: fetchedData, isLoading } = useAIRecommendations({
@@ -202,6 +204,18 @@ const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
     window.open(`https://www.acmicpc.net/problem/${externalId}`, '_blank', 'noopener,noreferrer');
   };
 
+  const handleSolveClick = async (problemId: string, title: string) => {
+    const externalId = String(problemId || '').replace(/[^0-9]/g, '');
+    if (!externalId) {
+      toast.error('문제 번호를 확인할 수 없어 스터디에 추가할 수 없습니다.');
+      return;
+    }
+
+    setSelectedStudyProblem({ externalId, title });
+    setIsStudyModalOpen(true);
+    await loadStudies();
+  };
+
   const handleSelectStudy = (studyId: number) => {
     if (!selectedStudyProblem) return;
     setIsStudyModalOpen(false);
@@ -350,10 +364,14 @@ const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
                 <div className="flex flex-col items-stretch gap-2">
                   <Button
                     className="h-8 w-full px-2.5 text-xs gap-1 bg-primary hover:bg-primary"
-                    onClick={() => handleOpenProblemLink(item.problemId)}
+                    onClick={() =>
+                      isMobile
+                        ? handleOpenProblemLink(item.problemId)
+                        : void handleSolveClick(item.problemId, item.title)
+                    }
                   >
                     <ExternalLink className="w-3 h-3" />
-                    문제 보러가기
+                    {isMobile ? '문제 보러가기' : '풀러가기'}
                   </Button>
                   <Button
                     variant="outline"

--- a/apps/frontend/src/domains/league/components/CCLeagueMyStatus.tsx
+++ b/apps/frontend/src/domains/league/components/CCLeagueMyStatus.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Trophy, Clock } from 'lucide-react';
+import { Clock } from 'lucide-react';
 import LeagueIcon, { LEAGUE_NAMES } from '@/components/LeagueIcon';
 import { useLeagueRanking, useWeeklyScore } from '@/domains/home/hooks/useDashboardData';
 import LeagueRuleModal from './LeagueRuleModal';
@@ -182,11 +182,8 @@ const CCLeagueMyStatus = ({ initialLeagueRanking, initialWeeklyScore }: CCLeague
     <div className="space-y-6">
       {/* 헤더 */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 mb-2">
-          <Trophy className="w-5 h-5 text-yellow-500" />
-          <h2 className="text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-yellow-600 to-yellow-400">
-            리그
-          </h2>
+        <div className="flex items-center gap-2 mb-1">
+          <h2 className="text-2xl font-bold text-foreground">리그</h2>
           <LeagueRuleModal
             myLeague={rankingData.myLeague}
             myPercentile={rankingData.myPercentile}
@@ -195,7 +192,7 @@ const CCLeagueMyStatus = ({ initialLeagueRanking, initialWeeklyScore }: CCLeague
         </div>
       </div>
 
-      <p className="text-sm text-muted-foreground -mt-4 mb-4">
+      <p className="text-sm text-muted-foreground mb-4">
         매주 점수를 쌓아 상위 리그로 승급하세요
       </p>
 

--- a/apps/frontend/src/domains/league/components/LeagueRuleModal.tsx
+++ b/apps/frontend/src/domains/league/components/LeagueRuleModal.tsx
@@ -123,37 +123,37 @@ const LeagueRuleModal = ({
         </button>
       </DialogTrigger>
 
-      <DialogContent className="max-w-3xl p-0 overflow-hidden bg-card border-border">
-        <div className="flex h-[500px]">
-          {' '}
-          {/* 높이 줄임 */}
-          {/* [좌측] 리그 목록 */}
-          <div className="w-56 border-r border-border bg-muted/10 p-4 space-y-1 overflow-y-auto custom-scrollbar">
-            <div className="text-xs font-bold text-muted-foreground mb-3 px-2">리그 선택</div>
-            {LEAGUE_ORDER.map((league) => (
-              <button
-                key={league}
-                onClick={() => setSelectedLeague(league)}
-                className={cn(
-                  'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all',
-                  selectedLeague === league
-                    ? 'bg-primary/10 text-foreground shadow-sm ring-1 ring-border'
-                    : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
-                )}
-              >
-                <LeagueIcon league={league} size={18} />
-                <span>{LEAGUE_NAMES[league]}</span>
-              </button>
-            ))}
+      <DialogContent className="w-[95vw] max-w-3xl p-0 overflow-hidden bg-card border-border">
+        <div className="flex flex-col sm:flex-row h-[82dvh] sm:h-[500px]">
+          {/* [좌측/상단] 리그 목록 */}
+          <div className="w-full sm:w-56 border-b sm:border-b-0 sm:border-r border-border bg-muted/10 p-3 sm:p-4">
+            <div className="text-xs font-bold text-muted-foreground mb-2 px-1 sm:px-2">리그 선택</div>
+            <div className="flex sm:flex-col gap-1 sm:space-y-1 overflow-x-auto sm:overflow-y-auto custom-scrollbar">
+              {LEAGUE_ORDER.map((league) => (
+                <button
+                  key={league}
+                  onClick={() => setSelectedLeague(league)}
+                  className={cn(
+                    'shrink-0 sm:w-full flex items-center gap-2 sm:gap-3 px-2.5 sm:px-3 py-2 rounded-lg text-xs sm:text-sm font-medium transition-all',
+                    selectedLeague === league
+                      ? 'bg-primary/10 text-foreground shadow-sm ring-1 ring-border'
+                      : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+                  )}
+                >
+                  <LeagueIcon league={league} size={16} />
+                  <span>{LEAGUE_NAMES[league]}</span>
+                </button>
+              ))}
+            </div>
           </div>
           {/* [우측] 상세 내용 */}
           <div className="flex-1 flex flex-col min-w-0">
             {/* 헤더 (Compact) */}
-            <div className="flex items-center justify-between p-6 border-b border-border/50">
+            <div className="flex items-center justify-between p-4 sm:p-6 border-b border-border/50">
               <div className="flex items-center gap-3">
                 <LeagueIcon league={selectedLeague} size={36} />
                 <div>
-                  <DialogTitle className="text-xl font-bold flex items-center gap-2 text-foreground">
+                  <DialogTitle className="text-lg sm:text-xl font-bold flex items-center gap-2 text-foreground">
                     <span>{LEAGUE_NAMES[selectedLeague]}</span>
                     {displayPercentileText !== '' && (
                       <Badge className="bg-primary/10 text-primary hover:bg-primary/20 border-primary/20 text-[10px] px-1.5 py-0 h-5 font-normal shadow-none">
@@ -167,7 +167,7 @@ const LeagueRuleModal = ({
 
             {/* 탭 컨텐츠 */}
             <Tabs defaultValue="grade" className="flex-1 flex flex-col overflow-hidden">
-              <div className="px-6 pt-4">
+              <div className="px-4 sm:px-6 pt-3 sm:pt-4">
                 <TabsList className="grid w-full grid-cols-2">
                   <TabsTrigger value="grade">승급/강등 규칙</TabsTrigger>
                   <TabsTrigger value="score">점수 획득 방법</TabsTrigger>
@@ -177,11 +177,11 @@ const LeagueRuleModal = ({
               {/* 1. 승급/강등 탭 */}
               <TabsContent
                 value="grade"
-                className="flex-1 p-6 pt-4 overflow-y-auto space-y-3 custom-scrollbar"
+                className="flex-1 p-4 sm:p-6 pt-3 sm:pt-4 overflow-y-auto space-y-3 custom-scrollbar"
               >
-                <div className="flex items-center justify-between mb-2">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-2">
                   <span className="text-xs font-bold text-muted-foreground">구간 정보</span>
-                  <div className="flex flex-col items-end gap-1">
+                  <div className="flex flex-col items-start sm:items-end gap-1">
                     <span className="text-[10px] text-muted-foreground bg-muted px-2 py-1 rounded">
                       * 인원은 올림(Ceiling) 처리
                     </span>
@@ -262,7 +262,7 @@ const LeagueRuleModal = ({
               {/* 2. 점수 획득 탭 (Compact List) */}
               <TabsContent
                 value="score"
-                className="flex-1 p-6 pt-4 overflow-y-auto custom-scrollbar"
+                className="flex-1 p-4 sm:p-6 pt-3 sm:pt-4 overflow-y-auto custom-scrollbar"
               >
                 <div className="space-y-2">
                   {SCORE_RULES.map((rule, idx) => (
@@ -270,8 +270,8 @@ const LeagueRuleModal = ({
                       key={idx}
                       className={`p-3 rounded-lg border transition-colors ${rule.style}`}
                     >
-                      <div className="flex items-center justify-between mb-1">
-                        <div className="flex items-center gap-2.5">
+                      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-1">
+                        <div className="flex items-center gap-2.5 min-w-0">
                           <div className={`p-1.5 rounded-md border shadow-sm ${rule.iconStyle}`}>
                             <rule.icon className="w-4 h-4" />
                           </div>
@@ -291,8 +291,8 @@ const LeagueRuleModal = ({
                 </div>
                 {/* 팀전 규칙 카드 - Unified Theme */}
                 <div className="group p-3 rounded-lg border border-primary/20 bg-primary/5 hover:bg-primary/10 transition-colors mt-2">
-                  <div className="flex items-center justify-between mb-1">
-                    <div className="flex items-center gap-2.5">
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-1">
+                    <div className="flex items-center gap-2.5 min-w-0">
                       <div className="p-1.5 rounded-md bg-background border border-primary/20 shadow-sm">
                         <Users className="w-4 h-4 text-primary" />
                       </div>

--- a/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
+++ b/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Settings } from 'lucide-react';
+import { NAV_ITEMS } from './Sidebar';
+import { cn } from '@/lib/utils';
+import { useSettingsStore } from '@/domains/settings/hooks/useSettingsStore';
+
+const MOBILE_ITEMS = NAV_ITEMS.filter((item) =>
+  ['/home', '/study', '/workbooks', '/ranking', '/league', '/search'].includes(item.href),
+);
+
+export default function MobileBottomNav() {
+  const pathname = usePathname();
+  const openModal = useSettingsStore((state) => state.openModal);
+
+  const isItemActive = (href: string) => {
+    if (href === '/home') return pathname === '/home';
+    return pathname.startsWith(href);
+  };
+
+  return (
+    <div className="lg:hidden fixed inset-x-0 bottom-0 z-50 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80">
+      <nav className="mx-auto flex max-w-7xl items-center gap-1 overflow-x-auto px-2 py-2 no-scrollbar">
+        {MOBILE_ITEMS.map((item) => {
+          const Icon = item.icon;
+          const active = isItemActive(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex min-w-14 flex-1 shrink-0 flex-col items-center justify-center rounded-lg py-1 text-[10px] font-medium transition-colors',
+                active ? 'bg-primary/10 text-primary' : 'text-muted-foreground',
+              )}
+            >
+              <Icon className="mb-0.5 h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+        <button
+          type="button"
+          onClick={() => openModal()}
+          className="flex min-w-14 flex-1 shrink-0 flex-col items-center justify-center rounded-lg py-1 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-muted"
+        >
+          <Settings className="mb-0.5 h-4 w-4" />
+          설정
+        </button>
+      </nav>
+    </div>
+  );
+}

--- a/apps/frontend/src/domains/lnb/components/Sidebar.tsx
+++ b/apps/frontend/src/domains/lnb/components/Sidebar.tsx
@@ -12,18 +12,18 @@ interface SidebarProps {
   user: UserProfile;
 }
 
+export const NAV_ITEMS = [
+  { icon: Home, label: '메인', href: '/home' },
+  { icon: Users, label: '스터디 방', href: '/study' },
+  { icon: Gamepad2, label: '게임 방', href: '/game' },
+  { icon: BookOpen, label: '문제집', href: '/workbooks' },
+  { icon: Trophy, label: '랭킹', href: '/ranking' },
+  { icon: Medal, label: '리그', href: '/league' },
+  { icon: Search, label: '검색', href: '/search' },
+] as const;
+
 const Sidebar = ({ user }: SidebarProps) => {
   const pathname = usePathname();
-
-  const navItems = [
-    { icon: Home, label: '메인', href: '/home' },
-    { icon: Users, label: '스터디 방', href: '/study' },
-    { icon: Gamepad2, label: '게임 방', href: '/game' },
-    { icon: BookOpen, label: '문제집', href: '/workbooks' },
-    { icon: Trophy, label: '랭킹', href: '/ranking' },
-    { icon: Medal, label: '리그', href: '/league' },
-    { icon: Search, label: '검색', href: '/search' },
-  ];
 
   const isItemActive = (href: string) => {
     if (href === '/home' && pathname === '/home') return true;
@@ -34,7 +34,7 @@ const Sidebar = ({ user }: SidebarProps) => {
   const { openModal, isOpen } = useSettingsStore();
 
   return (
-    <aside className="w-[240px] h-screen bg-card border-r border-border flex flex-col fixed left-0 top-0 z-50 overflow-y-auto font-sans transition-colors duration-300">
+    <aside className="hidden lg:flex w-[240px] h-screen bg-card border-r border-border flex-col fixed left-0 top-0 z-50 overflow-y-auto font-sans transition-colors duration-300">
       {/* User Logic Section */}
       <div className="mt-6">
         <UserProfileSection initialUser={user} />
@@ -42,7 +42,7 @@ const Sidebar = ({ user }: SidebarProps) => {
 
       {/* Navigation Section */}
       <nav className="flex-1 px-2 space-y-1 mt-2">
-        {navItems.map((item) => (
+        {NAV_ITEMS.map((item) => (
           <SidebarItem
             key={item.href}
             icon={item.icon}

--- a/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { type ReactNode } from 'react';
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { ChevronUp, ChevronDown, Lock, Plus } from 'lucide-react';
 import { toast } from 'sonner';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 interface CCCenterPanelProps {
   ideContent?: ReactNode;
@@ -53,6 +54,8 @@ export function CCCenterPanel({
   onSettingsClick,
   className,
 }: CCCenterPanelProps) {
+  const isMobile = useIsMobile();
+
   const getTemplateCode = (languageValue: string): string => {
     const normalized = languageValue.toLowerCase();
 
@@ -132,6 +135,8 @@ print("Hello World!")`;
     viewMode === 'SPLIT_REALTIME' ? viewingUser : null,
   );
   const roomId = useRoomStore((state) => state.roomId);
+  const mobileTab = useRoomStore((state) => state.mobileTab);
+  const setMobileTab = useRoomStore((state) => state.setMobileTab);
   const currentUserId = useRoomStore((state) => state.currentUserId);
   const selectedStudyProblemId = useRoomStore((state) => state.selectedStudyProblemId);
   const selectedProblemId = useRoomStore((state) => state.selectedProblemId);
@@ -140,6 +145,7 @@ print("Hello World!")`;
   const isWhiteboardOverlayOpen = useRoomStore((state) => state.isWhiteboardOverlayOpen);
   const socket = useSocket(roomId, currentUserId);
   const setRightPanelActiveTab = useRoomStore((state) => state.setRightPanelActiveTab);
+  const setIsLeftPanelFolded = useRoomStore((state) => state.setIsLeftPanelFolded);
   const setIsRightPanelFolded = useRoomStore((state) => state.setIsRightPanelFolded);
   const targetSubmissionId = targetSubmission?.submissionId;
 
@@ -200,6 +206,22 @@ print("Hello World!")`;
     setFontSize(newSize);
     localStorage.setItem('ide-font-size', newSize.toString());
   };
+
+  useEffect(() => {
+    if (isMobile) {
+      setVideoGridHeight(420);
+    } else {
+      setVideoGridHeight(240);
+      setMobileTab('video');
+    }
+  }, [isMobile, setMobileTab]);
+
+  // Auto-switch to code view on mobile when opening a code block
+  useEffect(() => {
+    if (isMobile && (viewMode === 'SPLIT_REALTIME' || viewMode === 'SPLIT_SAVED')) {
+      setMobileTab('code');
+    }
+  }, [isMobile, viewMode, setMobileTab]);
 
   const formatCommentDate = useCallback((value?: string): string => {
     if (!value) return '';
@@ -1299,6 +1321,11 @@ print("Hello World!")`;
 
   // Show right panel when viewing other's code OR whiteboard is open
   const showRightPanel = isViewingOther || isWhiteboardVisible;
+  const showVideoSection = !isMobile || mobileTab === 'video';
+  const showProblemSection = !isMobile || mobileTab === 'code';
+  const isVideoGridCollapsed = !isMobile && isVideoGridFolded;
+  const showMyIdePanel = !isMobile || !showRightPanel;
+  const showViewerPanel = showRightPanel;
   const myProblemLabel = selectedProblemTitle
     ? `${selectedProblemExternalId ? `[${selectedProblemExternalId}] ` : ''}${selectedProblemTitle}`
     : '문제 선택 중';
@@ -1326,6 +1353,64 @@ print("Hello World!")`;
           : '';
         return `${externalPrefix}${title}${languageSuffix}`;
       })();
+  const normalizedProblemExternalId = String(selectedProblemExternalId ?? '').replace(/[^0-9]/g, '');
+  const canSplitOpenProblem =
+    !isMobile &&
+    !isViewingOther &&
+    normalizedProblemExternalId.length > 0 &&
+    Number(normalizedProblemExternalId) > 0;
+
+  const handleOpenProblemSplit = useCallback(() => {
+    const externalId = Number(normalizedProblemExternalId);
+    if (!Number.isFinite(externalId) || externalId <= 0) {
+      toast.error('분할로 열 수 있는 문제 링크가 없습니다.');
+      return;
+    }
+
+    const screenAvailWidth = window.screen.availWidth;
+    const screenAvailHeight = window.screen.availHeight;
+    const halfWidth = Math.floor(screenAvailWidth / 2);
+    const screenLeft = (window.screen as any).availLeft || 0;
+    const screenTop = (window.screen as any).availTop || 0;
+
+    setIsLeftPanelFolded(true);
+    setIsRightPanelFolded(true);
+
+    const studyProblemIdValue = Number(selectedStudyProblemId);
+    const studyIdValue = Number(roomId);
+
+    window.postMessage(
+      {
+        type: 'PEEKLE_WINDOW_SPLIT',
+        payload: {
+          url: `https://www.acmicpc.net/problem/${externalId}`,
+          leftWindow: { left: screenLeft, top: screenTop, width: halfWidth, height: screenAvailHeight },
+          rightWindow: {
+            left: screenLeft + halfWidth,
+            top: screenTop,
+            width: halfWidth,
+            height: screenAvailHeight,
+          },
+          context: {
+            sourceType: 'STUDY',
+            externalId,
+            studyProblemId:
+              Number.isFinite(studyProblemIdValue) && studyProblemIdValue > 0
+                ? studyProblemIdValue
+                : undefined,
+            studyId: Number.isFinite(studyIdValue) && studyIdValue > 0 ? studyIdValue : undefined,
+          },
+        },
+      },
+      '*',
+    );
+  }, [
+    normalizedProblemExternalId,
+    selectedStudyProblemId,
+    roomId,
+    setIsLeftPanelFolded,
+    setIsRightPanelFolded,
+  ]);
 
   // Track my latest code to respond to pull requests
   const myLatestCodeRef = useRef<string>('');
@@ -1677,43 +1762,61 @@ print("Hello World!")`;
 
   return (
     <div className={cn('flex h-full flex-col min-w-0 min-h-0', className)}>
-      {/* Video Grid Header */}
-      <div className="flex bg-card items-center justify-between border-b border-border px-4 h-14 shrink-0">
-        <span className="text-sm font-medium">화상 타일</span>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6"
-          onClick={toggleVideoGrid}
-          title={isVideoGridFolded ? '화상 타일 펼치기' : '화상 타일 접기'}
-        >
-          {isVideoGridFolded ? (
-            <ChevronDown className="h-4 w-4" />
-          ) : (
-            <ChevronUp className="h-4 w-4" />
-          )}
-        </Button>
-      </div>
 
-      {/* Video Grid */}
-      {!isVideoGridFolded && (
+      {showVideoSection && (
         <>
-          <div style={{ height: videoGridHeight }} className="shrink-0 relative transition-none">
-            <VideoGrid onWhiteboardClick={onWhiteboardClick} className="h-full" />
+          {/* Video Grid Header */}
+          <div className="flex bg-card items-center justify-between border-b border-border px-4 h-14 shrink-0">
+            <span className="text-sm font-medium">화상 타일</span>
+            {!isMobile && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={toggleVideoGrid}
+                title={isVideoGridFolded ? '화상 타일 펼치기' : '화상 타일 접기'}
+              >
+                {isVideoGridFolded ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronUp className="h-4 w-4" />
+                )}
+              </Button>
+            )}
           </div>
-          {/* Resize Handle */}
-          <div
-            className="h-1 cursor-row-resize bg-border/50 hover:bg-primary/50 active:bg-primary transition-colors shrink-0 z-10"
-            onMouseDown={startResizingVideo}
-          />
+
+          {/* Video Grid */}
+          {!isVideoGridCollapsed && (
+            <>
+              <div
+                style={
+                  isMobile && mobileTab === 'video' ? undefined : { height: videoGridHeight }
+                }
+                className={cn(
+                  'relative transition-none',
+                  isMobile && mobileTab === 'video' ? 'flex-1 min-h-0' : 'shrink-0',
+                )}
+              >
+                <VideoGrid onWhiteboardClick={onWhiteboardClick} className="h-full" />
+              </div>
+              {/* Resize Handle */}
+              {!isMobile && (
+                <div
+                  className="h-1 cursor-row-resize bg-border/50 hover:bg-primary/50 active:bg-primary transition-colors shrink-0 z-10"
+                  onMouseDown={startResizingVideo}
+                />
+              )}
+            </>
+          )}
         </>
       )}
 
       {/* IDE Area */}
-      <div
-        className="relative flex min-h-0 flex-1 flex-col min-w-0 bg-background"
-        data-tour="ide-panel"
-      >
+      {showProblemSection && (
+        <div
+          className="relative flex min-h-0 flex-1 flex-col min-w-0 bg-background"
+          data-tour="ide-panel"
+        >
         {/* Header Row: Always show toolbar for Left IDE.  
             If isViewingOther, the toolbar layout adapts to show View Mode Banner on left and Tools on right. */}
         <div className="flex h-14 shrink-0 border-b border-border bg-card">
@@ -1810,7 +1913,7 @@ print("Hello World!")`;
                 void handleSubmit();
               }}
               // New Props for Execute
-              showExecute={!isViewingOther}
+              showExecute={!isViewingOther && !isMobile}
               isExecuting={isExecuting}
               onToggleConsole={() => setIsConsoleOpen((prev) => !prev)}
               onExecute={() => {
@@ -1819,82 +1922,103 @@ print("Hello World!")`;
                 window.dispatchEvent(new CustomEvent('study-ide-execute-trigger'));
               }}
               // Toggles
-              showSubmit={!isViewingOther}
-              showChatRef={true}
-              showThemeToggle={true}
+              showSubmit={!isViewingOther && !isMobile}
+              showChatRef={!isMobile}
+              showThemeToggle={!isMobile}
+              showProblemSplit={canSplitOpenProblem}
+              onOpenProblemSplit={handleOpenProblemSplit}
             />
           </div>
         </div>
+
+
 
         {/* Editor Body Row */}
         <div className="flex min-h-0 flex-1 min-w-0 relative flex-col">
           <div className="flex min-h-0 flex-1 min-w-0 relative">
             {/* Left IDE Panel (My Code) */}
-            <div
-              className={cn(
-                'flex flex-1 min-w-0 flex-col',
-                showRightPanel && 'border-r border-border',
-              )}
-            >
-              <div className="h-8 shrink-0 border-b border-border bg-muted/35 px-3 text-xs text-muted-foreground">
-                <div className="flex h-full items-center gap-2">
-                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                  <span className="shrink-0">내 문제</span>
-                  <span className="truncate text-foreground/90" title={myProblemLabel}>
-                    {myProblemLabel}
-                  </span>
+            {showMyIdePanel && (
+              <div
+                className={cn(
+                  'flex flex-1 min-w-0 flex-col',
+                  !isMobile && showRightPanel && 'border-r border-border',
+                )}
+              >
+                <div className="h-8 shrink-0 border-b border-border bg-muted/35 px-3 text-xs text-muted-foreground">
+                  <div className="flex h-full items-center gap-2">
+                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                    <span className="shrink-0">내 문제</span>
+                    <span className="truncate text-foreground/90" title={myProblemLabel}>
+                      {myProblemLabel}
+                    </span>
+                  </div>
+                </div>
+                <div className="relative min-h-0 flex-1">
+                  {ideContent ?? (
+                    <IDEPanel
+                      ref={leftPanelRef}
+                      editorId="my-editor"
+                      language={language}
+                      onLanguageChange={handleLanguageChange}
+                      theme={theme}
+                      fontSize={fontSize}
+                      hideToolbar // Pass this so it doesn't render double toolbar
+                      onFontSizeChange={handleFontSizeChange}
+                      onCodeChange={handleCodeChange}
+                      restoredCode={restoredCode}
+                      restoreVersion={restoreVersion}
+                    />
+                  )}
+
+                  {isHydratingDraft && !!selectedStudyProblemId && (
+                    <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/70 backdrop-blur-sm">
+                      <p className="text-sm font-medium text-muted-foreground">Loading problem...</p>
+                    </div>
+                  )}
+
+                  {/* [New] Overlay if no problem is selected and not viewing other */}
+                  {!selectedProblemTitle && !isViewingOther && !isWhiteboardVisible && (
+                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-background/50 backdrop-blur-sm">
+                      <Lock className="h-8 w-8 text-muted-foreground mb-2" />
+                      <p className="text-sm font-medium text-muted-foreground">
+                        좌측 목록에서 문제를 선택해주세요
+                      </p>
+                    </div>
+                  )}
                 </div>
               </div>
-              <div className="relative min-h-0 flex-1">
-                {ideContent ?? (
-                  <IDEPanel
-                    ref={leftPanelRef}
-                    editorId="my-editor"
-                    language={language}
-                    onLanguageChange={handleLanguageChange}
-                    theme={theme}
-                    fontSize={fontSize}
-                    hideToolbar // Pass this so it doesn't render double toolbar
-                    onFontSizeChange={handleFontSizeChange}
-                    onCodeChange={handleCodeChange}
-                    restoredCode={restoredCode}
-                    restoreVersion={restoreVersion}
-                  />
-                )}
-
-                {isHydratingDraft && !!selectedStudyProblemId && (
-                  <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/70 backdrop-blur-sm">
-                    <p className="text-sm font-medium text-muted-foreground">Loading problem...</p>
-                  </div>
-                )}
-
-                {/* [New] Overlay if no problem is selected and not viewing other */}
-                {!selectedProblemTitle && !isViewingOther && !isWhiteboardVisible && (
-                  <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-background/50 backdrop-blur-sm">
-                    <Lock className="h-8 w-8 text-muted-foreground mb-2" />
-                    <p className="text-sm font-medium text-muted-foreground">
-                      좌측 목록에서 문제를 선택해주세요
-                    </p>
-                  </div>
-                )}
-              </div>
-            </div>
+            )}
             {/* Right Panel: Whiteboard OR Other's Code */}
-            {showRightPanel && (
+            {showViewerPanel && (
               <div className="flex min-w-0 flex-1 flex-col">
                 {isWhiteboardVisible ? (
                   <WhiteboardPanel className="border-l-2 border-rose-400" />
                 ) : (
                   <>
                     <div className="h-8 shrink-0 border-b border-border bg-muted/35 px-3 text-xs text-muted-foreground">
-                      <div className="flex h-full items-center gap-2">
-                        <span className="inline-block h-1.5 w-1.5 rounded-full bg-pink-500" />
-                        <span className="shrink-0">
-                          {viewMode === 'SPLIT_SAVED' ? savedCodePanelLabel : '상대 문제'}
-                        </span>
-                        <span className="truncate text-foreground/90" title={otherProblemLabel}>
-                          {otherProblemLabel}
-                        </span>
+                      <div className="flex h-full items-center justify-between gap-2">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <span className="inline-block h-1.5 w-1.5 rounded-full bg-pink-500" />
+                          <span className="shrink-0">
+                            {viewMode === 'SPLIT_SAVED' ? savedCodePanelLabel : '상대 문제'}
+                          </span>
+                          <span className="truncate text-foreground/90" title={otherProblemLabel}>
+                            {otherProblemLabel}
+                          </span>
+                        </div>
+                        {isMobile && isViewingOther && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-6 shrink-0 px-2 text-[11px]"
+                            onClick={() => {
+                              resetToOnlyMine();
+                              setMobileTab('code');
+                            }}
+                          >
+                            내 코드로 돌아가기
+                          </Button>
+                        )}
                       </div>
                     </div>
                     {viewMode === 'SPLIT_SAVED' ? (
@@ -1966,7 +2090,7 @@ print("Hello World!")`;
           </div>
 
           {/* Console Overlay Drawer */}
-          {!isViewingOther && (
+          {!isViewingOther && !isMobile && (
             <div
               style={{ height: isConsoleOpen ? consoleHeight : 0, opacity: isConsoleOpen ? 1 : 0 }}
               className={cn(
@@ -1991,6 +2115,7 @@ print("Hello World!")`;
           )}
         </div>
       </div>
+      )}
 
       {/* Control Bar */}
       <ControlBar

--- a/apps/frontend/src/domains/study/components/CCIDEPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCIDEPanel.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
 import Editor, { OnMount } from '@monaco-editor/react';
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 import { CCIDEToolbar as IDEToolbar } from '@/domains/study/components/CCIDEToolbar';
 import { cn } from '@/lib/utils';
 import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 // ----------------------------------------------------------------------
 // 타입 및 상수 정의
@@ -102,6 +103,7 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
     const [internalLanguage, setInternalLanguage] = useState<string>('python');
     const [internalTheme, setInternalTheme] = useState<'light' | 'vs-dark'>('light');
     const params = useParams();
+    const isMobile = useIsMobile(768);
     const studyId = params.id as string;
     const language = propLanguage || internalLanguage;
     const theme = propTheme || internalTheme;
@@ -638,8 +640,10 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
               fontFamily: "'D2Coding', 'Fira Code', Consolas, monospace",
               fontSize: fontSize,
               minimap: { enabled: false },
-              glyphMargin: true,
-              lineDecorationsWidth: 22,
+              glyphMargin: !isMobile,
+              lineDecorationsWidth: isMobile ? 8 : 22,
+              lineNumbersMinChars: isMobile ? 3 : 5,
+              folding: !isMobile,
               wordWrap: 'on',
               automaticLayout: true,
               scrollBeyondLastLine: false,

--- a/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
+++ b/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Copy, Moon, Sun, MessageSquare, Send, Eye, Archive, FileText, Minus, Plus, Play, TerminalSquare, Share2 } from 'lucide-react';
+import { Copy, Moon, Sun, MessageSquare, Send, Eye, Archive, FileText, Minus, Plus, Play, TerminalSquare, Share2, Columns2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import {
   type ViewMode,
   type Participant,
@@ -33,7 +34,9 @@ export interface CCIDEToolbarProps {
   onSubmit?: () => void;
   onExecute?: () => void;
   onToggleConsole?: () => void;
+  onOpenProblemSplit?: () => void;
   disabled?: boolean;
+  showProblemSplit?: boolean;
 
   // View Mode Props
   viewingUser?: Participant | null;
@@ -61,16 +64,21 @@ export function CCIDEToolbar({
   onSubmit,
   onExecute,
   onToggleConsole,
+  onOpenProblemSplit,
   viewingUser,
   viewMode,
   targetSubmission,
   onResetView,
   disabled = false,
+  showProblemSplit = false,
   problemExternalId,
 }: CCIDEToolbarProps) {
+  const isMobile = useIsMobile();
   const isRealtime = viewMode === 'SPLIT_REALTIME';
   const isSaved = viewMode === 'SPLIT_SAVED';
   const isViewingOther = viewMode !== 'ONLY_MINE';
+  const shouldShowLanguageSelect = !isViewingOther;
+  const [isSplitSizedWindow, setIsSplitSizedWindow] = useState(false);
 
   // Use local state for the input field to allow users to clear it while typing
   const [inputValue, setInputValue] = useState<string>(fontSize.toString());
@@ -79,6 +87,28 @@ export function CCIDEToolbar({
   useEffect(() => {
     setInputValue(fontSize.toString());
   }, [fontSize]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const updateWindowSplitState = () => {
+      const availWidth = window.screen?.availWidth || window.innerWidth;
+      const currentWidth = window.outerWidth || window.innerWidth;
+      const widthRatio = currentWidth / Math.max(availWidth, 1);
+
+      // Split windows are usually near half width; keep tolerance for OS/browser chrome.
+      setIsSplitSizedWindow(widthRatio <= 0.67);
+    };
+
+    updateWindowSplitState();
+    window.addEventListener('resize', updateWindowSplitState);
+    return () => window.removeEventListener('resize', updateWindowSplitState);
+  }, []);
+
+  const problemSplitButtonLabel = isSplitSizedWindow ? '좌측 문제 열기' : '분할해서 열기';
+  const problemSplitTooltipLabel = isSplitSizedWindow
+    ? '좌측 창에 현재 문제 열기'
+    : '현재 문제를 분할 화면으로 열기';
 
   const handleDecreaseFont = () => {
     if (onFontSizeChange && fontSize > 5) {
@@ -126,25 +156,27 @@ export function CCIDEToolbar({
     <TooltipProvider>
       <div className="flex bg-card items-center justify-between border-b border-border px-4 h-14 shrink-0 w-full">
         <div className="flex items-center gap-3 min-w-0">
-          {/* Language Select - Always Visible */}
-          <select
-            value={language}
-            onChange={(e) => onLanguageChange?.(e.target.value)}
-            disabled={disabled}
-            className={cn(
-              'h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring text-strong font-medium',
-              disabled && 'opacity-50 cursor-not-allowed',
-            )}
-          >
-            {LANGUAGES.map((lang) => (
-              <option key={lang.value} value={lang.value}>
-                {lang.label}
-              </option>
-            ))}
-          </select>
+          {/* Language Select - Show on desktop and mobile(my code only) */}
+          {shouldShowLanguageSelect && (
+            <select
+              value={language}
+              onChange={(e) => onLanguageChange?.(e.target.value)}
+              disabled={disabled}
+              className={cn(
+                'h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring text-strong font-medium',
+                disabled && 'opacity-50 cursor-not-allowed',
+              )}
+            >
+              {LANGUAGES.map((lang) => (
+                <option key={lang.value} value={lang.value}>
+                  {lang.label}
+                </option>
+              ))}
+            </select>
+          )}
 
           {/* View Mode Banner - Conditional (Next to Select) */}
-          {isViewingOther && (
+          {isViewingOther && !isMobile && (
             <div
               className={cn(
                 'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-semibold animate-in fade-in slide-in-from-left-2 duration-300 shadow-sm border',
@@ -286,6 +318,25 @@ export function CCIDEToolbar({
           {/* Standard Tools (Hidden when Viewing Other) */}
           {!isViewingOther && (
             <>
+              {/* Desktop-only Split Open */}
+              {showProblemSplit && !isMobile && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={onOpenProblemSplit}
+                      disabled={disabled}
+                      className="ml-1 gap-1.5 focus:ring-0 transition-all active:scale-95 px-3 h-10 text-muted-foreground hover:text-foreground"
+                    >
+                      <Columns2 className="h-[18px] w-[18px]" />
+                      <span className="font-semibold text-sm">{problemSplitButtonLabel}</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{problemSplitTooltipLabel}</TooltipContent>
+                </Tooltip>
+              )}
+
               {/* Console Toggle */}
               {showExecute && (
                 <Tooltip>
@@ -345,7 +396,7 @@ export function CCIDEToolbar({
           )}
 
           {/* View Only Mine Button (Visible only when Viewing Other) */}
-          {isViewingOther && (
+          {isViewingOther && !isMobile && (
             <Button
               size="sm"
               variant="secondary"

--- a/apps/frontend/src/domains/study/components/CCProblemCard.tsx
+++ b/apps/frontend/src/domains/study/components/CCProblemCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { cn, getBojTierName, getBojTierColorClass } from '@/lib/utils';
-import { ExternalLink, Trash2, Lightbulb, FileText, Users } from 'lucide-react';
+import { Trash2, Lightbulb, FileText, Users } from 'lucide-react';
 import { StudyProblem as Problem } from '@/domains/study/types';
 import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
 import { Button } from '@/components/ui/button';
@@ -35,10 +35,7 @@ export function CCProblemCard({
   const [showHint, setShowHint] = useState(false);
   const [isTestcaseModalOpen, setIsTestcaseModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const setIsLeftPanelFolded = useRoomStore((state) => state.setIsLeftPanelFolded);
-  const setIsRightPanelFolded = useRoomStore((state) => state.setIsRightPanelFolded);
   const myRole = useRoomStore((state) => state.myRole);
-  const roomId = useRoomStore((state) => state.roomId);
 
   const isCustom = problem.type === 'CUSTOM' || (!problem.problemId && !problem.externalId);
   const problemUrl =
@@ -51,48 +48,9 @@ export function CCProblemCard({
   const displayTags = problem.tags?.slice(0, 2) || [];
   const remainingTagsCount = (problem.tags?.length || 0) - 2;
 
-  const handleOpenExternal = () => {
+  const handleOpenProblemSite = () => {
     if (!problemUrl) return;
-
-    const screenAvailWidth = window.screen.availWidth;
-    const screenAvailHeight = window.screen.availHeight;
-    const halfWidth = Math.floor(screenAvailWidth / 2);
-    const screenLeft = (window.screen as any).availLeft || 0;
-    const screenTop = (window.screen as any).availTop || 0;
-
-    setIsLeftPanelFolded(true);
-    setIsRightPanelFolded(true);
-
-    const contextExternalId = Number(
-      String(problem.externalId ?? problem.problemId ?? '').replace(/[^0-9]/g, ''),
-    );
-    const contextStudyProblemId = Number(
-      String((problem as any).studyProblemId ?? (problem as any).id ?? '').replace(/[^0-9]/g, ''),
-    );
-    const contextStudyId = Number(String(roomId ?? '').replace(/[^0-9]/g, ''));
-
-    const studyContext =
-      Number.isFinite(contextExternalId) && contextExternalId > 0
-        ? {
-          sourceType: 'STUDY',
-          externalId: contextExternalId,
-          studyProblemId:
-            Number.isFinite(contextStudyProblemId) && contextStudyProblemId > 0
-              ? contextStudyProblemId
-              : undefined,
-          studyId: Number.isFinite(contextStudyId) && contextStudyId > 0 ? contextStudyId : undefined,
-        }
-        : undefined;
-
-    window.postMessage({
-      type: 'PEEKLE_WINDOW_SPLIT',
-      payload: {
-        url: problemUrl,
-        leftWindow: { left: screenLeft, top: screenTop, width: halfWidth, height: screenAvailHeight },
-        rightWindow: { left: screenLeft + halfWidth, top: screenTop, width: halfWidth, height: screenAvailHeight },
-        context: studyContext,
-      }
-    }, '*');
+    window.open(problemUrl, '_blank', 'noopener,noreferrer');
   };
 
   const getBadgeText = () => {
@@ -125,19 +83,20 @@ export function CCProblemCard({
           <span className="text-[10px] text-muted-foreground shrink-0 font-medium">
             {getBadgeText()}
           </span>
-          <span className="text-sm font-medium truncate">{displayTitle}</span>
-          {problemUrl && (
+          {problemUrl ? (
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
-                onSelect?.();
-                handleOpenExternal();
+                handleOpenProblemSite();
               }}
-              className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
-              title="바로가기 새 탭"
+              className="truncate text-sm font-semibold text-primary underline-offset-4 hover:underline hover:text-primary/80 transition-colors text-left"
+              title="문제 사이트 열기"
             >
-              <ExternalLink className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+              {displayTitle}
             </button>
+          ) : (
+            <span className="text-sm font-medium truncate">{displayTitle}</span>
           )}
         </div>
 

--- a/apps/frontend/src/domains/study/components/CCProblemListPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCProblemListPanel.tsx
@@ -39,6 +39,7 @@ export interface CCProblemListPanelProps {
   onFetchSubmissions?: (studyProblemId: number) => void;
   historyDates?: Date[];
   showFoldButton?: boolean;
+  allowProblemManage?: boolean;
 }
 
 export function CCProblemListPanel({
@@ -56,6 +57,7 @@ export function CCProblemListPanel({
   onFetchSubmissions,
   historyDates,
   showFoldButton = true,
+  allowProblemManage = true,
 }: CCProblemListPanelProps) {
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [submissionModalOpen, setSubmissionModalOpen] = useState(false);
@@ -240,22 +242,24 @@ export function CCProblemListPanel({
         <div className="flex items-center gap-2">
 
 
-          <Button
-            onClick={() => setAddProblemModalOpen(true)}
-            className={cn(
-              "bg-primary hover:bg-primary/90 text-white h-8 text-xs shadow-sm",
-              isCompact ? "px-2" : "px-3"
-            )}
-            title={isCompact ? "문제 추가" : undefined}
-          >
-            <Plus className={cn("h-3 w-3", !isCompact && "mr-1")} />
-            {!isCompact && "문제 추가"}
-          </Button>
+          {allowProblemManage && (
+            <Button
+              onClick={() => setAddProblemModalOpen(true)}
+              className={cn(
+                'bg-primary hover:bg-primary/90 text-white h-8 text-xs shadow-sm',
+                isCompact ? 'px-2' : 'px-3',
+              )}
+              title={isCompact ? '문제 추가' : undefined}
+            >
+              <Plus className={cn('h-3 w-3', !isCompact && 'mr-1')} />
+              {!isCompact && '문제 추가'}
+            </Button>
+          )}
           {showFoldButton && (
             <Button
               variant="ghost"
               size="sm"
-              className="text-muted-foreground hover:text-foreground p-0 h-8 gap-4"
+              className="hidden md:inline-flex text-muted-foreground hover:text-foreground p-0 h-8 gap-4"
               onClick={onToggleFold}
             >
               <ChevronLeft className="h-4 w-4" />
@@ -323,13 +327,15 @@ export function CCProblemListPanel({
         onViewCode={handleViewCode}
       />
 
-      <CCAddProblemModal
-        isOpen={addProblemModalOpen}
-        onClose={() => setAddProblemModalOpen(false)}
-        onAdd={handleAddProblem}
-        onRemove={handleRemoveProblem}
-        currentProblems={problems}
-      />
+      {allowProblemManage && (
+        <CCAddProblemModal
+          isOpen={addProblemModalOpen}
+          onClose={() => setAddProblemModalOpen(false)}
+          onAdd={handleAddProblem}
+          onRemove={handleRemoveProblem}
+          currentProblems={problems}
+        />
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/domains/study/components/CCStudyHeader.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyHeader.tsx
@@ -199,21 +199,21 @@ export function CCStudyHeader({
   const totalSteps = guideSteps.length || 1;
 
   return (
-    <div className={cn('flex h-14 items-center justify-between px-4', className)}>
+    <div className={cn('flex h-14 items-center justify-between px-3 lg:px-4', className)}>
       {/* Left Section */}
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2 min-w-0">
         <Button variant="ghost" size="icon" onClick={onBack} aria-label="뒤로 가기">
           <ArrowLeft className="h-5 w-5" />
         </Button>
 
-        <h1 className="text-lg font-semibold">{roomTitle}</h1>
+        <h1 className="text-base lg:text-lg font-semibold truncate">{roomTitle}</h1>
 
-        <div className="mx-2 h-6 w-px bg-border" />
+        <div className="mx-2 h-6 w-px bg-border hidden lg:block" />
 
         <Button
           variant="ghost"
           size="sm"
-          className="gap-2 text-muted-foreground hover:text-foreground"
+          className="hidden lg:inline-flex gap-2 text-muted-foreground hover:text-foreground"
           onClick={() => setIsGuideOpen(true)}
           data-tour="manual-button"
         >
@@ -232,7 +232,7 @@ export function CCStudyHeader({
       )}
 
       {/* Right Section */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1 lg:gap-2">
         <Button
           variant="outline"
           size="sm"
@@ -241,7 +241,7 @@ export function CCStudyHeader({
           data-tour="invite-button"
         >
           <Copy className="h-4 w-4" />
-          초대하기
+          <span className="hidden lg:inline">초대하기</span>
         </Button>
 
         {isOwner && (
@@ -249,7 +249,7 @@ export function CCStudyHeader({
             variant="outline"
             size="sm"
             onClick={onSettings}
-            className="gap-2 font-normal"
+            className="hidden lg:inline-flex gap-2 font-normal"
             title="스터디 설정"
             data-tour="settings-button"
           >

--- a/apps/frontend/src/domains/study/components/CCStudyListPage.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyListPage.tsx
@@ -9,6 +9,7 @@ import { CCJoinStudyModal } from '@/domains/study/components/CCJoinStudyModal';
 import { CCCreateStudyModal } from '@/domains/study/components/CCCreateStudyModal';
 import type { StudyListContent, StudyRoomDetail } from '@/domains/study/types';
 import { useRouter } from 'next/navigation';
+import { CCMainPageHeader } from '@/components/common/CCMainPageHeader';
 
 export function CCStudyListPage() {
   const router = useRouter();
@@ -44,18 +45,30 @@ export function CCStudyListPage() {
     <div className="min-h-screen">
       <div className="mx-auto max-w-6xl px-4 py-8">
         {/* Header with Action Buttons */}
-        <div className="mb-6 flex items-center justify-between">
-          <h1 className="text-2xl font-bold text-foreground">나의 스터디</h1>
-          <div className="flex items-center gap-2">
-            <Button variant="outline" onClick={() => setJoinModalOpen(true)} className="gap-2">
-              <LogIn className="h-4 w-4" />
-              참여하기
-            </Button>
-            <Button onClick={() => setCreateModalOpen(true)} className="gap-2">
-              <Plus className="h-4 w-4" />방 만들기
-            </Button>
-          </div>
-        </div>
+        <CCMainPageHeader
+          title="나의 스터디"
+          actions={
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setJoinModalOpen(true)}
+                className="gap-1.5 px-3 sm:gap-2 sm:px-4"
+              >
+                <LogIn className="h-4 w-4" />
+                참여하기
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => setCreateModalOpen(true)}
+                className="gap-1.5 px-3 sm:gap-2 sm:px-4"
+              >
+                <Plus className="h-4 w-4" />
+                방 만들기
+              </Button>
+            </>
+          }
+        />
 
         {/* Search Bar */}
         <div className="mb-6">
@@ -100,7 +113,7 @@ export function CCStudyListPage() {
             )}
           </div>
         ) : (
-          <div className="grid gap-4 grid-cols-3">
+          <div className="grid gap-4 grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
             {studies.map((study, index) => (
               <CCStudyCard
                 key={study.id}

--- a/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
@@ -8,9 +8,9 @@ import { Loader2 } from 'lucide-react';
 import { CCStudyHeader as StudyHeader } from './CCStudyHeader';
 import { CCProblemListPanel as ProblemListPanel } from './CCProblemListPanel';
 import { CCCenterPanel as CenterPanel } from './CCCenterPanel';
-import { CCVideoGrid as VideoGrid } from './CCVideoGrid';
 import { CCRightPanel as RightPanel } from './CCRightPanel';
 import { StudyLayoutContent } from './StudyLayoutContent';
+import { CCStudyRoomMobileLayout } from './CCStudyRoomMobileLayout';
 import { useProblems } from '@/domains/study/hooks/useProblems';
 import { useSubmissions } from '@/domains/study/hooks/useSubmissions';
 import type { StudyProblem as Problem } from '@/domains/study/types';
@@ -33,6 +33,7 @@ import { CCPreJoinModal } from '@/components/common/CCPreJoinModal';
 import { CCLiveKitWrapper } from './CCLiveKitWrapper';
 import { useStudyPresenceSync } from '@/domains/study/hooks/useStudyPresenceSync';
 import { useProblemDates } from '@/domains/study/hooks/useProblemDates';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 function StudySocketInitiator({ studyId }: { studyId: number }) {
   const { user, checkAuth } = useAuthStore();
@@ -71,6 +72,7 @@ function StudyRoomContent({
   aiRecommendationRequestId: string | null;
 }) {
   const router = useRouter();
+  const isMobile = useIsMobile();
   const { user } = useAuthStore();
   const { connected } = useSocketContext();
   const { localParticipant, isMicrophoneEnabled, isCameraEnabled } = useLocalParticipant();
@@ -103,10 +105,6 @@ function StudyRoomContent({
   const updateParticipant = useRoomStore((state) => state.updateParticipant);
   const setInviteModalOpen = useRoomStore((state) => state.setInviteModalOpen);
   const setSettingsOpen = useRoomStore((state) => state.setSettingsOpen);
-  const openSettingsModal = useSettingsStore((state) => state.openModal);
-
-  // [Fix] Move device settings modal open logic to after successful join or remove auto-open if causing issues on redirect.
-  const [isJoined, setIsJoined] = useState(false);
 
   // Whiteboard State
   const setIsWhiteboardActive = useRoomStore((state) => state.setIsWhiteboardActive);
@@ -295,6 +293,7 @@ function StudyRoomContent({
   const selectedStudyProblemId = useRoomStore((state) => state.selectedStudyProblemId);
   const setSelectedProblem = useRoomStore((state) => state.setSelectedProblem);
   const resetToOnlyMine = useRoomStore((state) => state.resetToOnlyMine);
+  const setMobileTab = useRoomStore((state) => state.setMobileTab);
   const [hintedStudyProblemId, setHintedStudyProblemId] = useState<number | null>(null);
   const lastProblemFallbackRequestedRef = useRef(false);
   const initialHintAppliedRef = useRef(false);
@@ -616,6 +615,9 @@ function StudyRoomContent({
       problem.title,
       problem.externalId || String((problem as any).number || 'Custom'),
     );
+    if (isMobile) {
+      setMobileTab('code');
+    }
     if (studyProblemId) setHintedStudyProblemId(Number(studyProblemId));
   };
 
@@ -656,6 +658,7 @@ function StudyRoomContent({
       onFetchSubmissions={(problemId) => void loadSubmissions(problemId)}
       historyDates={historyDates}
       showFoldButton={true}
+      allowProblemManage={!isMobile}
     />
   );
 
@@ -847,39 +850,62 @@ function StudyRoomContent({
     router,
     studyId,
   ]);
-
-
-
   return (
     <>
       <SettingsModal />
-      <StudyLayoutContent
-        header={
-          <StudyHeader
-            onBack={handleBack}
-            onAddProblem={handleAddProblem}
-            onInvite={handleInvite}
-            onSettings={handleSettings}
-            selectedDate={selectedDate}
-            onDateChange={handleDateChange}
-          />
-        }
-        leftPanel={problemList}
-        centerPanel={
-          <CenterPanel
-            onWhiteboardClick={handleWhiteboardClick}
-            onMicToggle={handleMicToggle}
-            onVideoToggle={handleVideoToggle}
-            onWhiteboardToggle={handleWhiteboardToggle}
-            onSettingsClick={handleSettings}
-          />
-        }
-        rightPanel={<RightPanel onFold={() => setIsRightPanelFolded(true)} />}
-        isLeftPanelFolded={isLeftPanelFolded}
-        onUnfoldLeftPanel={handleToggleLeftPanel}
-        isRightPanelFolded={isRightPanelFolded}
-        onUnfoldRightPanel={handleToggleRightPanel}
-      />
+      {isMobile ? (
+        <CCStudyRoomMobileLayout
+          header={
+            <StudyHeader
+              onBack={handleBack}
+              onAddProblem={handleAddProblem}
+              onInvite={handleInvite}
+              onSettings={handleSettings}
+              selectedDate={selectedDate}
+              onDateChange={handleDateChange}
+            />
+          }
+          centerPanel={
+            <CenterPanel
+              onWhiteboardClick={handleWhiteboardClick}
+              onMicToggle={handleMicToggle}
+              onVideoToggle={handleVideoToggle}
+              onWhiteboardToggle={handleWhiteboardToggle}
+              onSettingsClick={handleSettings}
+            />
+          }
+          problemPanel={problemList}
+          chatPanel={<RightPanel onFold={() => setIsRightPanelFolded(true)} />}
+        />
+      ) : (
+        <StudyLayoutContent
+          header={
+            <StudyHeader
+              onBack={handleBack}
+              onAddProblem={handleAddProblem}
+              onInvite={handleInvite}
+              onSettings={handleSettings}
+              selectedDate={selectedDate}
+              onDateChange={handleDateChange}
+            />
+          }
+          leftPanel={problemList}
+          centerPanel={
+            <CenterPanel
+              onWhiteboardClick={handleWhiteboardClick}
+              onMicToggle={handleMicToggle}
+              onVideoToggle={handleVideoToggle}
+              onWhiteboardToggle={handleWhiteboardToggle}
+              onSettingsClick={handleSettings}
+            />
+          }
+          rightPanel={<RightPanel onFold={() => setIsRightPanelFolded(true)} />}
+          isLeftPanelFolded={isLeftPanelFolded}
+          onUnfoldLeftPanel={handleToggleLeftPanel}
+          isRightPanelFolded={isRightPanelFolded}
+          onUnfoldRightPanel={handleToggleRightPanel}
+        />
+      )}
     </>
   );
 }
@@ -888,6 +914,7 @@ function StudyRoomContent({
 export function CCStudyRoomClient(): React.ReactNode {
   const params = useParams();
   const searchParams = useSearchParams();
+  const isMobile = useIsMobile();
   const studyId = Number(params.id) || 0;
   const router = useRouter();
   const currentUserId = useRoomStore((state) => state.currentUserId);
@@ -992,8 +1019,10 @@ export function CCStudyRoomClient(): React.ReactNode {
     return null;
   }
 
-  if (!isJoined) {
-    return <CCPreJoinModal roomTitle={roomTitle} onJoin={handleJoin} />;
+  const shouldShowPreJoin = !isMobile && !isJoined;
+
+  if (shouldShowPreJoin) {
+    return <CCPreJoinModal roomTitle={roomTitle} onJoin={handleJoin} skipExtensionCheck={isMobile} />;
   }
 
   return (

--- a/apps/frontend/src/domains/study/components/CCStudyRoomMobileLayout.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyRoomMobileLayout.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+import { MessageSquare, ListTodo, Video, Code2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
+
+interface CCStudyRoomMobileLayoutProps {
+  header: ReactNode | null;
+  centerPanel: ReactNode | null;
+  problemPanel: ReactNode | null;
+  chatPanel: ReactNode | null;
+}
+
+export function CCStudyRoomMobileLayout({
+  header,
+  centerPanel,
+  problemPanel,
+  chatPanel,
+}: CCStudyRoomMobileLayoutProps) {
+  const mobileTab = useRoomStore((state) => state.mobileTab);
+  const setMobileTab = useRoomStore((state) => state.setMobileTab);
+  const viewMode = useRoomStore((state) => state.viewMode);
+
+  useEffect(() => {
+    if (viewMode === 'SPLIT_REALTIME' || viewMode === 'SPLIT_SAVED') {
+      setMobileTab('code');
+    }
+  }, [viewMode, setMobileTab]);
+
+  return (
+    <div className="flex h-[100dvh] flex-col bg-background text-foreground overflow-hidden w-full">
+      {header && <header className="shrink-0 border-b border-border">{header}</header>}
+
+      <main className="relative flex flex-col flex-1 min-h-0 overflow-hidden w-full">
+        {/* Render content based on active tab */}
+        {/* CenterPanel internally toggles its layout based on whether 'video' or 'code' is active */}
+        {(mobileTab === 'video' || mobileTab === 'code') && centerPanel}
+        
+        {/* Full width panel for problem list */}
+        {mobileTab === 'problems' && (
+          <div className="absolute inset-0 z-10 bg-card overflow-hidden w-full">
+            {problemPanel}
+          </div>
+        )}
+        
+        {/* Full width panel for chat and participants */}
+        {mobileTab === 'chat' && (
+          <div className="absolute inset-0 z-10 bg-card overflow-hidden w-full">
+            {chatPanel}
+          </div>
+        )}
+      </main>
+
+      {/* Bottom Navigation Bar */}
+      <nav className="shrink-0 flex items-center justify-around border-t border-border bg-card h-[64px] pb-safe z-50 w-full shadow-[0_-4px_10px_-4px_rgba(0,0,0,0.05)]">
+        <button
+          onClick={() => setMobileTab('video')}
+          className={cn(
+            'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
+            mobileTab === 'video' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
+          )}
+        >
+          <Video className="w-5 h-5" />
+          <span className="text-[10px] font-medium mt-0.5">화상</span>
+        </button>
+        
+        <button
+          onClick={() => setMobileTab('code')}
+          className={cn(
+            'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
+            mobileTab === 'code' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
+          )}
+        >
+          <Code2 className="w-5 h-5" />
+          <span className="text-[10px] font-medium mt-0.5">코드</span>
+        </button>
+        
+        <button
+          onClick={() => setMobileTab('problems')}
+          className={cn(
+            'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
+            mobileTab === 'problems' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
+          )}
+        >
+          <ListTodo className="w-5 h-5" />
+          <span className="text-[10px] font-medium mt-0.5">문제</span>
+        </button>
+        
+        <button
+          onClick={() => setMobileTab('chat')}
+          className={cn(
+            'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
+            mobileTab === 'chat' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
+          )}
+        >
+          <MessageSquare className="w-5 h-5" />
+          <span className="text-[10px] font-medium mt-0.5">소통</span>
+        </button>
+      </nav>
+    </div>
+  );
+}

--- a/apps/frontend/src/domains/study/components/CCSubmissionViewerModal.tsx
+++ b/apps/frontend/src/domains/study/components/CCSubmissionViewerModal.tsx
@@ -69,7 +69,7 @@ export function CCSubmissionViewerModal({
       onClick={onClose}
     >
       <div
-        className="bg-background rounded-2xl shadow-xl w-full max-w-2xl flex flex-col max-h-[85vh]"
+        className="bg-background rounded-2xl shadow-xl w-full max-w-2xl flex flex-col max-h-[80vh] md:max-h-[85vh]"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between p-6 pb-2">
@@ -96,7 +96,7 @@ export function CCSubmissionViewerModal({
         </div>
 
         <div className="p-6 pt-2 flex flex-col gap-6 flex-1 overflow-hidden">
-          <div className="bg-muted/40 dark:bg-slate-900/60 rounded-xl border border-border p-5 shadow-sm space-y-4">
+          <div className="hidden md:block bg-muted/40 dark:bg-slate-900/60 rounded-xl border border-border p-5 shadow-sm space-y-4">
             <div className="flex items-start gap-2.5">
               <CheckCircle2 className="h-5 w-5 text-green-500 shrink-0 mt-0.5" />
               <p className="text-sm text-foreground font-medium">
@@ -153,17 +153,17 @@ export function CCSubmissionViewerModal({
                         className="flex items-center justify-between px-4 py-3 transition-colors hover:bg-muted/30 group"
                       >
                         <div className="flex flex-col gap-1 min-w-0">
-                          <div className="flex items-center gap-2">
+                          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                             <CheckCircle2 className="h-4 w-4 text-green-500 fill-green-100 shrink-0" />
-                            <span className="text-[10px] bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-300 px-1.5 py-0.5 rounded font-bold uppercase tracking-wide">
+                            <span className="text-[10px] bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-300 px-1.5 py-0.5 rounded font-bold uppercase tracking-wide shrink-0">
                               {sub.language || '-'}
                             </span>
                             {sub.submittedAt && (
-                              <span className="text-xs text-muted-foreground truncate">{sub.submittedAt}</span>
+                              <span className="text-xs text-muted-foreground shrink-0">{sub.submittedAt}</span>
                             )}
                           </div>
 
-                          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                          <div className="flex flex-wrap items-center gap-2 sm:gap-3 text-xs text-muted-foreground mt-0.5">
                             <div className="flex items-center gap-1 bg-slate-50 dark:bg-slate-800 px-1.5 py-0.5 rounded text-slate-500 dark:text-slate-300">
                               <HardDrive className="h-3 w-3" />
                               <span>{sub.memory ? (sub.memory / 1024).toFixed(1) : '0.0'}MB</span>
@@ -176,12 +176,13 @@ export function CCSubmissionViewerModal({
                         </div>
 
                         <Button
-                          className="h-8 px-3 rounded-full border border-primary bg-white dark:bg-slate-900/60 text-primary hover:bg-primary/10 hover:border-primary/20 shadow-sm transition-all text-xs font-medium group-hover:bg-primary group-hover:text-white group-hover:border-primary disabled:opacity-50 dark:group-hover:bg-primary"
+                          className="h-8 w-8 p-0 sm:w-auto sm:px-3 rounded-full border border-primary bg-white dark:bg-slate-900/60 text-primary hover:bg-primary/10 hover:border-primary/20 shadow-sm transition-all text-xs font-medium group-hover:bg-primary group-hover:text-white group-hover:border-primary disabled:opacity-50 dark:group-hover:bg-primary shrink-0 ml-2"
                           disabled={!sub.submissionId}
                           onClick={() => sub.submissionId && onViewCode(sub.submissionId)}
+                          title="코드 확인하기"
                         >
-                          <FileCode2 className="h-3.5 w-3.5 mr-1.5" />
-                          코드 확인하기
+                          <FileCode2 className="h-3.5 w-3.5 sm:mr-1.5" />
+                          <span className="hidden sm:inline">코드 확인</span>
                         </Button>
                       </div>
                     ))}

--- a/apps/frontend/src/domains/study/components/CCVideoGrid.tsx
+++ b/apps/frontend/src/domains/study/components/CCVideoGrid.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import { useRoomStore, type Participant as StoreParticipant } from '@/domains/study/hooks/useRoomStore';
 import { CCVideoTile } from '@/domains/study/components/CCVideoTile';
@@ -156,7 +156,9 @@ export function CCVideoGrid({ onWhiteboardClick, className }: CCVideoGridProps) 
       onWheel={handleWheelScroll}
       data-tour="video-grid"
       className={cn(
-        'flex gap-2 overflow-x-auto overflow-y-hidden border-b border-border bg-card p-3 pb-2',
+        'border-b border-border bg-card p-3 pb-2 gap-2 content-start',
+        'grid grid-cols-2 overflow-y-auto overflow-x-hidden',
+        'md:flex md:flex-row md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden md:content-stretch',
         className,
       )}
     >
@@ -213,7 +215,8 @@ function CCOfflineTile({
   return (
     <div
       className={cn(
-        'relative h-full w-auto aspect-[4/3] shrink-0 overflow-hidden rounded-lg border border-border bg-muted',
+        'relative aspect-[4/3] shrink-0 overflow-hidden rounded-lg border border-border bg-muted',
+        'w-full h-auto md:h-full md:w-auto',
         'cursor-pointer hover:ring-2 hover:ring-primary/50 transition-all',
         isCurrentUser && 'ring-2 ring-primary',
         className,

--- a/apps/frontend/src/domains/study/components/CCVideoTile.tsx
+++ b/apps/frontend/src/domains/study/components/CCVideoTile.tsx
@@ -43,7 +43,8 @@ export function CCVideoTile({
   return (
     <div
       className={cn(
-        'relative h-full w-auto aspect-[4/3] shrink-0 overflow-hidden rounded-lg border border-border bg-muted',
+        'relative aspect-[4/3] shrink-0 overflow-hidden rounded-lg border border-border bg-muted',
+        'w-full h-auto md:h-full md:w-auto',
         'cursor-pointer hover:ring-2 hover:ring-primary/50 transition-all',
         isCurrentUser && 'ring-2 ring-primary',
         className,

--- a/apps/frontend/src/domains/study/components/CCWhiteboardTile.tsx
+++ b/apps/frontend/src/domains/study/components/CCWhiteboardTile.tsx
@@ -34,7 +34,8 @@ export function CCWhiteboardTile({ onClick, className }: CCWhiteboardTileProps) 
         }
       }}
       className={cn(
-        'relative flex h-full w-auto aspect-[4/3] shrink-0 cursor-pointer flex-col overflow-hidden rounded-lg transition-all hover:ring-2 hover:ring-rose-400 border border-transparent shadow-md',
+        'relative flex aspect-[4/3] shrink-0 cursor-pointer flex-col overflow-hidden rounded-lg transition-all hover:ring-2 hover:ring-rose-400 border border-transparent shadow-md',
+        'w-full h-auto md:h-full md:w-auto',
         isWhiteboardOverlayOpen
           ? 'bg-gradient-to-br from-rose-400 to-rose-600 ring-2 ring-rose-500 dark:from-rose-500 dark:to-rose-700'
           : 'bg-gradient-to-br from-rose-50 to-rose-200 border-rose-200 dark:from-slate-800 dark:to-slate-700 dark:border-slate-600',

--- a/apps/frontend/src/domains/study/components/chat/StudyChatPanel.tsx
+++ b/apps/frontend/src/domains/study/components/chat/StudyChatPanel.tsx
@@ -101,7 +101,11 @@ export function StudyChatPanel() {
           </div>
         )}
         {messages.map((msg) => (
-          <div key={msg.id} data-msg-id={msg.id}>
+          <div
+            key={msg.id}
+            data-msg-id={msg.id}
+            className={msg.senderId === currentUserId ? 'flex justify-end' : 'flex justify-start'}
+          >
             <ChatMessageItem message={msg} isMine={msg.senderId === currentUserId} />
           </div>
         ))}

--- a/apps/frontend/src/domains/study/hooks/useRoomStore.ts
+++ b/apps/frontend/src/domains/study/hooks/useRoomStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { ChatType } from '../types/chat';
 
 export type ViewMode = 'ONLY_MINE' | 'SPLIT_REALTIME' | 'SPLIT_SAVED';
+export type MobileTab = 'video' | 'code' | 'problems' | 'chat';
 
 export interface Participant {
   id: number;
@@ -52,6 +53,7 @@ export interface RoomState {
   isSettingsOpen: boolean;
 
   // Layout State (migrated from other stores/components)
+  mobileTab: MobileTab;
   rightPanelActiveTab: string;
   isWhiteboardActive: boolean;
   whiteboardOpenedBy: string | null;
@@ -126,6 +128,7 @@ export interface RoomActions {
   setSettingsOpen: (isOpen: boolean) => void;
 
   // Layout Actions
+  setMobileTab: (tab: MobileTab) => void;
   setRightPanelActiveTab: (tab: string) => void;
   setIsWhiteboardActive: (isActive: boolean) => void;
   setWhiteboardOpenedBy: (user: string | null) => void;
@@ -193,6 +196,7 @@ const initialState: RoomState = {
   isInviteModalOpen: false,
   isSettingsOpen: false,
 
+  mobileTab: 'video',
   rightPanelActiveTab: 'chat',
   isWhiteboardActive: false,
   whiteboardOpenedBy: null,
@@ -260,6 +264,7 @@ export const useRoomStore = create<RoomState & RoomActions>((set) => ({
   setInviteModalOpen: (isOpen): void => set({ isInviteModalOpen: isOpen }),
   setSettingsOpen: (isOpen): void => set({ isSettingsOpen: isOpen }),
 
+  setMobileTab: (tab): void => set({ mobileTab: tab }),
   setRightPanelActiveTab: (tab): void => set({ rightPanelActiveTab: tab }),
   setIsWhiteboardActive: (isActive): void => set({ isWhiteboardActive: isActive }),
   setWhiteboardOpenedBy: (user: string | null): void => set({ whiteboardOpenedBy: user }),

--- a/apps/frontend/src/domains/study/tests/CCProblemCard.test.tsx
+++ b/apps/frontend/src/domains/study/tests/CCProblemCard.test.tsx
@@ -64,28 +64,20 @@ describe('CCProblemCard', () => {
     }
   });
 
-  it('calls onSelect when shortcut external link is clicked', () => {
-    const postMessageSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+  it('opens problem site when title link is clicked', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     render(<CCProblemCard {...defaultProps} />);
 
-    const externalLinkButton = screen.getByRole('button', { name: /바로가기 새 탭/i });
-    fireEvent.click(externalLinkButton);
+    const titleButton = screen.getByRole('button', { name: /^Test Problem$/i });
+    fireEvent.click(titleButton);
 
-    expect(defaultProps.onSelect).toHaveBeenCalled();
-    expect(postMessageSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'PEEKLE_WINDOW_SPLIT',
-        payload: expect.objectContaining({
-          context: expect.objectContaining({
-            sourceType: 'STUDY',
-            externalId: 1001,
-            studyProblemId: 101,
-          }),
-        }),
-      }),
-      '*',
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://www.acmicpc.net/problem/1001',
+      '_blank',
+      'noopener,noreferrer',
     );
-    postMessageSpy.mockRestore();
+    expect(defaultProps.onSelect).not.toHaveBeenCalled();
+    openSpy.mockRestore();
   });
 
   it('displays solved count', () => {

--- a/apps/frontend/src/domains/study/tests/CCSubmissionViewerModal.test.tsx
+++ b/apps/frontend/src/domains/study/tests/CCSubmissionViewerModal.test.tsx
@@ -63,7 +63,7 @@ describe('CCSubmissionViewerModal', () => {
 
   it('calls onViewCode when code check button is clicked', () => {
     render(<CCSubmissionViewerModal {...defaultProps} />);
-    const checkButtons = screen.getAllByRole('button', { name: /코드 확인하기/i });
+    const checkButtons = screen.getAllByRole('button', { name: /코드 확인/i });
     fireEvent.click(checkButtons[0]);
     expect(defaultProps.onViewCode).toHaveBeenCalledWith(mockSubmissions[0].submissionId);
   });

--- a/apps/frontend/src/domains/workbook/components/AddToWorkbookModal.tsx
+++ b/apps/frontend/src/domains/workbook/components/AddToWorkbookModal.tsx
@@ -21,6 +21,7 @@ import {
 import { searchBojProblems, getProblemIdByExternalId } from '../api/problemApi';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 interface AddToWorkbookModalProps {
     isOpen: boolean;
@@ -35,6 +36,7 @@ export function AddToWorkbookModal({
     problemBojId,
     problemTitle,
 }: AddToWorkbookModalProps) {
+    const isMobile = useIsMobile();
     const [workbooks, setWorkbooks] = useState<WorkbookListResponse[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [isAdding, setIsAdding] = useState<number | null>(null);
@@ -141,11 +143,18 @@ export function AddToWorkbookModal({
 
     return (
         <ShadcnDialog open={isOpen} onOpenChange={onClose}>
-            <ShadcnDialogContent className="sm:max-w-[420px] bg-card border-border shadow-2xl rounded-3xl p-6 flex flex-col gap-0 max-h-[85vh]">
+            <ShadcnDialogContent
+                className={cn(
+                    'bg-card border-border shadow-2xl flex flex-col gap-0',
+                    isMobile
+                        ? 'w-[calc(100vw-1rem)] max-w-none h-[calc(100vh-1.5rem)] max-h-[calc(100vh-1.5rem)] rounded-2xl top-3 translate-y-0 p-4 overflow-hidden'
+                        : 'sm:max-w-[420px] rounded-3xl p-6 max-h-[85vh]'
+                )}
+            >
 
                 {/* 1. Header Area */}
-                <ShadcnDialogHeader className="space-y-1.5 pb-4 border-b shrink-0">
-                    <ShadcnDialogTitle className="text-xl font-bold flex items-center gap-2">
+                <ShadcnDialogHeader className={cn('space-y-1.5 border-b shrink-0', isMobile ? 'pb-3' : 'pb-4')}>
+                    <ShadcnDialogTitle className={cn('font-bold flex items-center gap-2', isMobile ? 'text-lg' : 'text-xl')}>
                         문제집에 추가
                     </ShadcnDialogTitle>
                     <ShadcnDialogDescription className="text-sm font-medium">
@@ -155,7 +164,7 @@ export function AddToWorkbookModal({
                 </ShadcnDialogHeader>
 
                 {/* 2. Body Area */}
-                <div className="flex-1 overflow-y-auto py-4 space-y-4 min-h-[250px] scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent px-1">
+                <div className={cn('flex-1 overflow-y-auto py-4 space-y-4 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent px-1', isMobile ? 'min-h-0' : 'min-h-[250px]')}>
                     {/* Search Bar */}
                     <div className="relative group">
                         <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground group-focus-within:text-foreground transition-colors" />
@@ -270,13 +279,23 @@ export function AddToWorkbookModal({
                 </div>
 
                 {/* 3. Footer Area */}
-                <ShadcnDialogFooter className="pt-4 border-t shrink-0 flex flex-row items-center justify-between sm:justify-between gap-2 mt-0">
+                <ShadcnDialogFooter
+                    className={cn(
+                        'border-t shrink-0 flex items-center gap-2 mt-0',
+                        isMobile
+                            ? 'pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] flex-row justify-between'
+                            : 'pt-4 flex-row justify-between sm:justify-between',
+                    )}
+                >
                     <Button
                         variant="ghost"
                         onClick={() => {
                             onClose();
                         }}
-                        className="text-muted-foreground hover:text-foreground rounded-xl flex-1 sm:flex-none border border-transparent hover:border-border h-11"
+                        className={cn(
+                            'text-muted-foreground hover:text-foreground rounded-xl border border-transparent hover:border-border h-11',
+                            isMobile ? 'flex-1' : 'flex-1 sm:flex-none',
+                        )}
                     >
                         취소
                     </Button>
@@ -287,7 +306,7 @@ export function AddToWorkbookModal({
                             }
                         }}
                         disabled={!selectedWorkbookId || isAdding !== null || isCreating || isLoading}
-                        className="font-bold px-8 rounded-xl h-11 flex-1 sm:flex-none"
+                        className={cn('font-bold rounded-xl h-11', isMobile ? 'flex-1' : 'px-8 flex-1 sm:flex-none')}
                     >
                         {isAdding !== null ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
                         추가

--- a/apps/frontend/src/domains/workbook/components/WorkbookModal.tsx
+++ b/apps/frontend/src/domains/workbook/components/WorkbookModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import {
   DndContext,
   closestCenter,
@@ -23,6 +23,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { createPortal } from 'react-dom';
 import type { WorkbookProblemItem, Workbook, WorkbookProblem } from '../types';
 import { searchBojProblems, type BojProblemResponse } from '../api/problemApi';
 
@@ -90,6 +92,7 @@ export function WorkbookModal({
   problems = [],
   onSubmit,
 }: WorkbookModalProps) {
+  const isMobile = useIsMobile();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [problemList, setProblemList] = useState<WorkbookProblemItem[]>([]);
@@ -161,6 +164,7 @@ export function WorkbookModal({
   // 외부 클릭 감지
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
+      if (isMobile) return;
       if (
         dropdownRef.current &&
         !dropdownRef.current.contains(event.target as Node) &&
@@ -173,7 +177,16 @@ export function WorkbookModal({
 
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  }, [isMobile]);
+
+  useEffect(() => {
+    if (!isMobile || !open) return;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isMobile, open]);
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -213,18 +226,184 @@ export function WorkbookModal({
     onOpenChange(false);
   };
 
+  const searchSection = (
+    <div className={cn('overflow-visible min-w-0', isMobile ? 'px-4 py-3 border-b shrink-0' : 'p-5 flex-1')}>
+      <label className="text-sm font-medium block mb-2">문제 검색</label>
+      <div className="relative min-w-0">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          ref={searchInputRef}
+          value={searchQuery}
+          onChange={(e) => {
+            setSearchQuery(e.target.value);
+            setIsDropdownOpen(true);
+          }}
+          onFocus={() => searchQuery && setIsDropdownOpen(true)}
+          placeholder="번호 또는 제목 검색"
+          className={cn('pl-9 pr-9', isMobile && 'h-9')}
+        />
+        {searchQuery && (
+          <button
+            type="button"
+            onClick={() => {
+              setSearchQuery('');
+              setSearchResults([]);
+              setIsDropdownOpen(false);
+            }}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+
+        {isDropdownOpen && searchQuery && (
+          <div
+            ref={dropdownRef}
+            className="absolute z-[100] top-full left-0 right-0 mt-1 bg-popover border rounded-md shadow-xl"
+          >
+            {isSearching ? (
+              <div className="px-3 py-4 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span>검색 중...</span>
+              </div>
+            ) : searchResults.length > 0 ? (
+              <div className={cn('py-1 overflow-y-auto', isMobile ? 'max-h-[180px]' : 'max-h-[240px]')}>
+                {searchResults.map((problem) => (
+                  <button
+                    key={problem.id}
+                    type="button"
+                    onClick={() => handleAddProblem(problem)}
+                    className="w-full px-3 py-2 text-left hover:bg-muted flex items-center gap-2 text-sm transition-colors min-w-0"
+                  >
+                    <span className="font-medium text-primary w-12 shrink-0">{problem.externalId}</span>
+                    <span className="truncate flex-1 min-w-0">{problem.title}</span>
+                    <span className={cn('text-xs text-muted-foreground shrink-0', isMobile && 'hidden')}>
+                      {problem.tier}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="px-3 py-4 text-sm text-muted-foreground text-center">
+                검색 결과가 없습니다
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      {!isMobile && <p className="text-xs text-muted-foreground mt-2">클릭하면 우측 목록에 추가됩니다</p>}
+    </div>
+  );
+
+  const problemListSection = (
+    <div className={cn('flex-1 flex flex-col min-w-0 bg-muted/20', isMobile && 'min-h-0')}>
+      <div
+        className={cn(
+          'border-b bg-background flex items-center justify-between shrink-0',
+          isMobile ? 'px-4 py-2.5' : 'px-5 py-3',
+        )}
+      >
+        <span className="text-sm font-medium">문제 목록</span>
+        <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded">
+          {problemList.length}개
+        </span>
+      </div>
+
+      <div className={cn('flex-1 overflow-y-auto', isMobile ? 'p-3' : 'p-4')}>
+        {problemList.length === 0 ? (
+          <div className="h-full flex items-center justify-center">
+            <div className="text-center text-muted-foreground">
+              <p className="text-sm">추가된 문제가 없습니다</p>
+            </div>
+          </div>
+        ) : (
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={problemList.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+              <div className="space-y-1.5">
+                {problemList.map((item, index) => (
+                  <SortableProblemItem
+                    key={item.id}
+                    item={item}
+                    index={index}
+                    onRemove={handleRemoveProblem}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        )}
+      </div>
+    </div>
+  );
+
+  if (isMobile) {
+    if (!open) return null;
+
+    return createPortal(
+      <div
+        className="fixed inset-x-0 top-0 bottom-[calc(4rem+env(safe-area-inset-bottom))] z-[70] bg-background flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-label={mode === 'create' ? '새 문제집 만들기' : '문제집 수정'}
+      >
+        <div className="border-b shrink-0 px-4 py-3">
+          <h2 className="text-lg font-semibold leading-none tracking-tight">
+            {mode === 'create' ? '새 문제집 만들기' : '문제집 수정'}
+          </h2>
+        </div>
+
+        <div className="flex-1 min-h-0 flex flex-col">
+          <div className="px-4 py-4 border-b space-y-4 shrink-0">
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">제목</label>
+              <Input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="문제집 제목"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-muted-foreground">설명 (선택)</label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="문제집 설명"
+                rows={3}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring resize-none"
+              />
+            </div>
+          </div>
+          {searchSection}
+          {problemListSection}
+        </div>
+
+        <div className="border-t flex gap-2 shrink-0 bg-background px-4 py-3">
+          <Button variant="outline" onClick={() => onOpenChange(false)} className="flex-1">
+            취소
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!title.trim()}
+            className="bg-primary hover:bg-primary text-white flex-1"
+          >
+            {mode === 'create' ? '만들기' : '저장'}
+          </Button>
+        </div>
+      </div>,
+      document.body,
+    );
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[800px] h-[560px] flex flex-col p-0 gap-0 overflow-visible">
-        <DialogHeader className="px-6 py-4 border-b shrink-0">
+      <DialogContent className="flex flex-col p-0 gap-0 max-w-[800px] h-[560px] overflow-visible">
+        <DialogHeader className="border-b shrink-0 px-6 py-4">
           <DialogTitle>{mode === 'create' ? '새 문제집 만들기' : '문제집 수정'}</DialogTitle>
         </DialogHeader>
 
         <div className="flex-1 flex min-h-0">
-          {/* 좌측 패널 */}
-          <div className="w-[320px] border-r flex flex-col shrink-0">
-            {/* 제목 & 설명 */}
-            <div className="p-5 space-y-4 border-b">
+          <div className="flex flex-col shrink-0 min-w-0 w-[320px] border-r">
+            <div className="space-y-4 border-b p-5">
               <div className="space-y-1.5">
                 <label className="text-sm font-medium">제목</label>
                 <Input
@@ -244,125 +423,12 @@ export function WorkbookModal({
                 />
               </div>
             </div>
-
-            {/* 검색 영역 */}
-            <div className="p-5 flex-1 overflow-visible">
-              <label className="text-sm font-medium block mb-2">문제 검색</label>
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-                <Input
-                  ref={searchInputRef}
-                  value={searchQuery}
-                  onChange={(e) => {
-                    setSearchQuery(e.target.value);
-                    setIsDropdownOpen(true);
-                  }}
-                  onFocus={() => searchQuery && setIsDropdownOpen(true)}
-                  placeholder="번호 또는 제목 검색"
-                  className="pl-9 pr-9"
-                />
-                {searchQuery && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSearchQuery('');
-                      setSearchResults([]);
-                      setIsDropdownOpen(false);
-                    }}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
-                )}
-
-                {/* 드롭다운 */}
-                {isDropdownOpen && searchQuery && (
-                  <div
-                    ref={dropdownRef}
-                    className="absolute z-[100] top-full left-0 right-0 mt-1 bg-popover border rounded-md shadow-xl"
-                  >
-                    {isSearching ? (
-                      <div className="px-3 py-4 flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        <span>검색 중...</span>
-                      </div>
-                    ) : searchResults.length > 0 ? (
-                      <div className="py-1 max-h-[240px] overflow-y-auto">
-                        {searchResults.map((problem) => (
-                          <button
-                            key={problem.id}
-                            type="button"
-                            onClick={() => handleAddProblem(problem)}
-                            className="w-full px-3 py-2 text-left hover:bg-muted flex items-center gap-3 text-sm transition-colors"
-                          >
-                            <span className="font-medium text-primary w-12">
-                              {problem.externalId}
-                            </span>
-                            <span className="truncate flex-1">{problem.title}</span>
-                            <span className="text-xs text-muted-foreground shrink-0">
-                              {problem.tier}
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="px-3 py-4 text-sm text-muted-foreground text-center">
-                        검색 결과가 없습니다
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-              <p className="text-xs text-muted-foreground mt-2">클릭하면 우측 목록에 추가됩니다</p>
-            </div>
+            {searchSection}
           </div>
-
-          {/* 우측 패널 - 문제 목록 */}
-          <div className="flex-1 flex flex-col min-w-0 bg-muted/20">
-            <div className="px-5 py-3 border-b bg-background flex items-center justify-between shrink-0">
-              <span className="text-sm font-medium">문제 목록</span>
-              <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded">
-                {problemList.length}개
-              </span>
-            </div>
-
-            <div className="flex-1 overflow-y-auto p-4">
-              {problemList.length === 0 ? (
-                <div className="h-full flex items-center justify-center">
-                  <div className="text-center text-muted-foreground">
-                    <p className="text-sm">추가된 문제가 없습니다</p>
-                    <p className="text-xs mt-1">좌측에서 문제를 검색해 추가하세요</p>
-                  </div>
-                </div>
-              ) : (
-                <DndContext
-                  sensors={sensors}
-                  collisionDetection={closestCenter}
-                  onDragEnd={handleDragEnd}
-                >
-                  <SortableContext
-                    items={problemList.map((p) => p.id)}
-                    strategy={verticalListSortingStrategy}
-                  >
-                    <div className="space-y-1.5">
-                      {problemList.map((item, index) => (
-                        <SortableProblemItem
-                          key={item.id}
-                          item={item}
-                          index={index}
-                          onRemove={handleRemoveProblem}
-                        />
-                      ))}
-                    </div>
-                  </SortableContext>
-                </DndContext>
-              )}
-            </div>
-          </div>
+          {problemListSection}
         </div>
 
-        {/* 하단 버튼 */}
-        <div className="px-6 py-4 border-t flex justify-end gap-2 shrink-0 bg-background">
+        <div className="border-t flex gap-2 shrink-0 bg-background px-6 py-4 justify-end">
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             취소
           </Button>

--- a/apps/frontend/src/domains/workbook/layout/WorkbooksFilter.tsx
+++ b/apps/frontend/src/domains/workbook/layout/WorkbooksFilter.tsx
@@ -64,13 +64,13 @@ export function WorkbooksFilter({
   return (
     <div className={cn('space-y-4', className)}>
       {/* 탭 */}
-      <div className="flex items-center gap-1 p-1 bg-muted rounded-lg w-fit">
+      <div className="flex items-center gap-1 p-1 bg-muted rounded-lg w-full overflow-x-auto no-scrollbar lg:w-fit">
         {TAB_OPTIONS.map((option) => (
           <button
             key={option.value}
             onClick={() => onTabChange(option.value)}
             className={cn(
-              'flex items-center gap-1.5 px-4 py-2 rounded-md text-sm font-medium transition-colors',
+              'flex shrink-0 items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium transition-colors lg:px-4',
               tab === option.value
                 ? 'bg-background text-primary shadow-sm'
                 : 'text-muted-foreground hover:text-foreground',
@@ -91,9 +91,9 @@ export function WorkbooksFilter({
       </div>
 
       {/* 검색 + 정렬 */}
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
         {/* 검색바 */}
-        <div className="relative flex-1 max-w-md">
+        <div className="relative flex-1 sm:max-w-md">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
             placeholder="문제집 검색..."
@@ -104,10 +104,10 @@ export function WorkbooksFilter({
         </div>
 
         {/* 정렬 드롭다운 */}
-        <div ref={sortRef} className="relative">
+        <div ref={sortRef} className="relative w-full sm:w-auto">
           <button
             onClick={() => setIsSortOpen(!isSortOpen)}
-            className="flex items-center gap-1 px-4 py-2 rounded-md bg-primary hover:bg-primary text-white text-sm font-medium transition-colors"
+            className="flex w-full items-center justify-between gap-1 px-4 py-2 rounded-md bg-primary hover:bg-primary text-white text-sm font-medium transition-colors sm:w-auto"
           >
             {currentSortLabel}
             <ChevronDown
@@ -116,7 +116,7 @@ export function WorkbooksFilter({
           </button>
 
           {isSortOpen && (
-            <div className="absolute right-0 top-full mt-1 w-32 bg-popover border border-border rounded-md shadow-lg z-10">
+            <div className="absolute right-0 top-full mt-1 w-full sm:w-32 bg-popover border border-border rounded-md shadow-lg z-10">
               {SORT_OPTIONS.map((option) => (
                 <button
                   key={option.value}

--- a/apps/frontend/src/domains/workbook/layout/WorkbooksHeader.tsx
+++ b/apps/frontend/src/domains/workbook/layout/WorkbooksHeader.tsx
@@ -3,20 +3,31 @@
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Plus } from 'lucide-react';
+import { CCMainPageHeader } from '@/components/common/CCMainPageHeader';
 
 interface WorkbooksHeaderProps {
   onCreateClick?: () => void;
   className?: string;
+  showCreate?: boolean;
 }
 
-export function WorkbooksHeader({ onCreateClick, className }: WorkbooksHeaderProps) {
+export function WorkbooksHeader({
+  onCreateClick,
+  className,
+  showCreate = true,
+}: WorkbooksHeaderProps) {
   return (
-    <div className={cn('flex items-center justify-between', className)}>
-      <h1 className="text-2xl font-bold text-foreground">문제집</h1>
-      <Button onClick={onCreateClick} className="bg-primary hover:bg-primary-dark text-white gap-1">
-        <Plus className="h-4 w-4" />
-        새로 만들기
-      </Button>
-    </div>
+    <CCMainPageHeader
+      title="문제집"
+      className={cn('mb-0', className)}
+      actions={
+        showCreate ? (
+          <Button onClick={onCreateClick} className="bg-primary hover:bg-primary-dark text-white gap-1">
+            <Plus className="h-4 w-4" />
+            새로 만들기
+          </Button>
+        ) : undefined
+      }
+    />
   );
 }

--- a/apps/frontend/src/domains/workbook/layout/WorkbooksLeftPanel.tsx
+++ b/apps/frontend/src/domains/workbook/layout/WorkbooksLeftPanel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { Loader2 } from 'lucide-react';
-import { CCWorkbookRow } from '../components';
+import { CCWorkbookCard, CCWorkbookRow } from '../components';
 import type { Workbook } from '../types';
 
 interface WorkbooksLeftPanelProps {
@@ -15,6 +15,7 @@ interface WorkbooksLeftPanelProps {
   hasMore: boolean;
   isLoading: boolean;
   onLoadMore: () => void;
+  isMobile?: boolean;
   className?: string;
 }
 
@@ -27,6 +28,7 @@ export function WorkbooksLeftPanel({
   hasMore,
   isLoading,
   onLoadMore,
+  isMobile = false,
   className,
 }: WorkbooksLeftPanelProps) {
   const observerRef = useRef<HTMLDivElement>(null);
@@ -64,30 +66,47 @@ export function WorkbooksLeftPanel({
       className={cn('flex-1 border rounded-xl bg-card overflow-hidden flex flex-col', className)}
     >
       {/* 헤더 */}
-      <div className="flex items-center gap-4 px-4 py-3 border-b bg-muted/50 text-xs font-medium text-muted-foreground shrink-0">
-        <div className="shrink-0 w-8 text-center">#</div>
-        <div className="flex-1">
+      {isMobile ? (
+        <div className="px-4 py-3 border-b bg-muted/50 text-xs font-medium text-muted-foreground shrink-0">
           문제집
           <span className="ml-2 text-muted-foreground/70">({totalCount})</span>
         </div>
-        <div className="shrink-0 w-24 text-center">진행률</div>
-        <div className="shrink-0 w-20 text-center">만든 사람</div>
-        <div className="shrink-0 w-14 text-center">즐겨찾기</div>
-        <div className="shrink-0 w-4" />
-      </div>
+      ) : (
+        <div className="flex items-center gap-4 px-4 py-3 border-b bg-muted/50 text-xs font-medium text-muted-foreground shrink-0">
+          <div className="shrink-0 w-8 text-center">#</div>
+          <div className="flex-1">
+            문제집
+            <span className="ml-2 text-muted-foreground/70">({totalCount})</span>
+          </div>
+          <div className="shrink-0 w-24 text-center">진행률</div>
+          <div className="shrink-0 w-20 text-center">만든 사람</div>
+          <div className="shrink-0 w-14 text-center">즐겨찾기</div>
+          <div className="shrink-0 w-4" />
+        </div>
+      )}
 
       {/* 리스트 - 스크롤 영역 */}
-      <div className="flex-1 overflow-y-auto">
-        {workbooks.map((workbook, index) => (
-          <CCWorkbookRow
-            key={workbook.id}
-            workbook={workbook}
-            isSelected={selectedId === workbook.id}
-            onSelect={() => onSelect(workbook.id)}
-            onToggleBookmark={onToggleBookmark}
-            className={index !== workbooks.length - 1 ? 'border-b border-border/50' : ''}
-          />
-        ))}
+      <div className={cn('flex-1 overflow-y-auto', isMobile && 'p-3 space-y-3')}>
+        {workbooks.map((workbook, index) =>
+          isMobile ? (
+            <CCWorkbookCard
+              key={workbook.id}
+              workbook={workbook}
+              isSelected={selectedId === workbook.id}
+              onSelect={() => onSelect(workbook.id)}
+              onToggleBookmark={onToggleBookmark}
+            />
+          ) : (
+            <CCWorkbookRow
+              key={workbook.id}
+              workbook={workbook}
+              isSelected={selectedId === workbook.id}
+              onSelect={() => onSelect(workbook.id)}
+              onToggleBookmark={onToggleBookmark}
+              className={index !== workbooks.length - 1 ? 'border-b border-border/50' : ''}
+            />
+          ),
+        )}
 
         {/* 로딩 인디케이터 & Observer 타겟 */}
         <div ref={observerRef} className="py-4 flex justify-center">

--- a/apps/frontend/src/domains/workbook/layout/WorkbooksRightPanel.tsx
+++ b/apps/frontend/src/domains/workbook/layout/WorkbooksRightPanel.tsx
@@ -30,6 +30,8 @@ interface WorkbooksRightPanelProps {
   onClose: () => void;
   onEdit?: () => void;
   onDelete?: () => void;
+  allowManage?: boolean;
+  isMobile?: boolean;
   className?: string;
 }
 
@@ -39,6 +41,8 @@ export function WorkbooksRightPanel({
   onClose,
   onEdit,
   onDelete,
+  allowManage = true,
+  isMobile = false,
   className,
 }: WorkbooksRightPanelProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -53,8 +57,9 @@ export function WorkbooksRightPanel({
   return (
     <div
       className={cn(
-        'w-[460px] flex flex-col overflow-hidden animate-in slide-in-from-right-4 duration-200',
-        'border-l bg-card shadow-lg',
+        'flex flex-col overflow-hidden animate-in duration-200',
+        isMobile ? 'w-full slide-in-from-bottom-4' : 'w-[460px] slide-in-from-right-4',
+        isMobile ? 'border-0 bg-card shadow-none' : 'border-l bg-card shadow-lg',
         className,
       )}
     >
@@ -77,7 +82,7 @@ export function WorkbooksRightPanel({
         {/* 문제집 이름 */}
         <div className="flex items-center gap-1 mb-3">
           <h2 className="font-bold text-xl text-foreground leading-tight">{workbook.title}</h2>
-          {workbook.isOwner && (
+          {workbook.isOwner && allowManage && (
             <>
               {onEdit && (
                 <button

--- a/apps/frontend/src/hooks/useIsMobile.ts
+++ b/apps/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useIsMobile(breakpoint = 1024): boolean {
+  const getCurrentIsMobile = () => {
+    if (typeof window === 'undefined') return false;
+    return window.innerWidth < breakpoint;
+  };
+
+  const [isMobile, setIsMobile] = useState(getCurrentIsMobile);
+
+  useEffect(() => {
+    const update = () => setIsMobile(getCurrentIsMobile());
+
+    update();
+    window.addEventListener('resize', update);
+
+    return () => window.removeEventListener('resize', update);
+  }, [breakpoint]);
+
+  return isMobile;
+}

--- a/apps/frontend/src/hooks/useIsMobile.ts
+++ b/apps/frontend/src/hooks/useIsMobile.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 
-export function useIsMobile(breakpoint = 1024): boolean {
+export function useIsMobile(breakpoint = 768): boolean {
   const getCurrentIsMobile = () => {
     if (typeof window === 'undefined') return false;
     return window.innerWidth < breakpoint;


### PR DESCRIPTION
## 💡 의도 / 배경
기존 Peekle은 데스크톱 중심 UI로 설계되어 모바일 환경에서 핵심 흐름(조회/참여)이 끊기는 문제가 있었습니다.  
이 PR은 이슈 #117의 목표에 맞춰 모바일에서 **조회와 가벼운 참여**를 우선 지원하도록 레이아웃/플로우를 재구성했습니다.  
추가로 사용 중 피드백을 반영해 문제집/스터디방/AI 추천 문제 플로우의 모바일 UX를 보완했습니다.

## 🛠️ 작업 내용
- [x] 모바일 반응형 기준 정리 (`useIsMobile` 기본값 1024 → 768)
- [x] 모바일 하단 네비게이션 및 토스트 위치 보정(모바일 우상단)
- [x] 스터디방 모바일 레이아웃 개선
- [x] 모바일 입장 시 사전 체크(확장프로그램/프리조인) 흐름 완화
- [x] 모바일에서 조회 중심 UI로 정리 (불필요한 편집/관리 요소 숨김)
- [x] 모바일에서 내 코드/타인 코드/문제/채팅 전환 시 화면 교체형 UX 적용
- [x] 문제 탭에서 문제 제목 클릭 시 BOJ 링크 이동 UX 개선
- [x] AI 추천 문제 버튼 분기
- [x] 모바일: `문제 보러가기`(외부 링크), 데스크탑: `풀러가기`(스터디 선택 후 이동)
- [x] 문제집 페이지 반응형 개선
- [x] 문제집 상세: 모바일 전체 화면(하단바 제외) 패널화
- [x] 새 문제집 만들기: 모바일 모달 느낌 제거, 전체 화면 편집형 구조로 전환
- [x] 문제집 생성 화면에서 문제 검색 섹션 위치/가시성 수정
- [x] 공통 페이지 헤더 정리(스터디방/문제집/랭킹/리그/검색) 및 리그 모바일 가독성 개선
- [x] 스터디 목록 상단 액션(나의 스터디/참여하기/방 만들기) 모바일 줄바꿈/밀림 이슈 수정
- [x] 관련 단위 테스트 실패 케이스 2건 갱신
  - `CCSubmissionViewerModal.test.tsx`
  - `CCProblemCard.test.tsx`

## 🔗 관련 이슈
- Closes #117

## 🖼️ 스크린샷 (선택)
- 모바일 홈/스터디/문제집/리그 주요 화면 캡처 첨부 예정
- 문제집 상세/생성 모바일 전체화면 동작 캡처 첨부 예정

## 🧪 테스트 방법
- [x] 타입 체크
  - `pnpm --filter frontend type-check`
- [x] 실패 테스트 재검증
  - `pnpm --filter frontend test -- src/domains/study/tests/CCSubmissionViewerModal.test.tsx src/domains/study/tests/CCProblemCard.test.tsx`
- [ ] 모바일 실기기/에뮬레이터 시나리오 점검
  - 홈 진입 → AI 추천 문제(보러가기/풀러가기 분기)
  - 스터디방 입장/탭 전환/채팅
  - 문제집 상세 열기/닫기, 새 문제집 생성 및 문제 검색 추가
  - 랭킹/리그/검색 페이지 탐색

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가? (전체 스위트는 추가 확인 필요)

## 💬 리뷰어에게 (선택)
모바일 UX 의도는 “생산/관리 최소화 + 조회/참여 우선”입니다.  
특히 아래 3가지를 중점 확인 부탁드립니다.
1. 모바일 break point(768)에서 데스크탑/모바일 전환이 자연스러운지
2. 문제집 상세/생성 화면이 “모달”이 아닌 “모바일 페이지형”으로 체감되는지
3. AI 추천 문제 버튼이 모바일/데스크탑에서 의도한 흐름으로 분기되는지