### PR TITLE
fix: 노트북 분할 시 모바일 오인식과 반응형 레이아웃 문제 수정

### DIFF
--- a/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
@@ -18,7 +18,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { ChevronUp, ChevronDown, Lock, Plus } from 'lucide-react';
 import { toast } from 'sonner';
-import { useIsMobile } from '@/hooks/useIsMobile';
+import { useIsTouchMobile } from '@/hooks/useIsMobile';
 
 interface CCCenterPanelProps {
   ideContent?: ReactNode;
@@ -54,7 +54,7 @@ export function CCCenterPanel({
   onSettingsClick,
   className,
 }: CCCenterPanelProps) {
-  const isMobile = useIsMobile();
+  const isMobile = useIsTouchMobile();
 
   const getTemplateCode = (languageValue: string): string => {
     const normalized = languageValue.toLowerCase();

--- a/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
+++ b/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Copy, Moon, Sun, MessageSquare, Send, Eye, Archive, FileText, Minus, Plus, Play, TerminalSquare, Share2, Columns2 } from 'lucide-react';
+import { Copy, Moon, Sun, Send, Eye, Archive, Minus, Plus, Play, TerminalSquare, Share2, Columns2, MoreHorizontal } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { useIsMobile } from '@/hooks/useIsMobile';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useIsTouchMobile } from '@/hooks/useIsMobile';
 import {
   type ViewMode,
   type Participant,
@@ -73,7 +74,7 @@ export function CCIDEToolbar({
   showProblemSplit = false,
   problemExternalId,
 }: CCIDEToolbarProps) {
-  const isMobile = useIsMobile();
+  const isMobile = useIsTouchMobile();
   const isRealtime = viewMode === 'SPLIT_REALTIME';
   const isSaved = viewMode === 'SPLIT_SAVED';
   const isViewingOther = viewMode !== 'ONLY_MINE';
@@ -92,12 +93,13 @@ export function CCIDEToolbar({
     if (typeof window === 'undefined') return;
 
     const updateWindowSplitState = () => {
-      const availWidth = window.screen?.availWidth || window.innerWidth;
-      const currentWidth = window.outerWidth || window.innerWidth;
+      const currentInnerWidth = window.innerWidth;
+      const availWidth = window.screen?.availWidth || currentInnerWidth;
+      const currentWidth = window.outerWidth || currentInnerWidth;
       const widthRatio = currentWidth / Math.max(availWidth, 1);
 
-      // Split windows are usually near half width; keep tolerance for OS/browser chrome.
-      setIsSplitSizedWindow(widthRatio <= 0.67);
+      // Some environments report screen/outer sizes inconsistently, so we also use innerWidth.
+      setIsSplitSizedWindow(widthRatio <= 0.8 || currentInnerWidth <= 1360);
     };
 
     updateWindowSplitState();
@@ -109,6 +111,7 @@ export function CCIDEToolbar({
   const problemSplitTooltipLabel = isSplitSizedWindow
     ? '좌측 창에 현재 문제 열기'
     : '현재 문제를 분할 화면으로 열기';
+  const isCompactToolbar = isSplitSizedWindow && !isMobile;
 
   const handleDecreaseFont = () => {
     if (onFontSizeChange && fontSize > 5) {
@@ -212,114 +215,216 @@ export function CCIDEToolbar({
 
         <div className="flex items-center gap-2">
           {/* Font Size Control */}
-          <div className="flex items-center gap-1 mr-2 bg-muted/50 rounded-md p-1">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleDecreaseFont}
-                  disabled={disabled || fontSize <= 5}
-                  className="h-7 w-7 text-muted-foreground hover:text-foreground hover:bg-background/80"
-                >
-                  <Minus className="h-3 w-3" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>폰트 작게</TooltipContent>
-            </Tooltip>
+          {!isCompactToolbar && (
+            <>
+              <div className="flex items-center gap-1 mr-2 bg-muted/50 rounded-md p-1">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={handleDecreaseFont}
+                      disabled={disabled || fontSize <= 5}
+                      className="h-7 w-7 text-muted-foreground hover:text-foreground hover:bg-background/80"
+                    >
+                      <Minus className="h-3 w-3" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>폰트 작게</TooltipContent>
+                </Tooltip>
 
-            <input
-              type="number"
-              value={inputValue}
-              onChange={handleInputChange}
-              onBlur={handleBlur}
-              onKeyDown={handleKeyDownInput}
-              disabled={disabled}
-              className="w-10 text-center text-xs font-mono text-muted-foreground bg-transparent border-none focus:outline-none focus:text-foreground appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-              min={5}
-              max={40}
-            />
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleIncreaseFont}
-                  disabled={disabled || fontSize >= 40}
-                  className="h-7 w-7 text-muted-foreground hover:text-foreground hover:bg-background/80"
-                >
-                  <Plus className="h-3 w-3" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>폰트 크게</TooltipContent>
-            </Tooltip>
-          </div>
-
-          <div className="w-px h-4 bg-border mx-1" />
-
-          {showThemeToggle && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onThemeToggle}
+                <input
+                  type="number"
+                  value={inputValue}
+                  onChange={handleInputChange}
+                  onBlur={handleBlur}
+                  onKeyDown={handleKeyDownInput}
                   disabled={disabled}
-                  className="h-10 w-10 text-foreground hover:bg-accent border border-transparent hover:border-border transition-all"
-                >
-                  {theme === 'light' ? (
-                    <Moon className="h-[22px] w-[22px] stroke-[2px]" />
-                  ) : (
-                    <Sun className="h-[22px] w-[22px] stroke-[2px]" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>테마 변경</TooltipContent>
-            </Tooltip>
+                  className="w-10 text-center text-xs font-mono text-muted-foreground bg-transparent border-none focus:outline-none focus:text-foreground appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  min={5}
+                  max={40}
+                />
+
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={handleIncreaseFont}
+                      disabled={disabled || fontSize >= 40}
+                      className="h-7 w-7 text-muted-foreground hover:text-foreground hover:bg-background/80"
+                    >
+                      <Plus className="h-3 w-3" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>폰트 크게</TooltipContent>
+                </Tooltip>
+              </div>
+
+              <div className="w-px h-4 bg-border mx-1" />
+
+              {showThemeToggle && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={onThemeToggle}
+                      disabled={disabled}
+                      className="h-10 w-10 text-foreground hover:bg-accent border border-transparent hover:border-border transition-all"
+                    >
+                      {theme === 'light' ? (
+                        <Moon className="h-[22px] w-[22px] stroke-[2px]" />
+                      ) : (
+                        <Sun className="h-[22px] w-[22px] stroke-[2px]" />
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>테마 변경</TooltipContent>
+                </Tooltip>
+              )}
+
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={onCopy}
+                    disabled={disabled}
+                    className="h-10 w-10 text-foreground hover:bg-accent border border-transparent hover:border-border transition-all"
+                  >
+                    <Copy className="h-[22px] w-[22px] stroke-[2px]" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  코드 복사 <span className="ml-1 opacity-60 text-xs">Ctrl+C</span>
+                </TooltipContent>
+              </Tooltip>
+
+              {showChatRef && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={onRefChat}
+                      disabled={disabled}
+                      className="h-10 w-10 text-foreground hover:bg-accent border border-transparent hover:border-border transition-all"
+                    >
+                      <Share2 className="h-[20px] w-[20px] stroke-[2.5px]" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>내 풀이 채팅에 공유</TooltipContent>
+                </Tooltip>
+              )}
+            </>
           )}
 
-          {/* Copy */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={onCopy}
-                disabled={disabled}
-                className="h-10 w-10 text-foreground hover:bg-accent border border-transparent hover:border-border transition-all"
-              >
-                <Copy className="h-[22px] w-[22px] stroke-[2px]" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              코드 복사 <span className="ml-1 opacity-60 text-xs">Ctrl+C</span>
-            </TooltipContent>
-          </Tooltip>
+          {isCompactToolbar && (
+            <Popover>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      disabled={disabled}
+                      className="h-10 w-10 text-foreground hover:bg-accent border border-transparent hover:border-border transition-all"
+                    >
+                      <MoreHorizontal className="h-[20px] w-[20px] stroke-[2.2px]" />
+                    </Button>
+                  </PopoverTrigger>
+                </TooltipTrigger>
+                <TooltipContent>추가 도구</TooltipContent>
+              </Tooltip>
+              <PopoverContent align="end" className="w-56 p-2">
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center justify-between rounded-md border px-2 py-1.5">
+                    <span className="text-xs text-muted-foreground">폰트</span>
+                    <div className="flex items-center gap-1.5">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={handleDecreaseFont}
+                        disabled={disabled || fontSize <= 5}
+                        className="h-7 w-7"
+                      >
+                        <Minus className="h-3 w-3" />
+                      </Button>
+                      <span className="w-8 text-center text-xs font-mono text-muted-foreground">
+                        {fontSize}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={handleIncreaseFont}
+                        disabled={disabled || fontSize >= 40}
+                        className="h-7 w-7"
+                      >
+                        <Plus className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </div>
 
-          {/* Code Reference - Always available if enabled */}
-          {showChatRef && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onRefChat}
-                  disabled={disabled}
-                  className="h-10 w-10 text-foreground hover:bg-accent border border-transparent hover:border-border transition-all"
-                >
-                  <Share2 className="h-[20px] w-[20px] stroke-[2.5px]" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>내 풀이 채팅에 공유</TooltipContent>
-            </Tooltip>
+                  {showThemeToggle && (
+                    <Button
+                      variant="ghost"
+                      onClick={onThemeToggle}
+                      disabled={disabled}
+                      className="h-9 justify-start gap-2"
+                    >
+                      {theme === 'light' ? (
+                        <Moon className="h-4 w-4" />
+                      ) : (
+                        <Sun className="h-4 w-4" />
+                      )}
+                      <span className="text-sm">테마 변경</span>
+                    </Button>
+                  )}
+
+                  <Button
+                    variant="ghost"
+                    onClick={onCopy}
+                    disabled={disabled}
+                    className="h-9 justify-start gap-2"
+                  >
+                    <Copy className="h-4 w-4" />
+                    <span className="text-sm">코드 복사</span>
+                  </Button>
+
+                  {showChatRef && (
+                    <Button
+                      variant="ghost"
+                      onClick={onRefChat}
+                      disabled={disabled}
+                      className="h-9 justify-start gap-2"
+                    >
+                      <Share2 className="h-4 w-4" />
+                      <span className="text-sm">채팅에 공유</span>
+                    </Button>
+                  )}
+
+                  {showProblemSplit && !isViewingOther && !isMobile && (
+                    <Button
+                      variant="ghost"
+                      onClick={onOpenProblemSplit}
+                      disabled={disabled}
+                      className="h-9 justify-start gap-2"
+                    >
+                      <Columns2 className="h-4 w-4" />
+                      <span className="text-sm">{problemSplitButtonLabel}</span>
+                    </Button>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
           )}
 
           {/* Standard Tools (Hidden when Viewing Other) */}
           {!isViewingOther && (
             <>
               {/* Desktop-only Split Open */}
-              {showProblemSplit && !isMobile && (
+              {showProblemSplit && !isMobile && !isCompactToolbar && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
@@ -346,10 +451,13 @@ export function CCIDEToolbar({
                       variant="ghost"
                       onClick={onToggleConsole}
                       disabled={disabled}
-                      className="ml-1 gap-1.5 focus:ring-0 transition-all active:scale-95 px-3 h-10 text-muted-foreground hover:text-foreground"
+                      className={cn(
+                        'ml-1 gap-1.5 focus:ring-0 transition-all active:scale-95 h-10 text-muted-foreground hover:text-foreground',
+                        isCompactToolbar ? 'w-10 px-0' : 'px-3',
+                      )}
                     >
                       <TerminalSquare className="h-[18px] w-[18px]" />
-                      <span className="font-semibold text-sm">테스트 케이스</span>
+                      {!isCompactToolbar && <span className="font-semibold text-sm">테스트 케이스</span>}
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>테스트 케이스 편집</TooltipContent>
@@ -365,7 +473,10 @@ export function CCIDEToolbar({
                       variant="secondary"
                       onClick={onExecute}
                       disabled={disabled || isExecuting}
-                      className="ml-1 gap-1.5 focus:ring-0 shadow-sm transition-all active:scale-95 px-4 h-10 border border-border"
+                      className={cn(
+                        'ml-1 gap-1.5 focus:ring-0 shadow-sm transition-all active:scale-95 h-10 border border-border',
+                        isCompactToolbar ? 'px-3' : 'px-4',
+                      )}
                     >
                       <Play className={cn("h-4 w-4 stroke-[2.5px]", isExecuting && "animate-pulse")} />
                       <span className="font-bold text-sm">{isExecuting ? '실행중' : '실행'}</span>
@@ -383,7 +494,10 @@ export function CCIDEToolbar({
                       size="sm"
                       onClick={onSubmit}
                       disabled={disabled || isExecuting}
-                      className="ml-1 gap-1.5 bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm transition-all active:scale-95 px-4 h-10 border border-primary-foreground/10"
+                      className={cn(
+                        'ml-1 gap-1.5 bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm transition-all active:scale-95 h-10 border border-primary-foreground/10',
+                        isCompactToolbar ? 'px-3' : 'px-4',
+                      )}
                     >
                       <Send className="h-4 w-4 stroke-[2.5px]" />
                       <span className="font-bold text-sm">제출</span>

--- a/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
@@ -33,7 +33,7 @@ import { CCPreJoinModal } from '@/components/common/CCPreJoinModal';
 import { CCLiveKitWrapper } from './CCLiveKitWrapper';
 import { useStudyPresenceSync } from '@/domains/study/hooks/useStudyPresenceSync';
 import { useProblemDates } from '@/domains/study/hooks/useProblemDates';
-import { useIsMobile } from '@/hooks/useIsMobile';
+import { useIsTouchMobile } from '@/hooks/useIsMobile';
 
 function StudySocketInitiator({ studyId }: { studyId: number }) {
   const { user, checkAuth } = useAuthStore();
@@ -72,7 +72,7 @@ function StudyRoomContent({
   aiRecommendationRequestId: string | null;
 }) {
   const router = useRouter();
-  const isMobile = useIsMobile();
+  const isMobile = useIsTouchMobile();
   const { user } = useAuthStore();
   const { connected } = useSocketContext();
   const { localParticipant, isMicrophoneEnabled, isCameraEnabled } = useLocalParticipant();
@@ -914,7 +914,7 @@ function StudyRoomContent({
 export function CCStudyRoomClient(): React.ReactNode {
   const params = useParams();
   const searchParams = useSearchParams();
-  const isMobile = useIsMobile();
+  const isTouchMobile = useIsTouchMobile();
   const studyId = Number(params.id) || 0;
   const router = useRouter();
   const currentUserId = useRoomStore((state) => state.currentUserId);
@@ -1019,10 +1019,16 @@ export function CCStudyRoomClient(): React.ReactNode {
     return null;
   }
 
-  const shouldShowPreJoin = !isMobile && !isJoined;
+  const shouldShowPreJoin = !isTouchMobile && !isJoined;
 
   if (shouldShowPreJoin) {
-    return <CCPreJoinModal roomTitle={roomTitle} onJoin={handleJoin} skipExtensionCheck={isMobile} />;
+    return (
+      <CCPreJoinModal
+        roomTitle={roomTitle}
+        onJoin={handleJoin}
+        skipExtensionCheck={isTouchMobile}
+      />
+    );
   }
 
   return (

--- a/apps/frontend/src/domains/study/components/CCVideoGrid.tsx
+++ b/apps/frontend/src/domains/study/components/CCVideoGrid.tsx
@@ -5,6 +5,7 @@ import { CCVideoTile } from '@/domains/study/components/CCVideoTile';
 import { CCWhiteboardTile as WhiteboardTile } from '@/domains/study/components/CCWhiteboardTile';
 import { cn } from '@/lib/utils';
 import { apiFetch } from '@/lib/api';
+import { useIsTouchMobile } from '@/hooks/useIsMobile';
 import { useParticipants } from '@livekit/components-react';
 import { useMemo, useRef, type WheelEvent } from 'react';
 import { toast } from 'sonner';
@@ -17,6 +18,7 @@ interface CCVideoGridProps {
 
 export function CCVideoGrid({ onWhiteboardClick, className }: CCVideoGridProps) {
   const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const isTouchMobile = useIsTouchMobile();
   const roomId = useRoomStore((state) => state.roomId);
   const isWhiteboardActive = useRoomStore((state) => state.isWhiteboardActive);
   const participants = useParticipants();
@@ -141,6 +143,8 @@ export function CCVideoGrid({ onWhiteboardClick, className }: CCVideoGridProps) 
   };
 
   const handleWheelScroll = (e: WheelEvent<HTMLDivElement>) => {
+    if (isTouchMobile) return;
+
     const scroller = scrollerRef.current;
     if (!scroller) return;
 
@@ -150,6 +154,8 @@ export function CCVideoGrid({ onWhiteboardClick, className }: CCVideoGridProps) 
     scroller.scrollLeft += e.deltaY;
   };
 
+  const tileSizeClass = isTouchMobile ? 'w-full h-auto' : 'h-full w-auto';
+
   return (
     <div
       ref={scrollerRef}
@@ -157,12 +163,15 @@ export function CCVideoGrid({ onWhiteboardClick, className }: CCVideoGridProps) 
       data-tour="video-grid"
       className={cn(
         'border-b border-border bg-card p-3 pb-2 gap-2 content-start',
-        'grid grid-cols-2 overflow-y-auto overflow-x-hidden',
-        'md:flex md:flex-row md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden md:content-stretch',
+        isTouchMobile
+          ? 'grid grid-cols-2 overflow-y-auto overflow-x-hidden'
+          : 'flex flex-row flex-nowrap overflow-x-auto overflow-y-hidden content-stretch items-stretch',
         className,
       )}
     >
-      {isWhiteboardActive && selectedProblemTitle && <WhiteboardTile onClick={onWhiteboardClick} />}
+      {isWhiteboardActive && selectedProblemTitle && (
+        <WhiteboardTile onClick={onWhiteboardClick} className={tileSizeClass} />
+      )}
 
       {visibleLiveKitParticipants.map((participant) => {
         let userIdString = participant.identity;
@@ -179,6 +188,7 @@ export function CCVideoGrid({ onWhiteboardClick, className }: CCVideoGridProps) 
             isCurrentUser={participant.isLocal}
             displayName={storeParticipant?.nickname}
             onClick={() => void handleTileClick(participant.identity)}
+            className={tileSizeClass}
           />
         );
       })}
@@ -189,6 +199,7 @@ export function CCVideoGrid({ onWhiteboardClick, className }: CCVideoGridProps) 
           participant={p}
           isCurrentUser={p.id === currentUserId}
           onClick={() => void handleTileClick(String(p.id))}
+          className={tileSizeClass}
         />
       ))}
 

--- a/apps/frontend/src/hooks/useIsMobile.ts
+++ b/apps/frontend/src/hooks/useIsMobile.ts
@@ -2,22 +2,41 @@
 
 import { useEffect, useState } from 'react';
 
-export function useIsMobile(breakpoint = 768): boolean {
-  const getCurrentIsMobile = () => {
+function useMediaQuery(query: string): boolean {
+  const getMatches = () => {
     if (typeof window === 'undefined') return false;
-    return window.innerWidth < breakpoint;
+    return window.matchMedia(query).matches;
   };
 
-  const [isMobile, setIsMobile] = useState(getCurrentIsMobile);
+  const [matches, setMatches] = useState(getMatches);
 
   useEffect(() => {
-    const update = () => setIsMobile(getCurrentIsMobile());
+    if (typeof window === 'undefined') return;
 
-    update();
-    window.addEventListener('resize', update);
+    const mediaQuery = window.matchMedia(query);
+    const update = (event: MediaQueryListEvent) => setMatches(event.matches);
 
-    return () => window.removeEventListener('resize', update);
-  }, [breakpoint]);
+    setMatches(mediaQuery.matches);
 
-  return isMobile;
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', update);
+      return () => mediaQuery.removeEventListener('change', update);
+    }
+
+    mediaQuery.addListener(update);
+    return () => mediaQuery.removeListener(update);
+  }, [query]);
+
+  return matches;
+}
+
+const getMaxWidthQuery = (breakpoint: number) => `(max-width: ${Math.max(0, breakpoint - 0.02)}px)`;
+
+export function useIsMobile(breakpoint = 768): boolean {
+  return useMediaQuery(getMaxWidthQuery(breakpoint));
+}
+
+export function useIsTouchMobile(breakpoint = 768): boolean {
+  const query = `${getMaxWidthQuery(breakpoint)} and (hover: none) and (pointer: coarse)`;
+  return useMediaQuery(query);
 }


### PR DESCRIPTION
## 💡 의도 / 배경
노트북 분할 화면(예: `innerWidth=707`)에서 실제 데스크톱 환경임에도 모바일로 오인식되어,
스터디룸 핵심 기능(실행/제출/콘솔/영상 타일 반응)이 비정상 동작하는 문제를 해결했습니다.

## 🛠️ 작업 내용
- [x] 모바일 판정 로직 개선
- [x] `useIsMobile`를 `matchMedia` 기반으로 변경해 리사이즈 전환 안정화
- [x] `useIsTouchMobile` 추가 (`max-width + hover:none + pointer:coarse`)
- [x] 스터디룸/센터패널/툴바 모바일 분기를 터치 기준으로 정리
- [x] 분할 폭에서 IDE 툴바 컴팩트 모드(`더보기`) 적용
- [x] 비터치 분할 환경에서 `CCVideoGrid` 타일이 리사이즈에 즉시 반응하도록 레이아웃 분기 수정
- [x] 변경 파일
- [x] `CCCenterPanel.tsx`
- [x] `CCIDEToolbar.tsx`
- [x] `CCStudyRoomClient.tsx`
- [x] `CCVideoGrid.tsx`
- [x] `useIsMobile.ts`

## 🔗 관련 이슈
- Closes #126

## 🖼️ 스크린샷 (선택)
분할 화면(노트북) 기준 Before/After 캡처 첨부 예정

## 🧪 테스트 방법
- [x] `pnpm --filter frontend type-check`
- [x] 노트북 분할 화면(`innerWidth < 768`, 비터치)에서 스터디룸이 데스크톱 레이아웃으로 유지되는지 확인
- [x] 분할 상태에서 실행/제출/테스트 케이스 버튼 노출 및 동작 확인
- [x] 화상 영역 높이 조절 시 비디오 타일이 동적으로 재배치되는지 확인
- [x] 터치 모바일 환경에서 기존 모바일 UX 유지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
모바일 판정을 "폭 기준"과 "터치 디바이스 기준"으로 분리한 변경이라,
분할 노트북/태블릿/실기기 모바일 3가지 케이스를 중점적으로 확인 부탁드립니다.