### PR TITLE
fix: ide가 리렌더링돼서 코드가 초기화되는 문제 수정

### DIFF
--- a/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
@@ -57,7 +57,13 @@ export function CCCenterPanel({
   onSettingsClick,
   className,
 }: CCCenterPanelProps) {
-  const isMobile = useIsTouchMobile();
+  const isTouchMobile = useIsTouchMobile();
+  const initialLayoutModeRef = useRef<'mobile' | 'desktop'>(
+    isTouchMobile ? 'mobile' : 'desktop',
+  );
+  // Keep center layout mode stable so viewport changes (e.g. opening devtools)
+  // do not unmount IDE sections while the user is typing.
+  const isMobile = initialLayoutModeRef.current === 'mobile';
 
   const getTemplateCode = (languageValue: string): string => {
     const normalized = languageValue.toLowerCase();

--- a/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyRoomClient.tsx
@@ -72,7 +72,13 @@ function StudyRoomContent({
   aiRecommendationRequestId: string | null;
 }) {
   const router = useRouter();
-  const isMobile = useIsTouchMobile();
+  const isTouchMobile = useIsTouchMobile();
+  const initialLayoutModeRef = useRef<'mobile' | 'desktop'>(
+    isTouchMobile ? 'mobile' : 'desktop',
+  );
+  // Keep the initial layout mode stable to avoid unmounting the IDE tree
+  // when viewport width changes (e.g. opening browser devtools).
+  const isMobile = initialLayoutModeRef.current === 'mobile';
   const { user } = useAuthStore();
   const { connected } = useSocketContext();
   const { localParticipant, isMicrophoneEnabled, isCameraEnabled } = useLocalParticipant();
@@ -169,6 +175,7 @@ function StudyRoomContent({
   // [New] Compact Mode: Mutual exclusion for sidebars
   // If window width is small (e.g. < 1200px), allow only one sidebar to be open at a time.
   const [isCompact, setIsCompact] = useState(false);
+  const wasCompactRef = useRef(false);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -188,7 +195,16 @@ function StudyRoomContent({
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  // In split mode, sidebars are mutually exclusive.
+  // When entering compact mode from normal width, close both side panels.
+  useEffect(() => {
+    if (!wasCompactRef.current && isCompact) {
+      setIsLeftPanelFolded(true);
+      setIsRightPanelFolded(true);
+    }
+    wasCompactRef.current = isCompact;
+  }, [isCompact, setIsLeftPanelFolded, setIsRightPanelFolded]);
+
+  // In compact mode, keep sidebars mutually exclusive.
   useEffect(() => {
     if (!isCompact) return;
     if (!isLeftPanelFolded && !isRightPanelFolded) {

--- a/apps/frontend/src/domains/study/components/StudyLayoutContent.tsx
+++ b/apps/frontend/src/domains/study/components/StudyLayoutContent.tsx
@@ -102,91 +102,87 @@ export function StudyLayoutContent({
 
       {/* Main Content */}
       <div ref={mainContainerRef} className="relative flex min-h-0 flex-1 overflow-hidden">
-        {/* NARROW MODE: Hide split panels, show center panel only */}
-        {isNarrow ? (
-          <>
-            {/* Center Panel (full width in narrow mode) */}
-            <main className="relative flex min-w-0 flex-1 flex-col">
-              {centerPanel}
-            </main>
+        {/* Left Panel - keep mounted container stable to avoid center panel remounts */}
+        <aside
+          style={{ width: isNarrow || isLeftPanelFolded ? 0 : leftWidth }}
+          className={cn(
+            'shrink-0 overflow-y-auto overflow-x-hidden border-r border-border/70 bg-card',
+            !isResizingLeft && 'transition-all duration-300 ease-in-out',
+            (isNarrow || isLeftPanelFolded) && 'border-r-0',
+          )}
+        >
+          {!isNarrow && (
+            <div style={{ width: leftWidth }} className="h-full">
+              {leftPanel}
+            </div>
+          )}
+        </aside>
 
-            {/* Left Panel Overlay */}
-            {!isLeftPanelFolded && (
-              <div className="fixed inset-0 z-40 animate-in fade-in duration-200">
-                <div
-                  className="absolute inset-0 bg-black/50"
-                  onClick={onUnfoldLeftPanel}
-                />
-                <div className="absolute left-0 top-0 bottom-0 w-80 bg-card shadow-2xl z-50 animate-in slide-in-from-left duration-300">
-                  {leftPanel}
-                </div>
-              </div>
+        {/* Left Resize Handle */}
+        <div
+          className={cn(
+            'z-20 shrink-0 transition-colors',
+            !isNarrow && !isLeftPanelFolded
+              ? 'w-1 hover:w-1.5 -ml-0.5 cursor-col-resize bg-transparent hover:bg-primary/50 active:bg-primary'
+              : 'w-0 -ml-0 pointer-events-none',
+          )}
+          onMouseDown={!isNarrow && !isLeftPanelFolded ? startResizingLeft : undefined}
+        />
+
+        {/* Center Panel */}
+        <main key="center-panel" className="relative flex min-w-0 flex-1 flex-col transition-all duration-300">
+          {centerPanel}
+        </main>
+
+        {/* Right Resize Handle */}
+        {hasRightPanel && (
+          <div
+            className={cn(
+              'z-20 shrink-0 transition-colors',
+              !isNarrow && !isRightPanelFolded
+                ? 'w-1 hover:w-1.5 -mr-0.5 cursor-col-resize bg-transparent hover:bg-primary/50 active:bg-primary'
+                : 'w-0 -mr-0 pointer-events-none',
             )}
+            onMouseDown={!isNarrow && !isRightPanelFolded ? startResizingRight : undefined}
+          />
+        )}
 
-            {/* Right Panel Overlay */}
-            {hasRightPanel && !isRightPanelFolded && (
-              <div className="fixed inset-0 z-40 animate-in fade-in duration-200">
-                <div
-                  className="absolute inset-0 bg-black/50"
-                  onClick={onUnfoldRightPanel}
-                />
-                <div className="absolute right-0 top-0 bottom-0 w-80 bg-card shadow-2xl z-50 animate-in slide-in-from-right duration-300">
-                  {rightPanel}
-                </div>
-              </div>
+        {hasRightPanel && (
+          <aside
+            style={{ width: isNarrow || isRightPanelFolded ? 0 : rightWidth }}
+            className={cn(
+              'shrink-0 overflow-y-auto overflow-x-hidden border-l border-border/70 bg-card',
+              !isResizingRight && 'transition-all duration-300 ease-in-out',
+              (isNarrow || isRightPanelFolded) && 'border-l-0',
             )}
-          </>
-        ) : (
-          /* WIDE MODE: Traditional split layout */
-          <>
-            {/* Left Panel - Animation handled by width */}
-            <aside
-              style={{ width: isLeftPanelFolded ? 0 : leftWidth }}
-              className={cn(
-                'shrink-0 overflow-y-auto overflow-x-hidden border-r border-border/70 bg-card',
-                !isResizingLeft && 'transition-all duration-300 ease-in-out',
-                isLeftPanelFolded && 'border-r-0',
-              )}
-            >
-              <div style={{ width: leftWidth }} className="h-full">
-                {leftPanel}
-              </div>
-            </aside>
+          >
+            {!isNarrow && <div style={{ width: rightWidth }} className="h-full">{rightPanel}</div>}
+          </aside>
+        )}
 
-            {/* Left Resize Handle */}
-            {!isLeftPanelFolded && (
-              <div
-                className="w-1 hover:w-1.5 -ml-0.5 z-20 cursor-col-resize bg-transparent hover:bg-primary/50 active:bg-primary transition-colors shrink-0"
-                onMouseDown={startResizingLeft}
-              />
-            )}
+        {/* Narrow mode overlays */}
+        {isNarrow && !isLeftPanelFolded && (
+          <div className="fixed inset-0 z-40 animate-in fade-in duration-200">
+            <div
+              className="absolute inset-0 bg-black/50"
+              onClick={onUnfoldLeftPanel}
+            />
+            <div className="absolute left-0 top-0 bottom-0 w-80 bg-card shadow-2xl z-50 animate-in slide-in-from-left duration-300">
+              {leftPanel}
+            </div>
+          </div>
+        )}
 
-            {/* Center Panel */}
-            <main className="relative flex min-w-0 flex-1 flex-col transition-all duration-300">
-              {centerPanel}
-            </main>
-
-            {/* Right Resize Handle */}
-            {hasRightPanel && !isRightPanelFolded && (
-              <div
-                className="w-1 hover:w-1.5 -mr-0.5 z-20 cursor-col-resize bg-transparent hover:bg-primary/50 active:bg-primary transition-colors shrink-0"
-                onMouseDown={startResizingRight}
-              />
-            )}
-
-            {hasRightPanel && (
-              <aside
-                style={{ width: isRightPanelFolded ? 0 : rightWidth }}
-                className={cn(
-                  'shrink-0 overflow-y-auto overflow-x-hidden border-l border-border/70 bg-card',
-                  !isResizingRight && 'transition-all duration-300 ease-in-out',
-                  isRightPanelFolded && 'border-l-0',
-                )}
-              >
-                <div style={{ width: rightWidth }} className="h-full">{rightPanel}</div>
-              </aside>
-            )}
-          </>
+        {isNarrow && hasRightPanel && !isRightPanelFolded && (
+          <div className="fixed inset-0 z-40 animate-in fade-in duration-200">
+            <div
+              className="absolute inset-0 bg-black/50"
+              onClick={onUnfoldRightPanel}
+            />
+            <div className="absolute right-0 top-0 bottom-0 w-80 bg-card shadow-2xl z-50 animate-in slide-in-from-right duration-300">
+              {rightPanel}
+            </div>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## 💡 의도 / 배경
전체 화면에서 코드를 작성 중 `F12`로 DevTools를 열어 화면이 좁아질 때, 레이아웃 분기(`wide ↔ narrow`, `desktop ↔ mobile`)로 IDE 트리가 재마운트되며 작성 중 코드가 초기화되는 문제가 있었습니다.  
사용자 작업 유실이 발생하는 S1급 이슈라, 뷰포트 변경 시에도 IDE 인스턴스/상태가 유지되도록 구조를 수정했습니다.

## 🛠️ 작업 내용
- [x] `StudyLayoutContent`의 `isNarrow ? ... : ...` 분기 렌더링을 제거하고, center panel(IDE)이 항상 동일 트리에서 유지되도록 구조 변경
- [x] narrow 모드 전환 시 좌/우 패널은 오버레이로만 토글하고 center panel은 언마운트되지 않도록 처리
- [x] `CCStudyRoomClient`, `CCCenterPanel`에서 `useIsTouchMobile()` 값을 초기 진입 시점으로 고정해 DevTools/F12로 인한 모바일 분기 전환 방지
- [x] 일반 화면 → compact 전환 시 문제/채팅 패널 자동 접기 동작 추가

## 🔗 관련 이슈
- Closes #129

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] 수동 재현 테스트
  1. 스터디 IDE 진입 후 코드 작성
  2. `F12`로 DevTools 열기(화면 좁아짐)
  3. DevTools 닫기
  4. 작성 중 코드가 유지되는지 확인
- [x] `pnpm -C apps/frontend type-check` 통과

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
핵심은 “뷰포트 변경 시 center IDE를 리마운트하지 않도록” 레이아웃 구조를 바꾼 점입니다.  
`F12`/창 크기 조절/화면 절반(컴팩트) 전환 케이스를 중심으로 확인 부탁드립니다.