### PR TITLE
feat: 모바일 ui 개선

### DIFF
--- a/apps/frontend/src/app/(main)/layout.tsx
+++ b/apps/frontend/src/app/(main)/layout.tsx
@@ -13,12 +13,16 @@ export default async function MainLayout({
   const user = await getMyProfile();
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex h-[100dvh] min-h-screen overflow-hidden lg:h-auto lg:min-h-screen lg:overflow-visible">
       <Sidebar user={user} />
-      <main className="flex-1 w-full max-w-7xl mx-auto px-4 lg:px-8 py-0 pb-20 lg:pb-0 lg:ml-[240px]">
-        {children}
-      </main>
-      <MobileBottomNav />
+      <div className="flex min-w-0 flex-1 flex-col lg:ml-[240px]">
+        <main className="flex-1 min-h-0 w-full max-w-7xl mx-auto overflow-y-auto px-4 py-0 lg:px-8 lg:overflow-visible">
+          {children}
+        </main>
+        <div className="shrink-0 lg:hidden">
+          <MobileBottomNav />
+        </div>
+      </div>
       <LeagueResultModal />
     </div>
   );

--- a/apps/frontend/src/components/UserIcon.tsx
+++ b/apps/frontend/src/components/UserIcon.tsx
@@ -26,7 +26,11 @@ export function UserIcon({
   // user 객체가 있으면 거기서 정보를 가져옴
   const finalNickname = nickname || user?.nickname;
   const userImage = user?.profileImg || user?.profileImage; // Handle both likely property names if types vary
-  const finalSrc = (src || userImage) as string;
+  const rawSrc = src ?? userImage;
+  const normalizedSrc = typeof rawSrc === 'string' ? rawSrc.trim() : '';
+  const hasValidSrc =
+    normalizedSrc.length > 0 && normalizedSrc !== 'null' && normalizedSrc !== 'undefined';
+  const fallbackLabel = finalNickname?.charAt(0)?.toUpperCase() || '?';
 
   return (
     <div
@@ -36,14 +40,18 @@ export function UserIcon({
       )}
       style={{ width: size, height: size }}
     >
-      <Image
-        src={finalSrc}
-        alt={finalNickname || 'User profile image'}
-        width={size}
-        height={size}
-        className="w-full h-full object-cover"
-        unoptimized={unoptimized}
-      />
+      {hasValidSrc ? (
+        <Image
+          src={normalizedSrc}
+          alt={finalNickname || 'User profile image'}
+          width={size}
+          height={size}
+          className="w-full h-full object-cover"
+          unoptimized={unoptimized}
+        />
+      ) : (
+        <span className="text-xs font-semibold text-muted-foreground">{fallbackLabel}</span>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
+++ b/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
@@ -21,8 +21,8 @@ export default function MobileBottomNav() {
   };
 
   return (
-    <div className="lg:hidden fixed inset-x-0 bottom-0 z-50 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80">
-      <nav className="mx-auto flex max-w-7xl items-center gap-1 overflow-x-auto px-2 py-2 no-scrollbar">
+    <div className="lg:hidden border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80">
+      <nav className="mx-auto flex max-w-7xl items-center gap-1 overflow-x-auto px-2 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] no-scrollbar">
         {MOBILE_ITEMS.map((item) => {
           const Icon = item.icon;
           const active = isItemActive(item.href);

--- a/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
@@ -16,6 +16,7 @@ import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
 import { apiFetch } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ChevronUp, ChevronDown, Lock, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import { useIsTouchMobile } from '@/hooks/useIsMobile';
@@ -44,6 +45,8 @@ interface SubmissionCommentItem {
   content: string;
   createdAt: string;
 }
+
+const FONT_SIZE_OPTIONS = [8, 9, 10, 11, 12, 14, 16, 18, 20, 22, 24, 26, 28, 36, 48, 72];
 
 export function CCCenterPanel({
   ideContent,
@@ -191,6 +194,8 @@ print("Hello World!")`;
 
   // Font Size State
   const [fontSize, setFontSize] = useState<number>(14);
+  const [fontSizeInput, setFontSizeInput] = useState<string>('14');
+  const [isFontSizeMenuOpen, setIsFontSizeMenuOpen] = useState(false);
 
   // Load font size from local storage on mount
   useEffect(() => {
@@ -206,6 +211,22 @@ print("Hello World!")`;
     setFontSize(newSize);
     localStorage.setItem('ide-font-size', newSize.toString());
   };
+
+  useEffect(() => {
+    setFontSizeInput(fontSize.toString());
+  }, [fontSize]);
+
+  const applyFontSizeInput = useCallback((rawValue: string) => {
+    const parsed = Number.parseInt(rawValue, 10);
+    if (Number.isNaN(parsed)) {
+      setFontSizeInput(fontSize.toString());
+      return;
+    }
+
+    const clamped = Math.max(5, Math.min(40, parsed));
+    handleFontSizeChange(clamped);
+    setFontSizeInput(clamped.toString());
+  }, [fontSize]);
 
   useEffect(() => {
     if (isMobile) {
@@ -1323,6 +1344,7 @@ print("Hello World!")`;
   const showRightPanel = isViewingOther || isWhiteboardVisible;
   const showVideoSection = !isMobile || mobileTab === 'video';
   const showProblemSection = !isMobile || mobileTab === 'code';
+  const showMobileConsoleReplacement = isMobile && isConsoleOpen && !isViewingOther;
   const isVideoGridCollapsed = !isMobile && isVideoGridFolded;
   const showMyIdePanel = !isMobile || !showRightPanel;
   const showViewerPanel = showRightPanel;
@@ -1913,12 +1935,20 @@ print("Hello World!")`;
                 void handleSubmit();
               }}
               // New Props for Execute
-              showExecute={!isViewingOther && !isMobile}
+              showExecute={!isViewingOther}
+              showConsoleToggle={!isMobile}
+              showFontSizeControl={false}
               isExecuting={isExecuting}
               onToggleConsole={() => setIsConsoleOpen((prev) => !prev)}
               onExecute={() => {
+                if (isMobile && !isConsoleOpen) {
+                  setIsConsoleOpen(true);
+                  window.requestAnimationFrame(() => {
+                    window.dispatchEvent(new CustomEvent('study-ide-execute-trigger'));
+                  });
+                  return;
+                }
                 if (!isConsoleOpen) setIsConsoleOpen(true);
-                // Console is now always mounted, so we can dispatch immediately
                 window.dispatchEvent(new CustomEvent('study-ide-execute-trigger'));
               }}
               // Toggles
@@ -1934,195 +1964,282 @@ print("Hello World!")`;
 
 
         {/* Editor Body Row */}
-        <div className="flex min-h-0 flex-1 min-w-0 relative flex-col">
-          <div className="flex min-h-0 flex-1 min-w-0 relative">
-            {/* Left IDE Panel (My Code) */}
-            {showMyIdePanel && (
-              <div
-                className={cn(
-                  'flex flex-1 min-w-0 flex-col',
-                  !isMobile && showRightPanel && 'border-r border-border',
-                )}
-              >
+        {showMobileConsoleReplacement ? (
+          <div className="flex min-h-0 flex-1 min-w-0">
+            <CCConsolePanel
+              roomId={roomId}
+              problemId={selectedStudyProblemId}
+              isOpen={isConsoleOpen}
+              onClose={() => setIsConsoleOpen(false)}
+              onExecute={handleExecuteWrapper}
+              isExecuting={isExecuting}
+              executionResult={executionResult}
+            />
+          </div>
+        ) : (
+          <div className="flex min-h-0 flex-1 min-w-0 relative flex-col">
+            <div className="flex min-h-0 flex-1 min-w-0 relative">
+              {/* Left IDE Panel (My Code) */}
+              {showMyIdePanel && (
+                <div
+                  className={cn(
+                    'flex flex-1 min-w-0 flex-col',
+                    !isMobile && showRightPanel && 'border-r border-border',
+                  )}
+                >
                 <div className="h-8 shrink-0 border-b border-border bg-muted/35 px-3 text-xs text-muted-foreground">
-                  <div className="flex h-full items-center gap-2">
-                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                    <span className="shrink-0">내 문제</span>
-                    <span className="truncate text-foreground/90" title={myProblemLabel}>
-                      {myProblemLabel}
-                    </span>
+                  <div className="flex h-full items-center justify-between gap-2">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                      <span className="shrink-0">내 문제</span>
+                      <span className="truncate text-foreground/90" title={myProblemLabel}>
+                        {myProblemLabel}
+                      </span>
+                    </div>
+                    <div
+                      className={cn(
+                        'flex shrink-0 items-center overflow-hidden rounded-sm border border-border/80 bg-card',
+                        isMobile ? 'h-5' : 'h-6',
+                      )}
+                    >
+                      <input
+                        inputMode="numeric"
+                        value={fontSizeInput}
+                        onChange={(event) => setFontSizeInput(event.target.value)}
+                        onBlur={(event) => applyFontSizeInput(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            applyFontSizeInput((event.target as HTMLInputElement).value);
+                            (event.target as HTMLInputElement).blur();
+                          }
+                        }}
+                        className={cn(
+                          'border-r border-border/70 bg-background/60 text-center font-mono text-foreground outline-none',
+                          isMobile ? 'h-full w-8 text-[10px]' : 'h-full w-9 text-xs',
+                        )}
+                      />
+                      <Popover open={isFontSizeMenuOpen} onOpenChange={setIsFontSizeMenuOpen}>
+                        <PopoverTrigger asChild>
+                          <button
+                            type="button"
+                            className={cn(
+                              'flex h-full items-center justify-center border-l border-border/60 bg-muted/40 hover:bg-muted/70',
+                              isMobile ? 'w-4' : 'w-5',
+                            )}
+                            aria-label="폰트 크기 목록 열기"
+                          >
+                            <ChevronDown className={cn(isMobile ? 'h-2.5 w-2.5' : 'h-3 w-3')} />
+                          </button>
+                        </PopoverTrigger>
+                        <PopoverContent
+                          align="end"
+                          side="bottom"
+                          sideOffset={2}
+                          className={cn('w-[68px] p-1', isMobile && 'w-[62px]')}
+                        >
+                          <div className="max-h-56 overflow-y-auto">
+                            {FONT_SIZE_OPTIONS.map((option) => (
+                              <button
+                                key={option}
+                                type="button"
+                                onClick={() => {
+                                  handleFontSizeChange(option);
+                                  setFontSizeInput(String(option));
+                                  setIsFontSizeMenuOpen(false);
+                                }}
+                                className={cn(
+                                  'w-full rounded-sm px-1.5 py-1 text-center font-mono text-xs text-foreground/80 hover:bg-muted',
+                                  fontSize === option && 'bg-muted font-semibold text-foreground',
+                                )}
+                              >
+                                {option}
+                              </button>
+                            ))}
+                          </div>
+                        </PopoverContent>
+                      </Popover>
+                    </div>
                   </div>
                 </div>
-                <div className="relative min-h-0 flex-1">
-                  {ideContent ?? (
-                    <IDEPanel
-                      ref={leftPanelRef}
-                      editorId="my-editor"
-                      language={language}
-                      onLanguageChange={handleLanguageChange}
-                      theme={theme}
-                      fontSize={fontSize}
-                      hideToolbar // Pass this so it doesn't render double toolbar
-                      onFontSizeChange={handleFontSizeChange}
-                      onCodeChange={handleCodeChange}
-                      restoredCode={restoredCode}
-                      restoreVersion={restoreVersion}
-                    />
-                  )}
+                  <div className="relative min-h-0 flex-1">
+                    {ideContent ?? (
+                      <IDEPanel
+                        ref={leftPanelRef}
+                        editorId="my-editor"
+                        language={language}
+                        onLanguageChange={handleLanguageChange}
+                        theme={theme}
+                        fontSize={fontSize}
+                        hideToolbar // Pass this so it doesn't render double toolbar
+                        onFontSizeChange={handleFontSizeChange}
+                        onCodeChange={handleCodeChange}
+                        restoredCode={restoredCode}
+                        restoreVersion={restoreVersion}
+                      />
+                    )}
 
-                  {isHydratingDraft && !!selectedStudyProblemId && (
-                    <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/70 backdrop-blur-sm">
-                      <p className="text-sm font-medium text-muted-foreground">Loading problem...</p>
-                    </div>
-                  )}
-
-                  {/* [New] Overlay if no problem is selected and not viewing other */}
-                  {!selectedProblemTitle && !isViewingOther && !isWhiteboardVisible && (
-                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-background/50 backdrop-blur-sm">
-                      <Lock className="h-8 w-8 text-muted-foreground mb-2" />
-                      <p className="text-sm font-medium text-muted-foreground">
-                        좌측 목록에서 문제를 선택해주세요
-                      </p>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-            {/* Right Panel: Whiteboard OR Other's Code */}
-            {showViewerPanel && (
-              <div className="flex min-w-0 flex-1 flex-col">
-                {isWhiteboardVisible ? (
-                  <WhiteboardPanel className="border-l-2 border-rose-400" />
-                ) : (
-                  <>
-                    <div className="h-8 shrink-0 border-b border-border bg-muted/35 px-3 text-xs text-muted-foreground">
-                      <div className="flex h-full items-center justify-between gap-2">
-                        <div className="flex min-w-0 items-center gap-2">
-                          <span className="inline-block h-1.5 w-1.5 rounded-full bg-pink-500" />
-                          <span className="shrink-0">
-                            {viewMode === 'SPLIT_SAVED' ? savedCodePanelLabel : '상대 문제'}
-                          </span>
-                          <span className="truncate text-foreground/90" title={otherProblemLabel}>
-                            {otherProblemLabel}
-                          </span>
-                        </div>
-                        {isMobile && isViewingOther && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-6 shrink-0 px-2 text-[11px]"
-                            onClick={() => {
-                              resetToOnlyMine();
-                              setMobileTab('code');
-                            }}
-                          >
-                            내 코드로 돌아가기
-                          </Button>
-                        )}
+                    {isHydratingDraft && !!selectedStudyProblemId && (
+                      <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/70 backdrop-blur-sm">
+                        <p className="text-sm font-medium text-muted-foreground">Loading problem...</p>
                       </div>
-                    </div>
-                    {viewMode === 'SPLIT_SAVED' ? (
-                      <div className="min-h-0 flex-1 flex flex-col">
-                        <div className="relative min-h-0 flex-1">
-                          <IDEPanel
-                            key={`${viewMode}-${targetSubmissionId || 'none'}`}
-                            editorId="other-editor"
-                            readOnly
-                            hideToolbar
-                            initialCode={targetSubmission?.code}
-                            language={targetSubmission?.language}
-                            theme={theme}
-                            fontSize={fontSize}
-                            onFontSizeChange={handleFontSizeChange}
-                            onEditorMount={handleSavedEditorMount}
-                            borderColorClass="border-indigo-400"
-                          />
-                          {hoveredLineForAdd && (
-                            <button
-                              type="button"
-                              title={`L${hoveredLineForAdd}에 인라인 댓글 추가`}
-                              className="absolute z-[80] flex h-5 w-5 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-md ring-1 ring-primary/30 hover:opacity-90"
-                              style={{ top: hoverAddButtonTop, left: hoverAddButtonLeft }}
-                              onMouseDown={(event) => {
-                                event.stopPropagation();
-                              }}
-                              onMouseEnter={() => {
-                                isHoveringAddButtonRef.current = true;
-                                clearHoverHideTimer();
-                              }}
-                              onMouseLeave={() => {
-                                isHoveringAddButtonRef.current = false;
-                                hideHoverAddButton();
-                              }}
+                    )}
+
+                    {/* [New] Overlay if no problem is selected and not viewing other */}
+                    {!selectedProblemTitle && !isViewingOther && !isWhiteboardVisible && (
+                      <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-background/50 backdrop-blur-sm">
+                        <Lock className="h-8 w-8 text-muted-foreground mb-2" />
+                        <p className="text-sm font-medium text-muted-foreground">
+                          좌측 목록에서 문제를 선택해주세요
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+              {/* Right Panel: Whiteboard OR Other's Code */}
+              {showViewerPanel && (
+                <div className="flex min-w-0 flex-1 flex-col">
+                  {isWhiteboardVisible ? (
+                    <WhiteboardPanel className="border-l-2 border-rose-400" />
+                  ) : (
+                    <>
+                      <div className="h-8 shrink-0 border-b border-border bg-muted/35 px-3 text-xs text-muted-foreground">
+                        <div className="flex h-full items-center justify-between gap-2">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <span className="inline-block h-1.5 w-1.5 rounded-full bg-pink-500" />
+                            <span className="shrink-0">
+                              {viewMode === 'SPLIT_SAVED' ? savedCodePanelLabel : '상대 문제'}
+                            </span>
+                            <span className="truncate text-foreground/90" title={otherProblemLabel}>
+                              {otherProblemLabel}
+                            </span>
+                          </div>
+                          {isMobile && isViewingOther && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-6 shrink-0 px-2 text-[11px]"
                               onClick={() => {
-                                setInlineDraftLine(hoveredLineForAdd);
-                                setInlineDraftParentId(null);
-                                setInlineEditingCommentId(null);
-                                setInlineEditingContent('');
-                                focusSavedLine(hoveredLineForAdd);
+                                resetToOnlyMine();
+                                setMobileTab('code');
                               }}
                             >
-                              <Plus className="h-3.5 w-3.5" />
-                            </button>
+                              내 코드로 돌아가기
+                            </Button>
                           )}
                         </div>
                       </div>
-                    ) : (
-                      <div className="min-h-0 flex-1">
-                        <IDEPanel
-                          key={viewMode}
-                          editorId="other-editor"
-                          readOnly
-                          hideToolbar
-                          initialCode={realtimeCode}
-                          language={realtimeLanguage}
-                          theme={theme}
-                          fontSize={fontSize}
-                          onFontSizeChange={handleFontSizeChange}
-                          borderColorClass="border-pink-400"
-                        />
-                      </div>
-                    )}
-                  </>
+                      {viewMode === 'SPLIT_SAVED' ? (
+                        <div className="min-h-0 flex-1 flex flex-col">
+                          <div className="relative min-h-0 flex-1">
+                            <IDEPanel
+                              key={`${viewMode}-${targetSubmissionId || 'none'}`}
+                              editorId="other-editor"
+                              readOnly
+                              hideToolbar
+                              initialCode={targetSubmission?.code}
+                              language={targetSubmission?.language}
+                              theme={theme}
+                              fontSize={fontSize}
+                              onFontSizeChange={handleFontSizeChange}
+                              onEditorMount={handleSavedEditorMount}
+                              borderColorClass="border-indigo-400"
+                            />
+                            {hoveredLineForAdd && (
+                              <button
+                                type="button"
+                                title={`L${hoveredLineForAdd}에 인라인 댓글 추가`}
+                                className="absolute z-[80] flex h-5 w-5 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-md ring-1 ring-primary/30 hover:opacity-90"
+                                style={{ top: hoverAddButtonTop, left: hoverAddButtonLeft }}
+                                onMouseDown={(event) => {
+                                  event.stopPropagation();
+                                }}
+                                onMouseEnter={() => {
+                                  isHoveringAddButtonRef.current = true;
+                                  clearHoverHideTimer();
+                                }}
+                                onMouseLeave={() => {
+                                  isHoveringAddButtonRef.current = false;
+                                  hideHoverAddButton();
+                                }}
+                                onClick={() => {
+                                  setInlineDraftLine(hoveredLineForAdd);
+                                  setInlineDraftParentId(null);
+                                  setInlineEditingCommentId(null);
+                                  setInlineEditingContent('');
+                                  focusSavedLine(hoveredLineForAdd);
+                                }}
+                              >
+                                <Plus className="h-3.5 w-3.5" />
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="min-h-0 flex-1">
+                          <IDEPanel
+                            key={viewMode}
+                            editorId="other-editor"
+                            readOnly
+                            hideToolbar
+                            initialCode={realtimeCode}
+                            language={realtimeLanguage}
+                            theme={theme}
+                            fontSize={fontSize}
+                            onFontSizeChange={handleFontSizeChange}
+                            borderColorClass="border-pink-400"
+                          />
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Console Overlay Drawer (Desktop) */}
+            {!isViewingOther && !isMobile && (
+              <div
+                style={{ height: isConsoleOpen ? consoleHeight : 0, opacity: isConsoleOpen ? 1 : 0 }}
+                className={cn(
+                  "absolute bottom-0 left-0 right-0 z-30 transition-[height,opacity] duration-300 ease-in-out border-t border-border shadow-[0_-10px_40px_-15px_rgba(0,0,0,0.3)] bg-background flex flex-col items-stretch justify-start",
+                  !isConsoleOpen && "pointer-events-none"
                 )}
+              >
+                <div
+                  className="absolute top-0 left-0 right-0 h-1.5 cursor-row-resize bg-transparent hover:bg-primary/50 active:bg-primary z-40 transition-colors"
+                  onMouseDown={startResizingConsole}
+                />
+
+                <div className="flex-1 w-full min-h-0 relative h-full">
+                  <CCConsolePanel
+                    roomId={roomId}
+                    problemId={selectedStudyProblemId}
+                    isOpen={isConsoleOpen} // Keep mounted, just manage visibility
+                    onClose={() => setIsConsoleOpen(false)}
+                    onExecute={handleExecuteWrapper}
+                    isExecuting={isExecuting}
+                    executionResult={executionResult}
+                  />
+                </div>
               </div>
             )}
           </div>
-
-          {/* Console Overlay Drawer */}
-          {!isViewingOther && !isMobile && (
-            <div
-              style={{ height: isConsoleOpen ? consoleHeight : 0, opacity: isConsoleOpen ? 1 : 0 }}
-              className={cn(
-                "absolute bottom-0 left-0 right-0 z-30 transition-[height,opacity] duration-300 ease-in-out border-t border-border shadow-[0_-10px_40px_-15px_rgba(0,0,0,0.3)] bg-background flex flex-col items-stretch justify-start",
-                !isConsoleOpen && "pointer-events-none"
-              )}
-            >
-              <div className="absolute top-0 left-0 right-0 h-1.5 cursor-row-resize bg-transparent hover:bg-primary/50 active:bg-primary z-40 transition-colors" onMouseDown={startResizingConsole} />
-
-              <div className="flex-1 w-full min-h-0 relative h-full">
-                <CCConsolePanel
-                  roomId={roomId}
-                  problemId={selectedStudyProblemId}
-                  isOpen={isConsoleOpen} // Keep mounted, just manage visibility
-                  onClose={() => setIsConsoleOpen(false)}
-                  onExecute={handleExecuteWrapper}
-                  isExecuting={isExecuting}
-                  executionResult={executionResult}
-                />
-              </div>
-            </div>
-          )}
-        </div>
+        )}
       </div>
       )}
 
       {/* Control Bar */}
+      {isMobile && <div aria-hidden className="h-13 shrink-0" />}
       <ControlBar
         onMicToggle={onMicToggle}
         onVideoToggle={onVideoToggle}
         onWhiteboardToggle={handleWhiteboardToggleWrapper}
         onSettingsClick={onSettingsClick}
+        className={cn(
+          isMobile &&
+            'fixed inset-x-0 bottom-[calc(64px+env(safe-area-inset-bottom))] mb-1 z-[55] shadow-[0_-8px_24px_-16px_rgba(0,0,0,0.4)]',
+        )}
       />
     </div>
   );

--- a/apps/frontend/src/domains/study/components/CCControlBar.tsx
+++ b/apps/frontend/src/domains/study/components/CCControlBar.tsx
@@ -51,19 +51,19 @@ export function CCControlBar({
     <TooltipProvider>
       <div
         className={cn(
-          'relative flex h-14 items-center justify-center border-t border-border bg-card px-4',
+          'relative flex h-13 items-center justify-center border-t border-border bg-card px-3',
           className,
         )}
       >
         {/* Center Controls - Media */}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-3">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
                 className={cn(
-                  'h-12 w-12 rounded-full border border-white/10 shadow-sm transition-all hover:scale-105 active:scale-95',
+                  'h-11 w-11 rounded-full border border-white/10 shadow-sm transition-all hover:scale-105 active:scale-95',
                   isMuted
                     ? 'bg-muted text-muted-foreground hover:bg-muted/80'
                     : 'bg-primary text-primary-foreground hover:bg-primary/90',
@@ -88,7 +88,7 @@ export function CCControlBar({
                 variant="ghost"
                 size="icon"
                 className={cn(
-                  'h-12 w-12 rounded-full border border-white/10 shadow-sm transition-all hover:scale-105 active:scale-95',
+                  'h-11 w-11 rounded-full border border-white/10 shadow-sm transition-all hover:scale-105 active:scale-95',
                   isVideoOff
                     ? 'bg-muted text-muted-foreground hover:bg-muted/80'
                     : 'bg-primary text-primary-foreground hover:bg-primary/90',
@@ -113,7 +113,7 @@ export function CCControlBar({
                 variant={isWhiteboardActive ? 'default' : 'ghost'}
                 size="icon"
                 className={cn(
-                  'h-12 w-12 rounded-full border border-white/10 shadow-sm transition-all hover:scale-105 active:scale-95',
+                  'h-11 w-11 rounded-full border border-white/10 shadow-sm transition-all hover:scale-105 active:scale-95',
                   isWhiteboardActive
                     ? 'bg-primary text-primary-foreground hover:bg-primary/90'
                     : 'bg-muted text-muted-foreground hover:bg-muted/80',
@@ -133,7 +133,7 @@ export function CCControlBar({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-12 w-12 rounded-full bg-muted text-muted-foreground hover:bg-muted/90 border border-white/10 shadow-sm transition-all hover:scale-105 active:scale-95"
+                className="h-11 w-11 rounded-full bg-muted text-muted-foreground hover:bg-muted/90 border border-white/10 shadow-sm transition-all hover:scale-105 active:scale-95"
                 onClick={handleSettingsClick}
               >
                 <Settings className="h-5 w-5" strokeWidth={2.25} />

--- a/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
+++ b/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
@@ -23,6 +23,8 @@ export interface CCIDEToolbarProps {
   fontSize?: number;
   showSubmit?: boolean;
   showExecute?: boolean;
+  showConsoleToggle?: boolean;
+  showFontSizeControl?: boolean;
   isExecuting?: boolean;
   showChatRef?: boolean;
   showThemeToggle?: boolean;
@@ -53,6 +55,8 @@ export function CCIDEToolbar({
   fontSize = 14,
   showSubmit = true,
   showExecute = false,
+  showConsoleToggle = true,
+  showFontSizeControl = true,
   isExecuting = false,
   showChatRef = true,
   showThemeToggle = true,
@@ -215,7 +219,7 @@ export function CCIDEToolbar({
 
         <div className="flex items-center gap-2">
           {/* Font Size Control */}
-          {!isCompactToolbar && (
+          {!isCompactToolbar && showFontSizeControl && (
             <>
               <div className="flex items-center gap-1 mr-2 bg-muted/50 rounded-md p-1">
                 <Tooltip>
@@ -262,7 +266,11 @@ export function CCIDEToolbar({
               </div>
 
               <div className="w-px h-4 bg-border mx-1" />
+            </>
+          )}
 
+          {!isCompactToolbar && (
+            <>
               {showThemeToggle && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -443,7 +451,7 @@ export function CCIDEToolbar({
               )}
 
               {/* Console Toggle */}
-              {showExecute && (
+              {showExecute && showConsoleToggle && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button

--- a/apps/frontend/src/domains/study/components/CCStudyHeader.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyHeader.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useStudyHeader } from '@/domains/study/hooks/useStudyHeader';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { ArrowLeft, Copy, Settings } from 'lucide-react';
+import { ArrowLeft, Copy, Settings, ListTodo, MessageSquare } from 'lucide-react';
 import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
 import { CCInviteModal } from './CCInviteModal';
 import { CCStudySettingsModal } from './CCStudySettingsModal';
@@ -14,6 +14,11 @@ interface CCStudyHeaderProps {
   onAddProblem?: (title: string, number: number, tags?: string[]) => Promise<void>;
   onInvite?: () => void;
   onSettings?: () => void;
+  isLeftPanelFolded?: boolean;
+  isRightPanelFolded?: boolean;
+  onToggleLeftPanel?: () => void;
+  onToggleRightPanel?: () => void;
+  panelToggleMode?: 'exclusive' | 'independent';
   className?: string;
   selectedDate: Date;
   onDateChange: (date: Date) => void;
@@ -23,6 +28,11 @@ export function CCStudyHeader({
   onBack,
   onInvite,
   onSettings,
+  isLeftPanelFolded,
+  isRightPanelFolded,
+  onToggleLeftPanel,
+  onToggleRightPanel,
+  panelToggleMode = 'exclusive',
   className,
 }: CCStudyHeaderProps): React.ReactElement {
   const { roomTitle, whiteboardMessage, isWhiteboardActive, isOwner } = useStudyHeader();
@@ -197,6 +207,12 @@ export function CCStudyHeader({
 
   const activeStep = guideSteps[guideStepIndex];
   const totalSteps = guideSteps.length || 1;
+  const canTogglePanels =
+    typeof isLeftPanelFolded === 'boolean' &&
+    typeof isRightPanelFolded === 'boolean' &&
+    onToggleLeftPanel &&
+    onToggleRightPanel;
+  const isExclusivePanelToggle = panelToggleMode === 'exclusive';
 
   return (
     <div className={cn('flex h-14 items-center justify-between px-3 lg:px-4', className)}>
@@ -208,16 +224,16 @@ export function CCStudyHeader({
 
         <h1 className="text-base lg:text-lg font-semibold truncate">{roomTitle}</h1>
 
-        <div className="mx-2 h-6 w-px bg-border hidden lg:block" />
+        <div className="mx-2 hidden h-4 w-px bg-border/70 md:block" />
 
         <Button
           variant="ghost"
           size="sm"
-          className="hidden lg:inline-flex gap-2 text-muted-foreground hover:text-foreground"
+          className="hidden md:inline-flex h-8 gap-2 px-2 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
           onClick={() => setIsGuideOpen(true)}
           data-tour="manual-button"
         >
-          <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-border text-xs font-semibold">
+          <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-border/70 text-xs font-semibold">
             ?
           </span>
           스터디 매뉴얼
@@ -232,12 +248,80 @@ export function CCStudyHeader({
       )}
 
       {/* Right Section */}
-      <div className="flex items-center gap-1 lg:gap-2">
+      <div className="flex items-center gap-1.5 lg:gap-2">
+        {canTogglePanels &&
+          (isExclusivePanelToggle ? (
+            <div className="flex items-center gap-1 rounded-md border border-border/70 bg-muted/20 px-1 py-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onToggleLeftPanel}
+                className={cn(
+                  'h-8 gap-1.5 px-2 text-xs font-medium',
+                  !isLeftPanelFolded
+                    ? 'bg-primary/10 text-primary hover:bg-primary/15'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                title={!isLeftPanelFolded ? '문제목록 패널 닫기' : '문제목록 패널 열기'}
+              >
+                <ListTodo className="h-4 w-4" />
+                <span className="hidden xl:inline">문제목록</span>
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onToggleRightPanel}
+                className={cn(
+                  'h-8 gap-1.5 px-2 text-xs font-medium',
+                  !isRightPanelFolded
+                    ? 'bg-primary/10 text-primary hover:bg-primary/15'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                title={!isRightPanelFolded ? '채팅 패널 닫기' : '채팅 패널 열기'}
+              >
+                <MessageSquare className="h-4 w-4" />
+                <span className="hidden xl:inline">채팅</span>
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onToggleLeftPanel}
+                className={cn(
+                  'h-8 gap-1.5 px-2 text-xs font-medium',
+                  !isLeftPanelFolded
+                    ? 'bg-primary/10 text-primary hover:bg-primary/15'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                title={!isLeftPanelFolded ? '문제목록 패널 닫기' : '문제목록 패널 열기'}
+              >
+                <ListTodo className="h-4 w-4" />
+                <span className="hidden xl:inline">문제목록</span>
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onToggleRightPanel}
+                className={cn(
+                  'h-8 gap-1.5 px-2 text-xs font-medium',
+                  !isRightPanelFolded
+                    ? 'bg-primary/10 text-primary hover:bg-primary/15'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                title={!isRightPanelFolded ? '채팅 패널 닫기' : '채팅 패널 열기'}
+              >
+                <MessageSquare className="h-4 w-4" />
+                <span className="hidden xl:inline">채팅</span>
+              </Button>
+            </div>
+          ))}
         <Button
-          variant="outline"
+          variant="ghost"
           size="sm"
           onClick={onInvite}
-          className="gap-2 font-normal"
+          className="h-8 gap-1.5 px-2 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
           data-tour="invite-button"
         >
           <Copy className="h-4 w-4" />
@@ -246,10 +330,10 @@ export function CCStudyHeader({
 
         {isOwner && (
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
             onClick={onSettings}
-            className="hidden lg:inline-flex gap-2 font-normal"
+            className="hidden h-8 gap-1.5 px-2 text-muted-foreground hover:bg-muted/40 hover:text-foreground lg:inline-flex"
             title="스터디 설정"
             data-tour="settings-button"
           >

--- a/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
@@ -174,7 +174,11 @@ function StudyRoomContent({
     if (typeof window === 'undefined') return;
 
     const handleResize = () => {
-      setIsCompact(window.innerWidth < 1200);
+      const availWidth = window.screen?.availWidth || window.innerWidth;
+      const currentWidth = window.outerWidth || window.innerWidth;
+      const widthRatio = currentWidth / Math.max(availWidth, 1);
+      // Split window mode: use window-to-screen width ratio.
+      setIsCompact(widthRatio <= 0.8);
     };
 
     // Initial check
@@ -184,83 +188,13 @@ function StudyRoomContent({
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  // Enforce mutual exclusion when isCompact is true
+  // In split mode, sidebars are mutually exclusive.
   useEffect(() => {
     if (!isCompact) return;
-
-    // If both are open (e.g. from resize), close right panel by default
     if (!isLeftPanelFolded && !isRightPanelFolded) {
       setIsRightPanelFolded(true);
     }
   }, [isCompact, isLeftPanelFolded, isRightPanelFolded, setIsRightPanelFolded]);
-
-  // Listener for Left Panel opening
-  useEffect(() => {
-    if (isCompact && !isLeftPanelFolded && !isRightPanelFolded) {
-      // logic already handled by above effect
-    }
-    // But we need to respond to user action of "Opening Left" -> "Close Right"
-    // The state change happens before effect.
-    // If Left became Open (false), and Right was Open (false) -> the above logic catches it.
-
-    // What if Left becomes Open, and Right IS Open? -> Both Open -> Above catches it.
-    // What if Right becomes Open, and Left IS Open? -> Both Open -> Above catches it.
-
-    // The issue with the previous code was:
-    // useEffect 1: if (!isLeftPanelFolded) setRight(true)
-    // useEffect 2: if (!isRightPanelFolded) setLeft(true)
-
-    // Example: User opens Left. isLeft=false. Effect 1 runs -> setRight(true).
-    // isRight becomes true. Effect 2 checks !isRight (false), does nothing. Safe.
-
-    // Example: User opens Right. isRight=false. Effect 2 runs -> setLeft(true).
-    // isLeft becomes true. Effect 1 checks !isLeft (false), does nothing. Safe.
-
-    // So actually the previous logic was mostly fine, BUT it didn't distinguish *which one* triggered it.
-    // It's better to keep it simple. As long as "Both Open" -> "Close One", we are safe.
-    // BUT user wants "Open Left -> Close Right" AND "Open Right -> Close Left".
-    // "Both Open" state only happens for a split second or on resize.
-
-    // Let's stick to the simple "Both Open" check.
-    // However, we want to know *which one* was specifically opened to close the *other*.
-    // Zustand setters don't tell us who called them.
-    // If we rely on "Both Open", we need a default victim (e.g. Right).
-    // But if user explicitly opens Right, validly dragging it out, we don't want it to immediately close because Left was open.
-    // We want Left to close.
-
-    // To do this reactively without action hooks is hard.
-    // We'd need previous state to know which one changed.
-    // Let's use a ref to track previous values.
-  }, []);
-
-  // Use refs to track previous state for directionality
-  const prevLeftFolded = useRef(isLeftPanelFolded);
-  const prevRightFolded = useRef(isRightPanelFolded);
-
-  useEffect(() => {
-    if (!isCompact) {
-      prevLeftFolded.current = isLeftPanelFolded;
-      prevRightFolded.current = isRightPanelFolded;
-      return;
-    }
-
-    const leftOpened = prevLeftFolded.current && !isLeftPanelFolded;
-    const rightOpened = prevRightFolded.current && !isRightPanelFolded;
-
-    if (leftOpened && !isRightPanelFolded) {
-      setIsRightPanelFolded(true);
-    } else if (rightOpened && !isLeftPanelFolded) {
-      setIsLeftPanelFolded(true);
-    }
-
-    // Just in case both are somehow open (resize), fallback to closing right
-    if (!isLeftPanelFolded && !isRightPanelFolded && !leftOpened && !rightOpened) {
-      setIsRightPanelFolded(true);
-    }
-
-    prevLeftFolded.current = isLeftPanelFolded;
-    prevRightFolded.current = isRightPanelFolded;
-  }, [isCompact, isLeftPanelFolded, isRightPanelFolded, setIsLeftPanelFolded, setIsRightPanelFolded]);
 
   useEffect(() => {
     const handleOpenCommentsPanel = (event: Event) => {
@@ -627,12 +561,14 @@ function StudyRoomContent({
   };
 
   const handleToggleLeftPanel = (): void => {
+    if (isCompact && isLeftPanelFolded && !isRightPanelFolded) {
+      setIsRightPanelFolded(true);
+    }
     setIsLeftPanelFolded(!isLeftPanelFolded);
   };
 
   const handleToggleRightPanel = (): void => {
-    // Close left panel when opening right panel (symmetric to handleToggleLeftPanel behavior)
-    if (isRightPanelFolded && !isLeftPanelFolded) {
+    if (isCompact && isRightPanelFolded && !isLeftPanelFolded) {
       setIsLeftPanelFolded(true);
     }
     setIsRightPanelFolded(!isRightPanelFolded);
@@ -861,6 +797,11 @@ function StudyRoomContent({
               onAddProblem={handleAddProblem}
               onInvite={handleInvite}
               onSettings={handleSettings}
+              isLeftPanelFolded={isLeftPanelFolded}
+              isRightPanelFolded={isRightPanelFolded}
+              onToggleLeftPanel={handleToggleLeftPanel}
+              onToggleRightPanel={handleToggleRightPanel}
+              panelToggleMode="exclusive"
               selectedDate={selectedDate}
               onDateChange={handleDateChange}
             />
@@ -885,6 +826,11 @@ function StudyRoomContent({
               onAddProblem={handleAddProblem}
               onInvite={handleInvite}
               onSettings={handleSettings}
+              isLeftPanelFolded={isLeftPanelFolded}
+              isRightPanelFolded={isRightPanelFolded}
+              onToggleLeftPanel={handleToggleLeftPanel}
+              onToggleRightPanel={handleToggleRightPanel}
+              panelToggleMode={isCompact ? 'exclusive' : 'independent'}
               selectedDate={selectedDate}
               onDateChange={handleDateChange}
             />

--- a/apps/frontend/src/domains/study/components/StudyLayoutContent.tsx
+++ b/apps/frontend/src/domains/study/components/StudyLayoutContent.tsx
@@ -2,8 +2,6 @@
 
 import { ReactNode, useState, useCallback, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
-import { PanelLeftOpen, PanelRightOpen } from 'lucide-react';
 
 export interface StudyLayoutContentProps {
   header: ReactNode | null;
@@ -98,46 +96,17 @@ export function StudyLayoutContent({
   }, []);
 
   return (
-    <div className={cn('flex h-screen flex-col bg-background text-foreground', className)}>
+    <div className={cn('flex h-screen flex-col overflow-hidden bg-background text-foreground', className)}>
       {/* Header */}
-      {header && <header className="shrink-0 border-b border-border">{header}</header>}
+      {header && <header className="shrink-0 border-b border-border/70">{header}</header>}
 
       {/* Main Content */}
-      <div ref={mainContainerRef} className="relative flex min-h-0 flex-1">
+      <div ref={mainContainerRef} className="relative flex min-h-0 flex-1 overflow-hidden">
         {/* NARROW MODE: Hide split panels, show center panel only */}
         {isNarrow ? (
           <>
             {/* Center Panel (full width in narrow mode) */}
             <main className="relative flex min-w-0 flex-1 flex-col">
-              {/* Unfold buttons */}
-              {isLeftPanelFolded && (
-                <div className="absolute left-2 top-2 z-10">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={onUnfoldLeftPanel}
-                    className="h-8 w-8 bg-background/80 shadow-sm backdrop-blur hover:bg-background"
-                    title="문제 목록 펼치기"
-                  >
-                    <PanelLeftOpen className="h-4 w-4" />
-                  </Button>
-                </div>
-              )}
-
-              {hasRightPanel && isRightPanelFolded && (
-                <div className="absolute right-2 top-2 z-10">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={onUnfoldRightPanel}
-                    className="h-8 w-8 bg-background/80 shadow-sm backdrop-blur hover:bg-background"
-                    title="채팅/참여자 펼치기"
-                  >
-                    <PanelRightOpen className="h-4 w-4" />
-                  </Button>
-                </div>
-              )}
-
               {centerPanel}
             </main>
 
@@ -174,7 +143,7 @@ export function StudyLayoutContent({
             <aside
               style={{ width: isLeftPanelFolded ? 0 : leftWidth }}
               className={cn(
-                'shrink-0 overflow-y-auto overflow-x-hidden border-r border-border bg-card',
+                'shrink-0 overflow-y-auto overflow-x-hidden border-r border-border/70 bg-card',
                 !isResizingLeft && 'transition-all duration-300 ease-in-out',
                 isLeftPanelFolded && 'border-r-0',
               )}
@@ -193,43 +162,7 @@ export function StudyLayoutContent({
             )}
 
             {/* Center Panel */}
-            <main
-              className={cn(
-                'relative flex min-w-0 flex-1 flex-col transition-all duration-300',
-                isLeftPanelFolded && 'pl-12',
-                hasRightPanel && isRightPanelFolded && 'pr-12',
-              )}
-            >
-              {/* Unfold Left Panel Button */}
-              {isLeftPanelFolded && (
-                <div className="absolute left-2 top-2 z-10">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={onUnfoldLeftPanel}
-                    className="h-8 w-8 bg-background/80 shadow-sm backdrop-blur hover:bg-background"
-                    title="문제 목록 펼치기"
-                  >
-                    <PanelLeftOpen className="h-4 w-4" />
-                  </Button>
-                </div>
-              )}
-
-              {/* Unfold Right Panel Button */}
-              {hasRightPanel && isRightPanelFolded && (
-                <div className="absolute right-2 top-2 z-10">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={onUnfoldRightPanel}
-                    className="h-8 w-8 bg-background/80 shadow-sm backdrop-blur hover:bg-background"
-                    title="채팅/참여자 펼치기"
-                  >
-                    <PanelRightOpen className="h-4 w-4" />
-                  </Button>
-                </div>
-              )}
-
+            <main className="relative flex min-w-0 flex-1 flex-col transition-all duration-300">
               {centerPanel}
             </main>
 
@@ -245,7 +178,7 @@ export function StudyLayoutContent({
               <aside
                 style={{ width: isRightPanelFolded ? 0 : rightWidth }}
                 className={cn(
-                  'shrink-0 overflow-y-auto overflow-x-hidden border-l border-border bg-card',
+                  'shrink-0 overflow-y-auto overflow-x-hidden border-l border-border/70 bg-card',
                   !isResizingRight && 'transition-all duration-300 ease-in-out',
                   isRightPanelFolded && 'border-l-0',
                 )}


### PR DESCRIPTION
## 💡 의도 / 배경
노트북 분할 화면에서 모바일로 오인식되어 레이아웃이 깨지고, 스터디룸 패널 토글/모바일 푸터/IDE 실행 흐름이 일관되지 않는 문제가 있었습니다.  
이번 PR은 스터디룸과 메인 화면의 반응형 동작을 안정화하고, 상단 헤더 중심의 패널 제어 UX로 정리해 전체 UI 일관성을 개선하는 것을 목표로 합니다.

## 🛠️ 작업 내용
- [x] 스터디룸 패널 토글 구조 개선
- [x] 분할/풀모드에서 패널 동작(배타/동시) 일치화
- [x] 헤더 내 문제목록/채팅 토글 UI 정리 및 액션 위계 조정
- [x] 모바일 IDE 실행 플로우 및 테스트/콘솔 영역 노출 동작 개선
- [x] 모바일 메인 레이아웃을 본문/푸터 영역으로 분리해 스크롤 충돌 완화
- [x] `UserIcon`의 invalid src 처리 보강으로 콘솔 에러 제거
- [x] 보더 강도/패딩 등 미세 스타일 튜닝으로 전체 UI 밀도 개선

## 🔗 관련 이슈
- Closes #123

## 🖼️ 스크린샷 (선택)
- UI 변경 전/후 비교 스크린샷 첨부 예정

## 🧪 테스트 방법
- [x] 노트북 분할 화면(약 700px대)에서 스터디룸 진입 후 패널 열기/닫기 확인
- [x] 풀모드에서 좌/우 패널 동시 오픈 동작 확인
- [x] 모바일 레이아웃에서 실행 버튼 및 테스트/결과 영역 노출 확인
- [x] 메인 모바일 푸터 고정 영역과 본문 스크롤 분리 동작 확인
- [x] `pnpm --filter frontend type-check` 통과 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [ ] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
헤더 패널 토글은 `compact(배타)` / `full(독립)` 모드에 따라 UI 타입을 분기했습니다.  
의도한 상호작용(특히 분할 화면 기준)이 현재 제품 정책과 정확히 맞는지 중점 확인 부탁드립니다.