### PR TITLE
[Fix] 실시간 코드 동기화 시 IDE 재마운트 제거 및 회귀 테스트 추가

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,24 @@
 #!/bin/sh
 
-echo "🚀 Running pre-push checks..."
+echo "Running pre-push checks..."
+
+is_wsl() {
+  grep -qi microsoft /proc/version 2>/dev/null
+}
+
+run_repo_cmd() {
+  if is_wsl; then
+    windows_cwd=$(wslpath -w "$(pwd)" | tr -d '\r')
+    command_text=$(printf '%s' "$1" | tr -d '\r')
+    cmd.exe /d /s /c "cd /d \"$windows_cwd\" && $command_text"
+  else
+    eval "$1"
+  fi
+}
 
 # Get the default branch (master or main)
 DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
 if [ -z "$DEFAULT_BRANCH" ]; then
-  # Fallback: check if origin/master or origin/main exists
   if git rev-parse --verify origin/master >/dev/null 2>&1; then
     DEFAULT_BRANCH="master"
   elif git rev-parse --verify origin/main >/dev/null 2>&1; then
@@ -15,85 +28,94 @@ if [ -z "$DEFAULT_BRANCH" ]; then
   fi
 fi
 
-echo "📌 Comparing with origin/$DEFAULT_BRANCH"
+echo "Comparing with origin/$DEFAULT_BRANCH"
 
 # Get changed files in current branch compared to default branch
 FILES=$(git diff --name-only origin/$DEFAULT_BRANCH...HEAD 2>/dev/null)
 if [ -z "$FILES" ]; then
-  # Fallback: compare with merge-base if three-dot diff fails
   MERGE_BASE=$(git merge-base origin/$DEFAULT_BRANCH HEAD 2>/dev/null)
   if [ -n "$MERGE_BASE" ]; then
-    FILES=$(git diff --name-only $MERGE_BASE HEAD)
+    FILES=$(git diff --name-only "$MERGE_BASE" HEAD)
   else
     FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
   fi
 fi
 
-# Check if frontend files changed
 FRONTEND_CHANGED=$(echo "$FILES" | grep -E '^apps/frontend/' || true)
-# Check if backend files changed
 BACKEND_CHANGED=$(echo "$FILES" | grep -E '^apps/backend/' || true)
 
 if [ -z "$FRONTEND_CHANGED" ] && [ -z "$BACKEND_CHANGED" ]; then
-  echo "ℹ️ No frontend or backend files changed, skipping checks"
+  echo "No frontend or backend files changed, skipping checks"
   exit 0
 fi
 
-# Frontend checks
 if [ -n "$FRONTEND_CHANGED" ]; then
-  echo "\n📦 Frontend files changed, running checks..."
+  printf "\nFrontend files changed, running checks...\n"
 
-  echo "• Running type check..."
-  pnpm --filter frontend type-check
+  echo "Running type check..."
+  run_repo_cmd "pnpm --filter frontend type-check"
   if [ $? -ne 0 ]; then
-    echo "❌ Frontend type check failed"
+    echo "Frontend type check failed"
     exit 1
   fi
 
-  echo "• Running unit tests (vitest)..."
-  pnpm --filter frontend test --run
+  echo "Running unit tests (vitest)..."
+  run_repo_cmd "pnpm --filter frontend test --run"
   if [ $? -ne 0 ]; then
-    echo "❌ Frontend unit tests failed"
+    echo "Frontend unit tests failed"
     exit 1
   fi
 
-  echo "• Building..."
-  pnpm --filter frontend build
+  echo "Building frontend..."
+  run_repo_cmd "pnpm --filter frontend build"
   if [ $? -ne 0 ]; then
-    echo "❌ Frontend build failed"
+    echo "Frontend build failed"
     exit 1
   fi
 
-  echo "• Running E2E tests (playwright)..."
-  pnpm --filter frontend test:e2e
+  echo "Running E2E tests (playwright)..."
+  run_repo_cmd "pnpm --filter frontend test:e2e"
   if [ $? -ne 0 ]; then
-    echo "❌ Frontend E2E tests failed"
+    echo "Frontend E2E tests failed"
     exit 1
   fi
 
-  echo "✅ Frontend checks passed"
+  echo "Frontend checks passed"
 fi
 
-# Backend checks
 if [ -n "$BACKEND_CHANGED" ]; then
-  echo "\n☕ Backend files changed, running checks..."
-  
-  echo "• Running tests..."
-  cd apps/backend && chmod +x gradlew
-  ./gradlew test --quiet
+  printf "\nBackend files changed, running checks...\n"
+
+  echo "Running backend tests..."
+  if is_wsl; then
+    run_repo_cmd "cd apps\\backend && gradlew.bat test --quiet"
+  else
+    (
+      cd apps/backend || exit 1
+      chmod +x gradlew
+      ./gradlew test --quiet
+    )
+  fi
   if [ $? -ne 0 ]; then
-    echo "❌ Backend tests failed"
+    echo "Backend tests failed"
     exit 1
   fi
 
-  echo "• Building..."
-  ./gradlew build -x test --quiet
+  echo "Building backend..."
+  if is_wsl; then
+    run_repo_cmd "cd apps\\backend && gradlew.bat build -x test --quiet"
+  else
+    (
+      cd apps/backend || exit 1
+      ./gradlew build -x test --quiet
+    )
+  fi
   if [ $? -ne 0 ]; then
-    echo "❌ Backend build failed"
+    echo "Backend build failed"
     exit 1
   fi
-  
-  echo "✅ Backend checks passed"
+
+  echo "Backend checks passed"
 fi
 
-echo "\n✅ All pre-push checks passed!"
+printf "\nAll pre-push checks passed!\n"

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:e2e": "cross-env NEXT_PUBLIC_ENABLE_E2E_ROUTES=true next build",
     "start": "next start",
+    "start:e2e": "cross-env NEXT_PUBLIC_ENABLE_E2E_ROUTES=true next start",
     "test": "vitest",
     "test:e2e": "playwright test",
     "lint": "next lint",

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'pnpm start --port 3001',
+    command: 'pnpm build:e2e && pnpm start:e2e --port 3001',
     url: 'http://localhost:3001',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/apps/frontend/src/app/e2e/layout.tsx
+++ b/apps/frontend/src/app/e2e/layout.tsx
@@ -1,0 +1,15 @@
+import { notFound } from 'next/navigation';
+
+import { isE2ERoutesEnabled } from '@/lib/e2e-routes';
+
+export default function E2ELayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  if (!isE2ERoutesEnabled) {
+    notFound();
+  }
+
+  return children;
+}

--- a/apps/frontend/src/app/e2e/readonly-editor/page.tsx
+++ b/apps/frontend/src/app/e2e/readonly-editor/page.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { CCIDEPanel, type CCIDEPanelRef } from '@/domains/study/components/CCIDEPanel';
+
+const REMOTE_PACKETS = [
+  'print("a")',
+  'print("ab")',
+  'print("abc")',
+  'print("abcd")',
+];
+
+export default function ReadonlyEditorE2EPage() {
+  const panelRef = useRef<CCIDEPanelRef>(null);
+  const [packetIndex, setPacketIndex] = useState(0);
+  const [mountCount, setMountCount] = useState(0);
+  const [observedEditorValue, setObservedEditorValue] = useState(REMOTE_PACKETS[0]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setObservedEditorValue(panelRef.current?.getValue() ?? '');
+    }, 50);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [packetIndex, mountCount]);
+
+  return (
+    <main className="min-h-screen bg-slate-950 p-8 text-slate-50">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <section className="space-y-3">
+          <p className="text-sm uppercase tracking-[0.3em] text-slate-400">Readonly Editor E2E</p>
+          <h1 className="text-3xl font-semibold">Realtime packet remount regression test</h1>
+          <p className="max-w-3xl text-sm text-slate-300">
+            This page simulates readonly realtime code packets and exposes mount count so
+            Playwright can verify Monaco stays mounted while the incoming code changes.
+          </p>
+        </section>
+
+        <section className="grid gap-3 rounded-2xl border border-slate-800 bg-slate-900/80 p-4 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Mount Count</p>
+            <p data-testid="mount-count" className="mt-1 text-3xl font-semibold">
+              {mountCount}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Active Packet</p>
+            <p data-testid="packet-index" className="mt-1 text-3xl font-semibold">
+              {packetIndex}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Language</p>
+            <p data-testid="packet-language" className="mt-1 text-3xl font-semibold">
+              python
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+          <div className="flex flex-wrap gap-3">
+            {REMOTE_PACKETS.map((packet, index) => (
+              <button
+                key={packet}
+                type="button"
+                data-testid={`apply-packet-${index}`}
+                onClick={() => setPacketIndex(index)}
+                className="rounded-full border border-cyan-400/40 bg-cyan-500/10 px-4 py-2 text-sm font-medium text-cyan-100 transition hover:bg-cyan-500/20"
+              >
+                Apply packet {index}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Incoming Packet</p>
+              <pre
+                data-testid="incoming-packet"
+                className="mt-2 overflow-x-auto whitespace-pre-wrap break-all text-sm text-emerald-200"
+              >
+                {REMOTE_PACKETS[packetIndex]}
+              </pre>
+            </div>
+            <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Observed Editor Value</p>
+              <pre
+                data-testid="observed-editor-value"
+                className="mt-2 overflow-x-auto whitespace-pre-wrap break-all text-sm text-amber-200"
+              >
+                {observedEditorValue}
+              </pre>
+            </div>
+          </div>
+        </section>
+
+        <section className="h-[560px] overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+          <CCIDEPanel
+            ref={panelRef}
+            readOnly
+            hideToolbar
+            editorId="readonly-e2e"
+            initialCode={REMOTE_PACKETS[packetIndex]}
+            language="python"
+            onEditorMount={() => {
+              setMountCount((current) => current + 1);
+            }}
+          />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/frontend/src/app/e2e/study-interactions/page.tsx
+++ b/apps/frontend/src/app/e2e/study-interactions/page.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { CCIDEPanel } from '@/domains/study/components/CCIDEPanel';
+import { CCProblemCard } from '@/domains/study/components/CCProblemCard';
+import { ChatInput } from '@/domains/study/components/chat/ChatInput';
+import { ChatMessageItem } from '@/domains/study/components/chat/ChatMessageItem';
+import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
+import type { ChatMessage } from '@/domains/study/types/chat';
+import type { StudyProblem } from '@/domains/study/types';
+
+const PROBLEMS: StudyProblem[] = [
+  {
+    problemId: 1001,
+    studyProblemId: 1001,
+    externalId: '1001',
+    title: 'Two Sum',
+    tier: 'Silver 4',
+    type: 'BOJ',
+    tags: ['implementation', 'math'],
+    solvedMemberCount: 2,
+    totalMemberCount: 4,
+  },
+  {
+    problemId: 2002,
+    studyProblemId: 2002,
+    externalId: '2002',
+    title: 'Binary Search Lab',
+    tier: 'Gold 5',
+    type: 'BOJ',
+    tags: ['binary-search'],
+    solvedMemberCount: 1,
+    totalMemberCount: 4,
+  },
+];
+
+const CHAT_MESSAGES: ChatMessage[] = [
+  {
+    id: 'msg-1',
+    roomId: 1,
+    senderId: 2,
+    senderName: 'OtherUser',
+    content: 'Hello, this is a message to reply to.',
+    type: 'TALK',
+    createdAt: new Date('2026-04-02T12:00:00.000Z').toISOString(),
+  },
+  {
+    id: 'msg-2',
+    roomId: 1,
+    senderId: 1,
+    senderName: 'Me',
+    content: 'I am replying to you.',
+    type: 'TALK',
+    parentMessage: {
+      id: 'msg-1',
+      senderId: 2,
+      senderName: 'OtherUser',
+      content: 'Hello, this is a message to reply to.',
+      type: 'TALK',
+    },
+    createdAt: new Date('2026-04-02T12:01:00.000Z').toISOString(),
+  },
+  {
+    id: 'code-msg-1',
+    roomId: 1,
+    senderId: 2,
+    senderName: 'OtherUser',
+    content: 'Check out my solution!',
+    type: 'CODE',
+    metadata: {
+      code: 'def solution():\n    return 42',
+      language: 'python',
+      problemTitle: 'Two Sum',
+      ownerName: 'OtherUser',
+      problemId: 1001,
+      externalId: '1001',
+      isRealtime: true,
+    },
+    createdAt: new Date('2026-04-02T12:02:00.000Z').toISOString(),
+  },
+  {
+    id: 'code-msg-mine',
+    roomId: 1,
+    senderId: 1,
+    senderName: 'Me',
+    content: 'Here is my code.',
+    type: 'CODE',
+    metadata: {
+      code: 'def my_solution():\n    return 1',
+      language: 'python',
+      problemTitle: 'Two Sum',
+      ownerName: 'Me',
+      problemId: 1001,
+      externalId: '1001',
+      isRealtime: true,
+    },
+    createdAt: new Date('2026-04-02T12:03:00.000Z').toISOString(),
+  },
+  {
+    id: 'msg-ref-code-other',
+    roomId: 1,
+    senderId: 1,
+    senderName: 'Me',
+    content: 'This reply references the other user code.',
+    type: 'TALK',
+    parentMessage: {
+      id: 'code-msg-1',
+      senderId: 2,
+      senderName: 'OtherUser',
+      content: 'Check out my solution!',
+      type: 'CODE',
+    },
+    createdAt: new Date('2026-04-02T12:04:00.000Z').toISOString(),
+  },
+  {
+    id: 'msg-ref-talk',
+    roomId: 1,
+    senderId: 2,
+    senderName: 'OtherUser',
+    content: 'This one points back to a normal message.',
+    type: 'TALK',
+    parentMessage: {
+      id: 'msg-1',
+      senderId: 2,
+      senderName: 'OtherUser',
+      content: 'Hello, this is a message to reply to.',
+      type: 'TALK',
+    },
+    createdAt: new Date('2026-04-02T12:05:00.000Z').toISOString(),
+  },
+  {
+    id: 'msg-ref-code-mine',
+    roomId: 1,
+    senderId: 2,
+    senderName: 'OtherUser',
+    content: 'This one points back to my own code.',
+    type: 'TALK',
+    parentMessage: {
+      id: 'code-msg-mine',
+      senderId: 1,
+      senderName: 'Me',
+      content: 'Here is my code.',
+      type: 'CODE',
+    },
+    createdAt: new Date('2026-04-02T12:06:00.000Z').toISOString(),
+  },
+];
+
+export default function StudyInteractionsE2EPage() {
+  const reset = useRoomStore((state) => state.reset);
+  const setRoomInfo = useRoomStore((state) => state.setRoomInfo);
+  const setCurrentUserId = useRoomStore((state) => state.setCurrentUserId);
+  const setParticipants = useRoomStore((state) => state.setParticipants);
+  const setSelectedProblem = useRoomStore((state) => state.setSelectedProblem);
+  const pendingCodeShare = useRoomStore((state) => state.pendingCodeShare);
+  const setPendingCodeShare = useRoomStore((state) => state.setPendingCodeShare);
+  const replyingTo = useRoomStore((state) => state.replyingTo);
+  const setReplyingTo = useRoomStore((state) => state.setReplyingTo);
+  const viewMode = useRoomStore((state) => state.viewMode);
+  const viewingUser = useRoomStore((state) => state.viewingUser);
+  const targetSubmission = useRoomStore((state) => state.targetSubmission);
+  const selectedStudyProblemId = useRoomStore((state) => state.selectedStudyProblemId);
+  const selectedProblemTitle = useRoomStore((state) => state.selectedProblemTitle);
+  const selectedProblemExternalId = useRoomStore((state) => state.selectedProblemExternalId);
+
+  const [lastSentMessage, setLastSentMessage] = useState('');
+
+  useEffect(() => {
+    reset();
+    setRoomInfo({ roomId: 1, roomTitle: 'E2E Study Room', myRole: 'MEMBER' });
+    setCurrentUserId(1);
+    setParticipants([
+      {
+        id: 1,
+        nickname: 'Me',
+        isOwner: true,
+        isMuted: false,
+        isVideoOff: false,
+        isOnline: true,
+      },
+      {
+        id: 2,
+        nickname: 'OtherUser',
+        isOwner: false,
+        isMuted: false,
+        isVideoOff: false,
+        isOnline: true,
+      },
+    ]);
+
+    return () => {
+      reset();
+    };
+  }, [reset, setCurrentUserId, setParticipants, setRoomInfo]);
+
+  const messageLookup = useMemo(
+    () => Object.fromEntries(CHAT_MESSAGES.map((message) => [message.id as string, message])),
+    [],
+  );
+
+  const handleSelectProblem = (problem: StudyProblem) => {
+    setSelectedProblem(problem.studyProblemId || problem.problemId, problem.problemId, problem.title, problem.externalId);
+  };
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-8 text-slate-50">
+      <div className="mx-auto flex max-w-[1600px] flex-col gap-6">
+        <section className="space-y-3">
+          <p className="text-sm uppercase tracking-[0.3em] text-slate-400">Study Interactions E2E</p>
+          <h1 className="text-3xl font-semibold">Chat reply, code reference, and IDE share harness</h1>
+          <p className="max-w-4xl text-sm text-slate-300">
+            This page exposes deterministic UI state for Playwright so reply preview, reference
+            navigation, problem selection, and code share flows can run without the full realtime
+            study-room stack.
+          </p>
+        </section>
+
+        <section className="grid gap-3 rounded-2xl border border-slate-800 bg-slate-900/80 p-4 md:grid-cols-3 xl:grid-cols-6">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">View Mode</p>
+            <p data-testid="view-mode" className="mt-1 text-xl font-semibold">
+              {viewMode}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Viewing User</p>
+            <p data-testid="viewing-user" className="mt-1 text-xl font-semibold">
+              {viewingUser?.nickname || '-'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Saved Target</p>
+            <p data-testid="saved-target" className="mt-1 text-xl font-semibold">
+              {targetSubmission?.problemTitle || '-'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Pending Share</p>
+            <p data-testid="pending-share-owner" className="mt-1 text-xl font-semibold">
+              {pendingCodeShare?.ownerName || '-'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Replying To</p>
+            <p data-testid="replying-to" className="mt-1 text-xl font-semibold">
+              {replyingTo?.id || '-'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Selected Problem</p>
+            <p data-testid="selected-problem" className="mt-1 text-xl font-semibold">
+              {selectedProblemExternalId
+                ? `${selectedProblemExternalId}. ${selectedProblemTitle}`
+                : selectedProblemTitle || '-'}
+            </p>
+            <p data-testid="selected-problem-id" className="text-xs text-slate-400">
+              {selectedStudyProblemId || '-'}
+            </p>
+          </div>
+        </section>
+
+        <section className="grid gap-6 xl:grid-cols-[380px_minmax(0,1fr)_420px]">
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+              <h2 className="text-lg font-semibold">Problems</h2>
+              <p className="mt-1 text-sm text-slate-400">Click a card to seed the IDE share metadata.</p>
+              <div className="mt-4 space-y-3">
+                {PROBLEMS.map((problem) => (
+                  <div key={problem.studyProblemId} data-testid={`problem-card-${problem.externalId}`}>
+                    <CCProblemCard
+                      problem={problem}
+                      isSelected={selectedStudyProblemId === problem.studyProblemId}
+                      onSelect={() => handleSelectProblem(problem)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+              <h2 className="text-lg font-semibold">Chat Input</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                Reply preview and pending code share preview are rendered here.
+              </p>
+              <div className="mt-4 overflow-hidden rounded-xl border border-slate-800 bg-background text-foreground">
+                <ChatInput
+                  onSend={(message) => {
+                    setLastSentMessage(message);
+                    setReplyingTo(null);
+                    setPendingCodeShare(null);
+                  }}
+                  pendingCodeShare={pendingCodeShare}
+                  onCancelShare={() => setPendingCodeShare(null)}
+                  replyingTo={replyingTo}
+                  onCancelReply={() => setReplyingTo(null)}
+                />
+              </div>
+              <div className="mt-3 rounded-lg border border-slate-800 bg-slate-950/70 p-3 text-sm">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Last Sent</p>
+                <p data-testid="last-sent-message" className="mt-2 text-slate-200">
+                  {lastSentMessage || '-'}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+              <h2 className="text-lg font-semibold">IDE</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                Use the toolbar share button to stage a code share into chat.
+              </p>
+            </div>
+            <div className="h-[640px] overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+              <CCIDEPanel
+                editorId="study-interactions-e2e"
+                initialCode={'def solve():\n    return "shared"'}
+                language="python"
+              />
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+            <h2 className="text-lg font-semibold">Chat Timeline</h2>
+            <p className="mt-1 text-sm text-slate-400">
+              Messages are static, but they drive the real store transitions for reply and code view.
+            </p>
+            <div
+              data-testid="chat-timeline"
+              className="mt-4 flex h-[780px] flex-col overflow-y-auto rounded-xl border border-slate-800 bg-slate-950/70 p-4"
+            >
+              {CHAT_MESSAGES.map((message) => (
+                <div
+                  key={message.id}
+                  data-msg-id={message.id}
+                  className={message.senderId === 1 ? 'flex justify-end' : 'flex justify-start'}
+                >
+                  <ChatMessageItem
+                    message={message}
+                    isMine={message.senderId === 1}
+                    messageLookup={messageLookup}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/frontend/src/components/providers/ClientSessionManager.tsx
+++ b/apps/frontend/src/components/providers/ClientSessionManager.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useAuthStore } from '@/store/auth-store';
+import { isPublicE2ERoute } from '@/lib/e2e-routes';
 
 const AUTH_OR_PUBLIC_ROUTES = new Set(['/login', '/signup', '/']);
 
@@ -12,7 +13,7 @@ export function ClientSessionManager() {
   const { checkAuth } = useAuthStore();
 
   useEffect(() => {
-    if (!pathname || AUTH_OR_PUBLIC_ROUTES.has(pathname)) {
+    if (!pathname || AUTH_OR_PUBLIC_ROUTES.has(pathname) || isPublicE2ERoute(pathname)) {
       return;
     }
 

--- a/apps/frontend/src/domains/study/components/CCIDEPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCIDEPanel.tsx
@@ -157,6 +157,8 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
     const [pendingLanguage, setPendingLanguage] = useState<string | null>(null);
 
     const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+    const monacoRef = useRef<any>(null);
+    const editorDomCleanupRef = useRef<(() => void) | null>(null);
     const readOnlyRef = useRef(readOnly);
     const setRightPanelActiveTab = useRoomStore((state) => state.setRightPanelActiveTab);
     const setPendingCodeShare = useRoomStore((state) => state.setPendingCodeShare);
@@ -214,20 +216,48 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
       if (!readOnly) return;
 
       const incomingCode = initialCode ?? '';
-      const incomingLanguage = propLanguage ?? internalLanguage;
+      const incomingLanguage = propLanguage ?? language;
       const snapshotKey = `${incomingLanguage}::${incomingCode}`;
 
       if (readOnlySnapshotKeyRef.current === snapshotKey) return;
       readOnlySnapshotKeyRef.current = snapshotKey;
 
-      setInternalLanguage(incomingLanguage);
-      setCode(incomingCode);
+      setInternalLanguage((current) => (current === incomingLanguage ? current : incomingLanguage));
+      setCode((current) => (current === incomingCode ? current : incomingCode));
       originCodeRef.current = incomingCode;
       isDirtyRef.current = false;
 
-      // Force remount to avoid intermittent blank rendering on readonly stream updates.
-      setModelId((prev) => prev + 1);
-    }, [readOnly, initialCode, propLanguage, internalLanguage]);
+      const editor = editorRef.current;
+      const monaco = monacoRef.current;
+      const model = editor?.getModel?.();
+
+      if (model && monaco?.editor?.setModelLanguage) {
+        const nextLanguage = getSafeLanguageKey(incomingLanguage);
+        const currentLanguage = model.getLanguageId?.();
+        if (currentLanguage !== nextLanguage) {
+          monaco.editor.setModelLanguage(model, nextLanguage);
+        }
+      }
+
+      if (editor && editor.getValue() !== incomingCode) {
+        editor.setValue(incomingCode);
+      }
+    }, [readOnly, initialCode, propLanguage, language]);
+
+    useEffect(() => {
+      return () => {
+        if (debounceTimerRef.current) {
+          clearTimeout(debounceTimerRef.current);
+          debounceTimerRef.current = null;
+        }
+        if (editorDomCleanupRef.current) {
+          editorDomCleanupRef.current();
+          editorDomCleanupRef.current = null;
+        }
+        editorRef.current = null;
+        monacoRef.current = null;
+      };
+    }, []);
 
     // ----------------------------------------------------------------------
     // 언어 변경 로직
@@ -331,20 +361,20 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
     };
 
     const handleRefChat = (): void => {
-      if (editorRef.current) {
-        const currentCode = editorRef.current.getValue();
-        const { selectedStudyProblemId, selectedProblemTitle, selectedProblemExternalId } =
-          useRoomStore.getState();
-        setPendingCodeShare({
-          code: currentCode,
-          language,
-          ownerName: 'Me',
-          isRealtime: true,
-          problemId: selectedStudyProblemId ?? undefined,
-          externalId: selectedProblemExternalId ?? undefined,
-          problemTitle: selectedProblemTitle ?? undefined,
-        });
-      }
+      const currentCode = editorRef.current?.getValue() ?? code;
+      const { selectedStudyProblemId, selectedProblemTitle, selectedProblemExternalId } =
+        useRoomStore.getState();
+
+      setPendingCodeShare({
+        code: currentCode,
+        language,
+        ownerName: 'Me',
+        isRealtime: true,
+        problemId: selectedStudyProblemId ?? undefined,
+        externalId: selectedProblemExternalId ?? undefined,
+        problemTitle: selectedProblemTitle ?? undefined,
+      });
+
       setRightPanelActiveTab('chat');
       setTimeout(() => {
         const chatInput = document.getElementById('chat-input');
@@ -403,6 +433,7 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
 
     const handleEditorDidMount: OnMount = (editor, monaco): void => {
       editorRef.current = editor;
+      monacoRef.current = monaco;
 
       // [Anti-Cheat] 게임 모드일 때 붙여넣기 금지 (Ctrl+V, Cmd+V)
       if (sourceType === 'GAME') {
@@ -556,11 +587,26 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
         });
       };
 
+      if (editorDomCleanupRef.current) {
+        editorDomCleanupRef.current();
+      }
+
       container.addEventListener('copy', preventClipboard);
       container.addEventListener('cut', preventClipboard);
       container.addEventListener('paste', preventClipboard);
       container.addEventListener('keydown', handleKeyDown as EventListener, true);
-      container.addEventListener('wheel', handleWheel as EventListener, { capture: true, passive: false });
+      container.addEventListener('wheel', handleWheel as EventListener, {
+        capture: true,
+        passive: false,
+      });
+
+      editorDomCleanupRef.current = () => {
+        container.removeEventListener('copy', preventClipboard);
+        container.removeEventListener('cut', preventClipboard);
+        container.removeEventListener('paste', preventClipboard);
+        container.removeEventListener('keydown', handleKeyDown as EventListener, true);
+        container.removeEventListener('wheel', handleWheel as EventListener, true);
+      };
     };
 
     useImperativeHandle(ref, () => ({
@@ -683,4 +729,3 @@ export const CCIDEPanel = forwardRef<CCIDEPanelRef, CCIDEPanelProps>(
 );
 
 CCIDEPanel.displayName = 'CCIDEPanel';
-

--- a/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
+++ b/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
@@ -312,14 +312,17 @@ export function CCIDEToolbar({
               {showChatRef && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={onRefChat}
-                      disabled={disabled}
-                      className="h-10 w-10 text-foreground hover:bg-accent border border-transparent hover:border-border transition-all"
-                    >
-                      <Share2 className="h-[20px] w-[20px] stroke-[2.5px]" />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={onRefChat}
+                    disabled={disabled}
+                    title="Share code to chat"
+                    aria-label="Share code to chat"
+                    data-testid="ide-share-code-button"
+                    className="h-10 w-10 text-foreground hover:bg-accent border border-transparent hover:border-border transition-all"
+                  >
+                    <Share2 className="h-[20px] w-[20px] stroke-[2.5px]" />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>내 풀이 채팅에 공유</TooltipContent>
@@ -405,6 +408,9 @@ export function CCIDEToolbar({
                       variant="ghost"
                       onClick={onRefChat}
                       disabled={disabled}
+                      title="Share code to chat"
+                      aria-label="Share code to chat"
+                      data-testid="ide-share-code-button"
                       className="h-9 justify-start gap-2"
                     >
                       <Share2 className="h-4 w-4" />

--- a/apps/frontend/src/domains/study/components/chat/ChatInput.tsx
+++ b/apps/frontend/src/domains/study/components/chat/ChatInput.tsx
@@ -1,6 +1,8 @@
 import { useState, KeyboardEvent } from 'react';
-import { Button } from '@/components/ui/button';
 import { Send, X, FileCode } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import type { ChatType } from '@/domains/study/types/chat';
 
 interface ChatInputProps {
   onSend: (message: string) => void;
@@ -14,9 +16,23 @@ interface ChatInputProps {
     externalId?: string;
   } | null;
   onCancelShare?: () => void;
+  replyingTo?: {
+    id: string;
+    senderId: number;
+    senderName: string;
+    content: string;
+    type: ChatType;
+  } | null;
+  onCancelReply?: () => void;
 }
 
-export function ChatInput({ onSend, pendingCodeShare, onCancelShare }: ChatInputProps) {
+export function ChatInput({
+  onSend,
+  pendingCodeShare,
+  onCancelShare,
+  replyingTo,
+  onCancelReply,
+}: ChatInputProps) {
   const [value, setValue] = useState('');
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -35,11 +51,37 @@ export function ChatInput({ onSend, pendingCodeShare, onCancelShare }: ChatInput
   };
 
   return (
-    <div className="min-h-[3.5rem] px-3 py-2 border-t bg-background flex flex-col justify-center">
+    <div className="min-h-[3.5rem] border-t bg-background px-3 py-2 flex flex-col justify-center">
+      {replyingTo && (
+        <div
+          data-testid="reply-preview"
+          className="mb-2 flex items-center gap-2 rounded-md border border-amber-200/70 bg-amber-50 p-2 text-xs dark:border-amber-500/30 dark:bg-amber-500/10"
+        >
+          <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" />
+          <span className="flex-1 truncate font-medium text-amber-900 dark:text-amber-100">
+            {replyingTo.senderName} : {replyingTo.content || 'Code share'}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="ml-auto h-5 w-5 hover:bg-destructive/10 hover:text-destructive"
+            onClick={onCancelReply}
+            title="Cancel reply"
+            aria-label="Cancel reply"
+            data-testid="cancel-reply-button"
+          >
+            <X size={12} />
+          </Button>
+        </div>
+      )}
+
       {pendingCodeShare && (
-        <div className="flex items-center gap-2 mb-2 p-2 bg-muted/50 rounded-md border text-xs animate-in slide-in-from-bottom-2">
+        <div
+          data-testid="pending-code-share"
+          className="mb-2 flex items-center gap-2 rounded-md border bg-muted/50 p-2 text-xs animate-in slide-in-from-bottom-2"
+        >
           <FileCode size={14} className="text-primary" />
-          <span className="font-mono truncate flex-1">
+          <span className="flex-1 truncate font-mono">
             {(pendingCodeShare.externalId || pendingCodeShare.problemId) && (
               <span className="mr-1">
                 [#{pendingCodeShare.externalId || pendingCodeShare.problemId}]
@@ -52,21 +94,21 @@ export function ChatInput({ onSend, pendingCodeShare, onCancelShare }: ChatInput
           <Button
             variant="ghost"
             size="icon"
-            className="h-5 w-5 ml-auto hover:bg-destructive/10 hover:text-destructive"
+            className="ml-auto h-5 w-5 hover:bg-destructive/10 hover:text-destructive"
             onClick={onCancelShare}
-            title="취소"
+            title="Cancel code share"
+            aria-label="Cancel code share"
           >
             <X size={12} />
           </Button>
         </div>
       )}
+
       <div className="relative w-full">
         <textarea
           id="chat-input"
-          className="flex min-h-[40px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-none pr-10"
-          placeholder={
-            pendingCodeShare ? '코드에 대한 설명을 입력하세요...' : '메시지를 입력하세요...'
-          }
+          className="flex min-h-[40px] w-full resize-none rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder={pendingCodeShare ? 'Describe this code share...' : 'Type a message...'}
           rows={1}
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -75,8 +117,9 @@ export function ChatInput({ onSend, pendingCodeShare, onCancelShare }: ChatInput
         <Button
           size="icon"
           variant="ghost"
-          className="absolute right-1 bottom-1 h-8 w-8 text-muted-foreground hover:text-primary"
+          className="absolute bottom-1 right-1 h-8 w-8 text-muted-foreground hover:text-primary"
           onClick={handleSend}
+          aria-label="Send message"
         >
           <Send size={16} />
         </Button>

--- a/apps/frontend/src/domains/study/components/chat/ChatMessageItem.tsx
+++ b/apps/frontend/src/domains/study/components/chat/ChatMessageItem.tsx
@@ -1,11 +1,25 @@
 import { useRef, useState } from 'react';
-import { Copy, Check } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { ChatMessage } from '../../types/chat';
-import { cn } from '@/lib/utils';
+import { Check, Copy, Reply } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
-import { CodeShareCard } from './CodeShareCard';
+
+import { Button } from '@/components/ui/button';
+import { useIsTouchMobile } from '@/hooks/useIsMobile';
+import { cn } from '@/lib/utils';
 import { useRoomStore } from '../../hooks/useRoomStore';
+import type { ChatMessage } from '../../types/chat';
+import { CodeShareCard } from './CodeShareCard';
+
+const HIGHLIGHT_CLASSES = ['ring-2', 'ring-amber-400', 'ring-offset-2', 'ring-offset-background'];
+
+const normalizeSharedDisplayContent = (message: ChatMessage) => {
+  if (message.type !== 'CODE') {
+    return message.content;
+  }
+
+  return message.content
+    .replace(/^\[CODE:[^\]]+\]\s*/i, '')
+    .replace(/\s*Ref:.*$/i, '');
+};
 
 const PreBlock = ({ children, ...props }: any) => {
   const preRef = useRef<HTMLPreElement>(null);
@@ -22,13 +36,14 @@ const PreBlock = ({ children, ...props }: any) => {
   };
 
   return (
-    <div className="relative my-2 overflow-hidden rounded-md bg-zinc-950/90 border border-white/10 text-left group/code">
-      <div className="absolute right-2 top-2 z-10 opacity-0 group-hover/code:opacity-100 transition-opacity">
+    <div className="group/code relative my-2 overflow-hidden rounded-md border border-white/10 bg-zinc-950/90 text-left">
+      <div className="absolute right-2 top-2 z-10 opacity-0 transition-opacity group-hover/code:opacity-100">
         <Button
           variant="ghost"
           size="icon"
           onClick={handleCopy}
-          className="h-6 w-6 text-zinc-400 hover:text-white hover:bg-white/10"
+          className="h-6 w-6 text-zinc-400 hover:bg-white/10 hover:text-white"
+          aria-label="Copy code block"
         >
           {isCopied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
         </Button>
@@ -43,152 +58,226 @@ const PreBlock = ({ children, ...props }: any) => {
 interface ChatMessageItemProps {
   message: ChatMessage;
   isMine: boolean;
+  messageLookup?: Record<string, ChatMessage>;
 }
 
-export function ChatMessageItem({ message, isMine }: ChatMessageItemProps) {
-  const {
-    viewSharedCode,
-    resetToOnlyMine,
-    participants,
-    viewRealtimeCode,
-    currentUserId,
-    setSelectedProblem, // Import
-  } = useRoomStore();
+export function ChatMessageItem({ message, isMine, messageLookup }: ChatMessageItemProps) {
+  const isTouchMobile = useIsTouchMobile();
+  const viewSharedCode = useRoomStore((state) => state.viewSharedCode);
+  const resetToOnlyMine = useRoomStore((state) => state.resetToOnlyMine);
+  const participants = useRoomStore((state) => state.participants);
+  const viewRealtimeCode = useRoomStore((state) => state.viewRealtimeCode);
+  const currentUserId = useRoomStore((state) => state.currentUserId);
+  const setSelectedProblem = useRoomStore((state) => state.setSelectedProblem);
+  const setReplyingTo = useRoomStore((state) => state.setReplyingTo);
 
   if (message.type === 'SYSTEM') {
     return (
-      <div className="flex justify-center my-2">
-        <span className="text-xs text-muted-foreground bg-muted/50 px-2 py-1 rounded-full">
+      <div className="my-2 flex justify-center">
+        <span className="rounded-full bg-muted/50 px-2 py-1 text-xs text-muted-foreground">
           {message.content}
         </span>
       </div>
     );
   }
 
-  const handleCodeClick = (e?: React.MouseEvent) => {
-    if (e) e.stopPropagation();
+  const isRefCodeMessage = message.type === 'CODE' && !!message.metadata;
+  const displayContent = normalizeSharedDisplayContent(message);
 
-    // Show the shared code in split view
-    if (message.type === 'CODE' && message.metadata) {
-      const { ownerName } = message.metadata;
+  const focusChatInput = () => {
+    const chatInput = document.getElementById('chat-input');
+    chatInput?.focus();
+  };
 
-      // 1. Determine Realtime Intent First
-      let isRealtimeShare = message.metadata.isRealtime;
+  const highlightOriginalMessage = (messageId: string) => {
+    const originalMessage = document.getElementById(`chat-msg-${messageId}`);
+    if (!originalMessage) return;
 
-      // [Safe Guard] If undefined, infer from ownerName (Legacy support)
-      if (isRealtimeShare === undefined) {
-        // If name indicates saved code, treat as snapshot
-        if (ownerName && ownerName.includes('저장된 코드')) {
-          isRealtimeShare = false;
-        } else {
-          isRealtimeShare = true;
-        }
-      }
+    originalMessage.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    originalMessage.classList.add(...HIGHLIGHT_CLASSES);
 
-      // 2. If share type is explicitly NOT realtime (Snapshot), show SPLIT_SAVED immediately
-      if (isRealtimeShare === false) {
-        let displayOwnerName = ownerName || message.senderName;
-        if (displayOwnerName === 'Me') {
-          displayOwnerName = message.senderName;
-        }
+    window.setTimeout(() => {
+      originalMessage.classList.remove(...HIGHLIGHT_CLASSES);
+    }, 2000);
+  };
 
-        viewSharedCode({
-          code: message.metadata.code || '',
-          language: message.metadata.language || 'python',
-          ownerName: displayOwnerName,
-          problemTitle: message.metadata.problemTitle,
-          problemId: message.metadata.problemId,
-          externalId: message.metadata.externalId,
-          isRealtime: false,
-        });
-        return;
-      }
+  const activateCodeView = (targetMessage: ChatMessage) => {
+    if (targetMessage.type !== 'CODE' || !targetMessage.metadata) return;
 
-      // 3. Determine the effective owner participant for Realtime View
-      let targetParticipant = undefined;
+    const { ownerName } = targetMessage.metadata;
+    let isRealtimeShare = targetMessage.metadata.isRealtime;
 
-      if (ownerName === 'Me') {
-        // Owner is the sender
-        targetParticipant = participants.find((p) => Number(p.id) === Number(message.senderId));
+    if (isRealtimeShare === undefined) {
+      if (ownerName && ownerName.includes('saved code')) {
+        isRealtimeShare = false;
       } else {
-        // Owner is someone else (by nickname)
-        targetParticipant = participants.find((p) => p.nickname === ownerName);
+        isRealtimeShare = true;
+      }
+    }
+
+    if (isRealtimeShare === false) {
+      let displayOwnerName = ownerName || targetMessage.senderName;
+      if (displayOwnerName === 'Me') {
+        displayOwnerName = targetMessage.senderName;
       }
 
-      // [Feature] Set Selected Problem if metadata has problemId, regardless of target
-      if (message.metadata.problemId) {
-        setSelectedProblem(
-          message.metadata.problemId,
-          null, // Actual problemId might not be available in metadata
-          message.metadata.problemTitle || '',
-          message.metadata.externalId,
-        );
-      }
+      viewSharedCode({
+        code: targetMessage.metadata.code || '',
+        language: targetMessage.metadata.language || 'python',
+        ownerName: displayOwnerName,
+        problemTitle: targetMessage.metadata.problemTitle,
+        problemId: targetMessage.metadata.problemId,
+        externalId: targetMessage.metadata.externalId,
+        isRealtime: false,
+      });
+      return;
+    }
 
-      // If the target is Me -> Reset to Only Mine
-      if (targetParticipant && Number(targetParticipant.id) === Number(currentUserId)) {
-        resetToOnlyMine();
-        return;
-      }
+    let targetParticipant;
 
-      // 4. Try to view real-time code (SPLIT_REALTIME)
-      if (targetParticipant) {
-        viewRealtimeCode(targetParticipant);
-      } else {
-        // Fallback to snapshot if participant is not currently in the room (SPLIT_SAVED)
-        let displayOwnerName = ownerName || message.senderName;
-        if (displayOwnerName === 'Me') {
-          displayOwnerName = message.senderName;
-        }
+    if (ownerName === 'Me') {
+      targetParticipant = participants.find(
+        (participant) => Number(participant.id) === Number(targetMessage.senderId),
+      );
+    } else {
+      targetParticipant = participants.find((participant) => participant.nickname === ownerName);
+    }
 
-        viewSharedCode({
-          code: message.metadata.code || '',
-          language: message.metadata.language || 'python',
-          ownerName: displayOwnerName,
-          problemTitle: message.metadata.problemTitle,
-        });
-      }
+    if (targetMessage.metadata.problemId) {
+      setSelectedProblem(
+        targetMessage.metadata.problemId,
+        null,
+        targetMessage.metadata.problemTitle || '',
+        targetMessage.metadata.externalId,
+      );
+    }
+
+    if (targetParticipant && Number(targetParticipant.id) === Number(currentUserId)) {
+      resetToOnlyMine();
+      return;
+    }
+
+    if (targetParticipant) {
+      viewRealtimeCode(targetParticipant);
+      return;
+    }
+
+    let displayOwnerName = ownerName || targetMessage.senderName;
+    if (displayOwnerName === 'Me') {
+      displayOwnerName = targetMessage.senderName;
+    }
+
+    viewSharedCode({
+      code: targetMessage.metadata.code || '',
+      language: targetMessage.metadata.language || 'python',
+      ownerName: displayOwnerName,
+      problemTitle: targetMessage.metadata.problemTitle,
+      problemId: targetMessage.metadata.problemId,
+      externalId: targetMessage.metadata.externalId,
+    });
+  };
+
+  const handleCodeClick = (e?: React.MouseEvent, targetMessage: ChatMessage = message) => {
+    e?.stopPropagation();
+    activateCodeView(targetMessage);
+  };
+
+  const handleReplyClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!message.id) return;
+
+    setReplyingTo({
+      id: message.id,
+      senderId: message.senderId,
+      senderName: message.senderName,
+      content: displayContent,
+      type: message.type,
+    });
+
+    focusChatInput();
+
+    if (isRefCodeMessage) {
+      activateCodeView(message);
     }
   };
 
-  const isRefCodeMessage = message.type === 'CODE' && !!message.metadata;
+  const handleReferenceClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!message.parentMessage?.id) return;
 
-  const displayContent =
-    isRefCodeMessage && message.content
-      ? message.content
-        // Strip leading [CODE:lang] prefix
-        .replace(/^\[CODE:[^\]]+\]\s*/i, '')
-        // Strip trailing "Ref: ..." part
-        .replace(/\s*Ref:.*$/i, '')
-      : message.content;
+    highlightOriginalMessage(message.parentMessage.id);
+
+    const originalMessage = messageLookup?.[message.parentMessage.id];
+    if (originalMessage?.type === 'CODE' && originalMessage.metadata) {
+      activateCodeView(originalMessage);
+    }
+  };
+
+  const referenceLabel = message.parentMessage
+    ? `${message.parentMessage.senderName}: ${
+        message.parentMessage.content || (message.parentMessage.type === 'CODE' ? 'Code share' : '')
+      }`
+    : null;
 
   return (
     <div
       id={`chat-msg-${message.id}`}
       className={cn(
-        'flex flex-col mb-4 group max-w-[85%] scroll-mt-20 transition-all duration-300',
+        'group mb-4 flex max-w-[85%] scroll-mt-20 flex-col transition-all duration-300',
         isMine ? 'self-end items-end' : 'self-start items-start',
       )}
     >
       {!isMine && (
-        <span className="text-xs text-muted-foreground mb-1 ml-1">{message.senderName}</span>
+        <span className="mb-1 ml-1 text-xs text-muted-foreground">{message.senderName}</span>
       )}
 
-      <div className="flex items-center gap-2 max-w-full">
+      <div className="flex max-w-full items-start gap-2">
+        {isMine && message.id && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleReplyClick}
+            title="Reply"
+            aria-label="Reply"
+            data-testid={`reply-button-${message.id}`}
+            className={cn(
+              'order-first h-8 w-8 shrink-0 transition-opacity',
+              isTouchMobile ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+            )}
+          >
+            <Reply className="h-4 w-4" />
+          </Button>
+        )}
+
         <div
           className={cn(
             'text-sm break-all',
             isRefCodeMessage
-              ? 'px-0 py-0'
+              ? 'cursor-pointer px-0 py-0'
               : isMine
-                ? 'px-3 py-2 rounded-2xl bg-primary text-primary-foreground rounded-tr-md'
-                : 'px-3 py-2 rounded-2xl bg-muted text-foreground rounded-tl-md',
-            isRefCodeMessage && 'cursor-pointer',
+                ? 'rounded-2xl rounded-tr-md bg-primary px-3 py-2 text-primary-foreground'
+                : 'rounded-2xl rounded-tl-md bg-muted px-3 py-2 text-foreground',
           )}
-          onClick={isRefCodeMessage ? handleCodeClick : undefined}
+          onClick={isRefCodeMessage ? (e) => handleCodeClick(e, message) : undefined}
         >
+          {message.parentMessage && referenceLabel && (
+            <button
+              type="button"
+              onClick={handleReferenceClick}
+              data-testid={`chat-reference-${message.id}`}
+              className={cn(
+                'mb-2 flex w-full items-center rounded-lg border px-2 py-1 text-left text-xs transition-colors',
+                isMine
+                  ? 'border-primary-foreground/20 bg-primary-foreground/10 text-primary-foreground/90 hover:bg-primary-foreground/15'
+                  : 'border-border bg-background/80 text-muted-foreground hover:border-primary/40 hover:text-foreground',
+              )}
+            >
+              <span className="truncate">{referenceLabel}</span>
+            </button>
+          )}
+
           {isRefCodeMessage && message.metadata ? (
-            <div className="flex flex-col gap-2 min-w-[220px] max-w-md">
+            <div className="flex max-w-md min-w-[220px] flex-col gap-2">
               <CodeShareCard
                 code={message.metadata.code || ''}
                 language={message.metadata.language}
@@ -196,13 +285,13 @@ export function ChatMessageItem({ message, isMine }: ChatMessageItemProps) {
                 ownerName={message.metadata.ownerName}
                 problemId={message.metadata.problemId}
                 externalId={message.metadata.externalId}
-                onClick={handleCodeClick}
+                onClick={(e) => handleCodeClick(e, message)}
                 className={
-                  isMine ? 'bg-primary-foreground/10 border-primary-foreground/20' : 'bg-background'
+                  isMine ? 'border-primary-foreground/20 bg-primary-foreground/10' : 'bg-background'
                 }
               />
               {displayContent && (
-                <span className="text-xs text-muted-foreground whitespace-pre-line">
+                <span className="whitespace-pre-line text-xs text-muted-foreground">
                   {displayContent}
                 </span>
               )}
@@ -212,12 +301,12 @@ export function ChatMessageItem({ message, isMine }: ChatMessageItemProps) {
               <ReactMarkdown
                 components={{
                   pre: PreBlock,
-                  code: ({ node, className, children, ...props }: any) => {
+                  code: ({ className, children, ...props }: any) => {
                     const match = /language-(\w+)/.exec(className || '');
                     return !match ? (
                       <code
                         className={cn(
-                          'rounded px-1 font-mono text-sm bg-black/10 dark:bg-white/10',
+                          'rounded bg-black/10 px-1 font-mono text-sm dark:bg-white/10',
                           className,
                         )}
                         {...props}
@@ -230,9 +319,7 @@ export function ChatMessageItem({ message, isMine }: ChatMessageItemProps) {
                       </code>
                     );
                   },
-                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                  a: ({ node, ...props }) => (
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  a: ({ ...props }) => (
                     <a {...(props as any)} target="_blank" rel="noopener noreferrer" />
                   ),
                 }}
@@ -242,6 +329,23 @@ export function ChatMessageItem({ message, isMine }: ChatMessageItemProps) {
             </div>
           )}
         </div>
+
+        {!isMine && message.id && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleReplyClick}
+            title="Reply"
+            aria-label="Reply"
+            data-testid={`reply-button-${message.id}`}
+            className={cn(
+              'h-8 w-8 shrink-0 transition-opacity',
+              isTouchMobile ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+            )}
+          >
+            <Reply className="h-4 w-4" />
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/domains/study/components/chat/StudyChatPanel.tsx
+++ b/apps/frontend/src/domains/study/components/chat/StudyChatPanel.tsx
@@ -1,14 +1,17 @@
-import { useRef, useEffect, useLayoutEffect } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+
 import { useRoomStore } from '../../hooks/useRoomStore';
 import { useStudyChat } from '../../hooks/useStudyChat';
-import { ChatMessageItem } from './ChatMessageItem';
 import { ChatInput } from './ChatInput';
-import { Loader2 } from 'lucide-react';
+import { ChatMessageItem } from './ChatMessageItem';
 
 export function StudyChatPanel() {
-  const roomId = useRoomStore((state) => state.roomId); // Revert variable name
+  const roomId = useRoomStore((state) => state.roomId);
   const pendingCodeShare = useRoomStore((state) => state.pendingCodeShare);
   const setPendingCodeShare = useRoomStore((state) => state.setPendingCodeShare);
+  const replyingTo = useRoomStore((state) => state.replyingTo);
+  const setReplyingTo = useRoomStore((state) => state.setReplyingTo);
 
   const {
     messages,
@@ -25,7 +28,16 @@ export function StudyChatPanel() {
   const restoreRef = useRef<{ scrollTop: number; scrollHeight: number } | null>(null);
   const isLoadingOlderRef = useRef(false);
 
-  // Restore scroll position after loading history (layout effect to avoid flicker)
+  const messageLookup = useMemo(
+    () =>
+      Object.fromEntries(
+        messages
+          .filter((message) => Boolean(message.id))
+          .map((message) => [message.id as string, message]),
+      ),
+    [messages],
+  );
+
   useLayoutEffect(() => {
     if (!scrollRef.current) return;
 
@@ -44,6 +56,15 @@ export function StudyChatPanel() {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messages]);
+
+  useEffect(() => {
+    return () => {
+      if (scrollDebounceRef.current) {
+        clearTimeout(scrollDebounceRef.current);
+        scrollDebounceRef.current = null;
+      }
+    };
+  }, []);
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
@@ -79,19 +100,26 @@ export function StudyChatPanel() {
     } else {
       sendMessage(text);
     }
+
+    setReplyingTo(null);
   };
 
   const handleCancelShare = () => {
     setPendingCodeShare(null);
   };
 
-  if (!roomId)
-    return <div className="p-4 text-center text-muted-foreground">스터디 룸에 입장해주세요.</div>;
+  const handleCancelReply = () => {
+    setReplyingTo(null);
+  };
+
+  if (!roomId) {
+    return <div className="p-4 text-center text-muted-foreground">Join a study room first.</div>;
+  }
 
   return (
-    <div className="flex flex-col h-full ">
+    <div className="flex h-full flex-col">
       <div
-        className="flex-1 overflow-y-auto p-4 flex flex-col relative [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+        className="relative flex flex-1 flex-col overflow-y-auto p-4 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         ref={scrollRef}
         onScroll={handleScroll}
       >
@@ -100,13 +128,18 @@ export function StudyChatPanel() {
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           </div>
         )}
+
         {messages.map((msg) => (
           <div
             key={msg.id}
             data-msg-id={msg.id}
             className={msg.senderId === currentUserId ? 'flex justify-end' : 'flex justify-start'}
           >
-            <ChatMessageItem message={msg} isMine={msg.senderId === currentUserId} />
+            <ChatMessageItem
+              message={msg}
+              isMine={msg.senderId === currentUserId}
+              messageLookup={messageLookup}
+            />
           </div>
         ))}
       </div>
@@ -115,6 +148,8 @@ export function StudyChatPanel() {
         onSend={handleSend}
         pendingCodeShare={pendingCodeShare}
         onCancelShare={handleCancelShare}
+        replyingTo={replyingTo}
+        onCancelReply={handleCancelReply}
       />
     </div>
   );

--- a/apps/frontend/src/domains/study/hooks/useStudyChat.ts
+++ b/apps/frontend/src/domains/study/hooks/useStudyChat.ts
@@ -48,7 +48,7 @@ export function useStudyChat(roomId: number) {
         content: msg.content,
         type,
         createdAt: msg.createdAt,
-        parentMessage: undefined,
+        parentMessage: msg.parentMessage || undefined,
         metadata,
       } as ChatMessage;
     },

--- a/apps/frontend/src/domains/study/tests/CCIDEPanel.readonly.test.tsx
+++ b/apps/frontend/src/domains/study/tests/CCIDEPanel.readonly.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CCIDEPanel } from '@/domains/study/components/CCIDEPanel';
+
+const editorStats = vi.hoisted(() => ({
+  mountCount: 0,
+  unmountCount: 0,
+  setModelLanguageCalls: 0,
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: '123' }),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock('@monaco-editor/react', async () => {
+  const React = await import('react');
+
+  const MockEditor = ({
+    value,
+    language,
+    path,
+    onMount,
+  }: {
+    value?: string;
+    language?: string;
+    path?: string;
+    onMount?: (editor: any, monaco: any) => void;
+  }) => {
+    const containerRef = React.useRef<HTMLDivElement | null>(null);
+    const valueRef = React.useRef(value ?? '');
+    const modelRef = React.useRef({
+      languageId: language ?? 'python',
+      getLanguageId() {
+        return modelRef.current.languageId;
+      },
+    });
+    const editorApiRef = React.useRef<any>(null);
+
+    if (!editorApiRef.current) {
+      editorApiRef.current = {
+        getValue: () => valueRef.current,
+        setValue: (next: string) => {
+          valueRef.current = next;
+        },
+        getContainerDomNode: () => containerRef.current ?? document.createElement('div'),
+        addCommand: vi.fn(),
+        trigger: vi.fn(),
+        getModel: () => modelRef.current,
+        onKeyDown: vi.fn(),
+      };
+    }
+
+    React.useEffect(() => {
+      valueRef.current = value ?? '';
+    }, [value]);
+
+    React.useEffect(() => {
+      modelRef.current.languageId = language ?? 'python';
+    }, [language]);
+
+    React.useEffect(() => {
+      editorStats.mountCount += 1;
+      onMount?.(editorApiRef.current, {
+        KeyMod: { Shift: 1 },
+        KeyCode: { Enter: 13, KeyV: 86 },
+        editor: {
+          setModelLanguage: (model: { languageId: string }, nextLanguage: string) => {
+            model.languageId = nextLanguage;
+            editorStats.setModelLanguageCalls += 1;
+          },
+        },
+      });
+
+      return () => {
+        editorStats.unmountCount += 1;
+      };
+    }, []);
+
+    return (
+      <div ref={containerRef} data-testid="mock-monaco-editor" data-language={language} data-path={path}>
+        {value}
+      </div>
+    );
+  };
+
+  return {
+    default: MockEditor,
+  };
+});
+
+describe('CCIDEPanel readonly sync', () => {
+  beforeEach(() => {
+    editorStats.mountCount = 0;
+    editorStats.unmountCount = 0;
+    editorStats.setModelLanguageCalls = 0;
+  });
+
+  it('keeps the readonly editor mounted while realtime code packets update', async () => {
+    const { rerender } = render(
+      <CCIDEPanel
+        readOnly
+        hideToolbar
+        editorId="other-editor"
+        initialCode={'print("a")'}
+        language="python"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(editorStats.mountCount).toBe(1);
+    });
+
+    rerender(
+      <CCIDEPanel
+        readOnly
+        hideToolbar
+        editorId="other-editor"
+        initialCode={'print("ab")'}
+        language="python"
+      />,
+    );
+
+    rerender(
+      <CCIDEPanel
+        readOnly
+        hideToolbar
+        editorId="other-editor"
+        initialCode={'print("abc")'}
+        language="python"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-monaco-editor')).toHaveTextContent('print("abc")');
+    });
+
+    expect(editorStats.mountCount).toBe(1);
+    expect(editorStats.unmountCount).toBe(0);
+  });
+});

--- a/apps/frontend/src/domains/study/types.ts
+++ b/apps/frontend/src/domains/study/types.ts
@@ -86,6 +86,13 @@ export interface ChatMessageResponse {
   content: string;
   type: 'TALK' | 'ENTER' | 'LEAVE' | 'SYSTEM' | 'CODE' | 'SUBMISSION';
   parentId?: number;
+  parentMessage?: {
+    id: string;
+    senderId: number;
+    senderName: string;
+    content: string;
+    type: 'TALK' | 'ENTER' | 'LEAVE' | 'SYSTEM' | 'CODE' | 'SUBMISSION';
+  };
   metadata?: any;
   createdAt: string;
 }

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { ApiResponse } from '@/types/apiUtils';
+import { isPublicE2ERoute } from '@/lib/e2e-routes';
 
 let BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'https://localhost';
 
@@ -206,7 +207,8 @@ function isAuthOrPublicRoute(pathname: string): boolean {
   return (
     pathname === '/' ||
     pathname.startsWith('/login') ||
-    pathname.startsWith('/signup')
+    pathname.startsWith('/signup') ||
+    isPublicE2ERoute(pathname)
   );
 }
 

--- a/apps/frontend/src/lib/e2e-routes.ts
+++ b/apps/frontend/src/lib/e2e-routes.ts
@@ -1,0 +1,9 @@
+export const isE2ERoutesEnabled = process.env.NEXT_PUBLIC_ENABLE_E2E_ROUTES === 'true';
+
+export function isE2ERoutePath(pathname: string | null | undefined): boolean {
+  return Boolean(pathname && pathname.startsWith('/e2e/'));
+}
+
+export function isPublicE2ERoute(pathname: string | null | undefined): boolean {
+  return isE2ERoutesEnabled && isE2ERoutePath(pathname);
+}

--- a/apps/frontend/tests/chat-reference.spec.ts
+++ b/apps/frontend/tests/chat-reference.spec.ts
@@ -1,141 +1,43 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
-// Skip all tests in this file - Reply button feature is not yet implemented in ChatMessageItem
-test.describe.skip('Chat Message Reference', () => {
+test.describe('Chat Message Reference', () => {
   test.beforeEach(async ({ page }) => {
-    // Mock Study Room Info
-    await page.route('**/api/study/1', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          roomId: 1,
-          roomTitle: 'Test Study Room',
-          roomDescription: 'Description',
-          inviteCode: 'TEST12',
-        }),
-      });
-    });
-
-    // Mock Participants
-    await page.route('**/api/study/1/participants', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([
-          { id: 1, nickname: 'Me', isOwner: true, isOnline: true },
-          { id: 2, nickname: 'User2', isOwner: false, isOnline: true },
-        ]),
-      });
-    });
-
-    // Mock Chat History
-    await page.route('**/api/study/1/chats', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([
-          {
-            id: 'msg-1',
-            senderId: 2,
-            senderName: 'User2',
-            content: 'Hello, this is a message to reply to.',
-            type: 'TALK',
-            createdAt: new Date().toISOString(),
-          },
-        ]),
-      });
-    });
-
-    // Mock Problems
-    await page.route('**/api/study/1/problems*', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([]),
-      });
-    });
-
-    await page.goto('/study/1');
-    await page.waitForSelector('text=Test Study Room', { timeout: 10000 }).catch(() => {
-      console.log('Room title not found. Current URL:', page.url());
-    });
+    await page.setViewportSize({ width: 1600, height: 1200 });
+    await page.goto('/e2e/study-interactions');
   });
 
   test('should show reply preview when reply button is clicked', async ({ page }) => {
     const messageItem = page.locator('#chat-msg-msg-1');
     await messageItem.hover();
 
-    const replyButton = messageItem.getByTitle('Reply');
+    const replyButton = page.getByTestId('reply-button-msg-1');
     await expect(replyButton).toBeVisible();
     await replyButton.click();
 
-    const replyPreview = page.locator('text=User2 : Hello, this is a message to reply to.');
-    await expect(replyPreview).toBeVisible();
-
+    await expect(page.getByTestId('reply-preview')).toBeVisible();
+    await expect(page.getByTestId('reply-preview')).toContainText(
+      'OtherUser : Hello, this is a message to reply to.',
+    );
+    await expect(page.getByTestId('replying-to')).toHaveText('msg-1');
     await expect(page.locator('#chat-input')).toBeFocused();
   });
 
   test('should clear reply preview when X is clicked', async ({ page }) => {
     const messageItem = page.locator('#chat-msg-msg-1');
     await messageItem.hover();
-    await messageItem.getByTitle('Reply').click();
+    await page.getByTestId('reply-button-msg-1').click();
 
-    const closeButton = page.locator('button:has(svg.lucide-x)');
-    await closeButton.click();
+    await page.getByTestId('cancel-reply-button').click();
 
-    const replyPreview = page.locator('text=User2 : Hello, this is a message to reply to.');
-    await expect(replyPreview).not.toBeVisible();
+    await expect(page.getByTestId('reply-preview')).toBeHidden();
+    await expect(page.getByTestId('replying-to')).toHaveText('-');
   });
 
   test('should highlight original message when reference is clicked', async ({ page }) => {
-    const messageItem = page.locator('#chat-msg-msg-1');
-    await messageItem.hover();
-    await messageItem.getByTitle('Reply').click();
+    await page.getByTestId('chat-reference-msg-2').click();
 
-    await page.route('**/api/study/1/chats', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([
-          {
-            id: 'msg-1',
-            senderId: 2,
-            senderName: 'User2',
-            content: 'Hello, this is a message to reply to.',
-            type: 'TALK',
-            createdAt: new Date(Date.now() - 10000).toISOString(),
-          },
-          {
-            id: 'msg-2',
-            senderId: 1,
-            senderName: 'Me',
-            content: 'I am replying to you.',
-            type: 'TALK',
-            parentMessage: {
-              id: 'msg-1',
-              senderId: 2,
-              senderName: 'User2',
-              content: 'Hello, this is a message to reply to.',
-              type: 'TALK',
-            },
-            createdAt: new Date().toISOString(),
-          },
-        ]),
-      });
-    });
-
-    await page.reload();
-
-    const replyMsg = page.locator('#chat-msg-msg-2');
-    const referenceBox = replyMsg.locator('text=User2: Hello, this is a message to reply to.');
-    await expect(referenceBox).toBeVisible();
-
-    await referenceBox.click();
-
-    const originalMsg = page.locator('#chat-msg-msg-1');
-    await expect(originalMsg).toHaveClass(/ring-2/);
-
-    await expect(originalMsg).not.toHaveClass(/ring-2/, { timeout: 3000 });
+    const originalMessage = page.locator('#chat-msg-msg-1');
+    await expect(originalMessage).toHaveClass(/ring-2/);
+    await expect(originalMessage).not.toHaveClass(/ring-2/, { timeout: 4000 });
   });
 });

--- a/apps/frontend/tests/code-reference-branch.spec.ts
+++ b/apps/frontend/tests/code-reference-branch.spec.ts
@@ -1,235 +1,112 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Code Reference Branch Tests', () => {
   test.beforeEach(async ({ page }) => {
-    // Mock Study Room Info
-    await page.route('**/api/study/1', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          roomId: 1,
-          roomTitle: 'Test Study Room',
-          roomDescription: 'Description',
-          inviteCode: 'TEST12',
-        }),
-      });
-    });
-
-    // Mock Participants (currentUserId = 1)
-    await page.route('**/api/study/1/participants', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([
-          { id: 1, nickname: 'Me', isOwner: true, isOnline: true },
-          { id: 2, nickname: 'OtherUser', isOwner: false, isOnline: true },
-        ]),
-      });
-    });
-
-    // Mock Problems (with complete Problem type fields)
-    await page.route('**/api/study/1/problems*', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([
-          {
-            id: 1001,
-            number: 1001,
-            title: 'Two Sum',
-            source: 'BOJ',
-            status: 'not_started',
-            participantCount: 2,
-            totalParticipants: 4,
-            tags: ['Implementation', 'Math'],
-          },
-        ]),
-      });
-    });
+    await page.setViewportSize({ width: 1600, height: 1200 });
+    await page.goto('/e2e/study-interactions');
   });
 
-  // Skip tests - UI selectors changed, needs update when feature is implemented
-  test.describe.skip('Problem selection', () => {
+  test.describe('Problem selection', () => {
     test('should display problem card and allow interaction', async ({ page }) => {
-      await page.route('**/api/study/1/chats', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify([]),
-        });
-      });
-
-      await page.goto('/study/1');
-      await page.waitForSelector('text=Test Study Room', { timeout: 10000 }).catch(() => {});
-
-      // Find problem card by role="button" containing the problem title
-      const problemCard = page.locator('[role="button"]').filter({ hasText: '1001. Two Sum' });
-      await expect(problemCard).toBeVisible({ timeout: 10000 });
-
-      // Verify problem card is clickable (has cursor-pointer class)
+      const problemCard = page.locator('[data-testid="problem-card-1001"] [role="button"]');
+      await expect(problemCard).toBeVisible();
       await expect(problemCard).toHaveClass(/cursor-pointer/);
 
-      // Click and verify no error occurs
       await problemCard.click();
 
-      // Wait a moment for potential state updates
-      await page.waitForTimeout(500);
+      await expect(page.getByTestId('selected-problem')).toHaveText('1001. Two Sum');
+      await expect(page.getByTestId('selected-problem-id')).toHaveText('1001');
     });
 
     test('should enable code reference button in IDE toolbar', async ({ page }) => {
-      await page.route('**/api/study/1/chats', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify([]),
-        });
-      });
+      await page.locator('[data-testid="problem-card-1001"] [role="button"]').click();
 
-      await page.goto('/study/1');
-      await page.waitForSelector('text=Test Study Room', { timeout: 10000 }).catch(() => {});
-
-      // Verify code reference button exists and is clickable
-      const codeRefButton = page.locator('button[title="코드 참조 (채팅)"]');
-      await expect(codeRefButton).toBeVisible({ timeout: 10000 });
+      const codeRefButton = page.getByTestId('ide-share-code-button');
+      await expect(codeRefButton).toBeVisible({ timeout: 30000 });
       await expect(codeRefButton).toBeEnabled();
-
-      // Click the button
-      await codeRefButton.click();
-
-      // Verify the click triggers some action
-      await page.waitForTimeout(500);
     });
   });
 
-  // Skip tests - CODE message UI not implemented yet
-  test.describe.skip('CODE message click branch', () => {
+  test.describe('CODE message click branch', () => {
     test('should activate split view when clicking other user CODE message', async ({ page }) => {
-      // Mock chat with other user's CODE message
-      await page.route('**/api/study/1/chats', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify([
-            {
-              id: 'code-msg-1',
-              senderId: 2, // Other user
-              senderName: 'OtherUser',
-              content: 'Check out my solution!',
-              type: 'CODE',
-              metadata: {
-                code: 'def solution(): pass',
-                language: 'python',
-                problemTitle: 'Two Sum',
-                ownerName: 'OtherUser',
-                isRealtime: true,
-              },
-              createdAt: new Date().toISOString(),
-            },
-          ]),
-        });
-      });
+      await page.locator('#chat-msg-code-msg-1').click();
 
-      await page.goto('/study/1');
-      await page.waitForSelector('text=Test Study Room', { timeout: 10000 }).catch(() => {});
-
-      // Click on CODE message card
-      const codeCard = page.locator('#chat-msg-code-msg-1');
-      await expect(codeCard).toBeVisible({ timeout: 10000 });
-      await codeCard.click();
-
-      // Verify split view banner appears with correct text pattern
-      const splitViewBanner = page.locator('text=OtherUser의 코드 실시간 열람 중');
-      await expect(splitViewBanner).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('view-mode')).toHaveText('SPLIT_REALTIME');
+      await expect(page.getByTestId('viewing-user')).toHaveText('OtherUser');
+      await expect(page.getByTestId('selected-problem')).toHaveText('1001. Two Sum');
     });
 
     test('should NOT activate split view when clicking own CODE message', async ({ page }) => {
-      // Mock chat with my CODE message
-      await page.route('**/api/study/1/chats', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify([
-            {
-              id: 'code-msg-mine',
-              senderId: 1, // My ID
-              senderName: 'Me',
-              content: 'Here is my code',
-              type: 'CODE',
-              metadata: {
-                code: 'def my_solution(): pass',
-                language: 'python',
-                problemTitle: 'Two Sum',
-                ownerName: 'Me',
-                isRealtime: true,
-              },
-              createdAt: new Date().toISOString(),
-            },
-          ]),
-        });
-      });
+      await page.locator('#chat-msg-code-msg-mine').click();
 
-      await page.goto('/study/1');
-      await page.waitForSelector('text=Test Study Room', { timeout: 10000 }).catch(() => {});
-
-      // Click on my CODE message
-      const codeCard = page.locator('#chat-msg-code-msg-mine');
-      await expect(codeCard).toBeVisible({ timeout: 10000 });
-      await codeCard.click();
-
-      // Verify split view banner does NOT appear
-      const splitViewBanner = page.locator('text=열람 중');
-      await expect(splitViewBanner).not.toBeVisible({ timeout: 2000 });
+      await expect(page.getByTestId('view-mode')).toHaveText('ONLY_MINE');
+      await expect(page.getByTestId('viewing-user')).toHaveText('-');
     });
   });
 
-  // Skip tests that require parentMessage reference display (not yet implemented)
-  test.describe.skip('CODE reference click in reply message', () => {
-    test('should scroll to original CODE message and activate split view when clicking reference', async () => {
-      // Test skipped - parentMessage reference display not implemented
+  test.describe('CODE reference click in reply message', () => {
+    test('should scroll to original CODE message and activate split view when clicking reference', async ({
+      page,
+    }) => {
+      await page.getByTestId('chat-reference-msg-ref-code-other').click();
+
+      await expect(page.locator('#chat-msg-code-msg-1')).toHaveClass(/ring-2/);
+      await expect(page.getByTestId('view-mode')).toHaveText('SPLIT_REALTIME');
+      await expect(page.getByTestId('viewing-user')).toHaveText('OtherUser');
     });
 
-    test('should only scroll without split view when clicking TALK reference', async () => {
-      // Test skipped - parentMessage reference display not implemented
+    test('should only scroll without split view when clicking TALK reference', async ({ page }) => {
+      await page.getByTestId('chat-reference-msg-ref-talk').click();
+
+      await expect(page.locator('#chat-msg-msg-1')).toHaveClass(/ring-2/);
+      await expect(page.getByTestId('view-mode')).toHaveText('ONLY_MINE');
+      await expect(page.getByTestId('viewing-user')).toHaveText('-');
     });
 
-    test('should NOT activate split view when clicking own CODE reference', async () => {
-      // Test skipped - parentMessage reference display not implemented
+    test('should NOT activate split view when clicking own CODE reference', async ({ page }) => {
+      await page.getByTestId('chat-reference-msg-ref-code-mine').click();
+
+      await expect(page.locator('#chat-msg-code-msg-mine')).toHaveClass(/ring-2/);
+      await expect(page.getByTestId('view-mode')).toHaveText('ONLY_MINE');
+      await expect(page.getByTestId('viewing-user')).toHaveText('-');
     });
   });
 
-  // Skip tests - IDE toolbar code reference button not implemented yet
-  test.describe.skip('IDE toolbar code reference button', () => {
+  test.describe('IDE toolbar code reference button', () => {
     test('should set pending code share when clicking code reference button', async ({ page }) => {
-      await page.route('**/api/study/1/chats', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify([]),
-        });
-      });
+      await page.locator('[data-testid="problem-card-1001"] [role="button"]').click();
+      await page.getByTestId('ide-share-code-button').click();
 
-      await page.goto('/study/1');
-      await page.waitForSelector('text=Test Study Room', { timeout: 10000 }).catch(() => {});
-
-      // Find and click the code reference button in IDE toolbar
-      const codeRefButton = page.locator('button[title="코드 참조 (채팅)"]');
-      await expect(codeRefButton).toBeVisible({ timeout: 10000 });
-      await codeRefButton.click();
-
-      // Verify the button click doesn't cause errors
-      await page.waitForTimeout(500);
+      await expect(page.getByTestId('pending-code-share')).toBeVisible();
+      await expect(page.getByTestId('pending-share-owner')).toHaveText('Me');
+      await expect(page.getByTestId('pending-code-share')).toContainText('Two Sum');
+      await expect(page.locator('#chat-input')).toBeFocused();
     });
   });
 
-  // Skip tests that require reply button (not yet implemented in ChatMessageItem)
-  test.describe.skip('Reply to CODE message branch', () => {
-    test('should auto-split view when replying to other user CODE message', async () => {
-      // Test skipped - Reply button not implemented
+  test.describe('Reply to CODE message branch', () => {
+    test('should auto-split view when replying to other user CODE message', async ({ page }) => {
+      const codeMessage = page.locator('#chat-msg-code-msg-1');
+      await codeMessage.hover();
+      await page.getByTestId('reply-button-code-msg-1').click();
+
+      await expect(page.getByTestId('reply-preview')).toContainText(
+        'OtherUser : Check out my solution!',
+      );
+      await expect(page.getByTestId('replying-to')).toHaveText('code-msg-1');
+      await expect(page.getByTestId('view-mode')).toHaveText('SPLIT_REALTIME');
+      await expect(page.getByTestId('viewing-user')).toHaveText('OtherUser');
     });
 
-    test('should NOT auto-split view when replying to own CODE message', async () => {
-      // Test skipped - Reply button not implemented
+    test('should NOT auto-split view when replying to own CODE message', async ({ page }) => {
+      const codeMessage = page.locator('#chat-msg-code-msg-mine');
+      await codeMessage.hover();
+      await page.getByTestId('reply-button-code-msg-mine').click();
+
+      await expect(page.getByTestId('reply-preview')).toContainText('Me : Here is my code.');
+      await expect(page.getByTestId('replying-to')).toHaveText('code-msg-mine');
+      await expect(page.getByTestId('view-mode')).toHaveText('ONLY_MINE');
+      await expect(page.getByTestId('viewing-user')).toHaveText('-');
     });
   });
 });

--- a/apps/frontend/tests/readonly-editor-realtime.spec.ts
+++ b/apps/frontend/tests/readonly-editor-realtime.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Readonly realtime editor', () => {
+  test('keeps Monaco mounted while readonly packets update', async ({ page }) => {
+    await page.goto('/e2e/readonly-editor');
+
+    await expect(page.getByTestId('mount-count')).toHaveText('1', { timeout: 30000 });
+    await expect(page.getByTestId('observed-editor-value')).toHaveText('print("a")');
+
+    await page.getByTestId('apply-packet-1').click();
+    await expect(page.getByTestId('incoming-packet')).toHaveText('print("ab")');
+    await expect(page.getByTestId('observed-editor-value')).toHaveText('print("ab")');
+    await expect(page.getByTestId('mount-count')).toHaveText('1');
+
+    await page.getByTestId('apply-packet-2').click();
+    await expect(page.getByTestId('incoming-packet')).toHaveText('print("abc")');
+    await expect(page.getByTestId('observed-editor-value')).toHaveText('print("abc")');
+    await expect(page.getByTestId('mount-count')).toHaveText('1');
+
+    await page.getByTestId('apply-packet-3').click();
+    await expect(page.getByTestId('incoming-packet')).toHaveText('print("abcd")');
+    await expect(page.getByTestId('observed-editor-value')).toHaveText('print("abcd")');
+    await expect(page.getByTestId('mount-count')).toHaveText('1');
+  });
+});


### PR DESCRIPTION
## 💡 의도 / 배경
- 실시간 코드 동기화 중 readonly Monaco Editor가 원격 코드 패킷마다 다시 마운트되면서, IDE 렌더링 비용이 불필요하게 커지고 있었습니다.
- 기존에는 `initialCode` 변경 시 `modelId`가 증가하고 `Editor key`가 바뀌어, 협업 타이핑이 많을수록 화면 안정성과 반응성이 저하될 수 있었습니다.
- 이번 PR은 해당 렌더링 병목을 제거하고, 같은 문제가 다시 발생하지 않도록 unit test / E2E / pre-push 검증까지 함께 보강하기 위해 작업했습니다.

## 🛠️ 작업 내용
- [x] `CCIDEPanel` readonly 동기화 경로를 수정해, 원격 코드 패킷 수신 시 Monaco 인스턴스를 재마운트하지 않고 기존 model의 `setValue`, `setModelLanguage`만 갱신하도록 변경했습니다.
- [x] readonly 실시간 코드 업데이트 시 editor mount count가 유지되는 unit test를 추가했습니다.
- [x] `/e2e/readonly-editor` 테스트 harness와 Playwright 시나리오를 추가해, 실제 브라우저 기준으로 remount 회귀를 검증할 수 있도록 했습니다.
- [x] `/e2e/*` 라우트가 public prod에 노출되지 않도록 env gate를 추가했습니다.
- [x] Windows/Git Bash 환경에서 pre-push 검증이 안정적으로 돌도록 `.husky/pre-push` 스크립트를 정리했습니다.

## 🔗 관련 이슈
- Closes #131

## 🖼️ 스크린샷 (선택)
- UI 변경보다는 성능 최적화와 회귀 방지 테스트가 중심인 작업이라 별도 스크린샷은 없습니다.
- 필요 시 `/e2e/readonly-editor` 검증 화면을 첨부할 수 있습니다.

## 🧪 테스트 방법
- [x] `pnpm --filter frontend type-check`
- [x] `pnpm --filter frontend test --run`
- [x] `pnpm --filter frontend build`
- [x] `pnpm --filter frontend test:e2e`

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
