### PR TITLE
feat: 테스트케이스 ui/ux 개선

### DIFF
--- a/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
@@ -8,6 +8,7 @@ import { CCControlBar as ControlBar } from '@/domains/study/components/CCControl
 import { CCIDEPanel as IDEPanel } from '@/domains/study/components/CCIDEPanel';
 import { CCIDEToolbar as IDEToolbar } from '@/domains/study/components/CCIDEToolbar';
 import { CCConsolePanel } from '@/domains/study/components/CCConsolePanel';
+import { CCTestcaseRunnerModal } from '@/domains/study/components/CCTestcaseRunnerModal';
 import { useExecution } from '@/domains/study/hooks/useExecution';
 import { WhiteboardPanel } from '@/domains/study/components/whiteboard/WhiteboardOverlay';
 import { useRealtimeCode } from '@/domains/study/hooks/useRealtimeCode';
@@ -195,6 +196,7 @@ print("Hello World!")`;
   const [isConsoleOpen, setIsConsoleOpen] = useState(false);
   const [consoleHeight, setConsoleHeight] = useState(250);
   const [isResizingConsole, setIsResizingConsole] = useState(false);
+  const [isTestcaseRunnerOpen, setIsTestcaseRunnerOpen] = useState(false);
   const consoleResizeStartY = useRef<number>(0);
   const consoleResizeStartHeight = useRef<number>(0);
 
@@ -233,6 +235,14 @@ print("Hello World!")`;
     handleFontSizeChange(clamped);
     setFontSizeInput(clamped.toString());
   }, [fontSize]);
+
+  const handleOpenTestcaseRunner = useCallback(() => {
+    if (!selectedStudyProblemId || !selectedProblemTitle) {
+      toast.error('문제를 먼저 선택해주세요.');
+      return;
+    }
+    setIsTestcaseRunnerOpen(true);
+  }, [selectedStudyProblemId, selectedProblemTitle]);
 
   useEffect(() => {
     if (isMobile) {
@@ -1946,6 +1956,8 @@ print("Hello World!")`;
               showFontSizeControl={false}
               isExecuting={isExecuting}
               onToggleConsole={() => setIsConsoleOpen((prev) => !prev)}
+              showTestcaseRunner={!isViewingOther}
+              onOpenTestcaseRunner={handleOpenTestcaseRunner}
               onExecute={() => {
                 if (isMobile && !isConsoleOpen) {
                   setIsConsoleOpen(true);
@@ -2246,6 +2258,13 @@ print("Hello World!")`;
           isMobile &&
             'fixed inset-x-0 bottom-[calc(64px+env(safe-area-inset-bottom))] mb-1 z-[55] shadow-[0_-8px_24px_-16px_rgba(0,0,0,0.4)]',
         )}
+      />
+      <CCTestcaseRunnerModal
+        roomId={roomId}
+        studyProblemId={selectedStudyProblemId}
+        problemTitle={selectedProblemTitle || '문제'}
+        isOpen={isTestcaseRunnerOpen}
+        onClose={() => setIsTestcaseRunnerOpen(false)}
       />
     </div>
   );

--- a/apps/frontend/src/domains/study/components/CCConsolePanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCConsolePanel.tsx
@@ -1,13 +1,20 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { X, Plus, Trash2, Settings2, Edit2, CheckCircle2, XCircle } from 'lucide-react';
+import { X, Plus, Trash2, Settings2, Edit2, CheckCircle2, XCircle, Share2 } from 'lucide-react';
 import type { ExecutionResponse } from '@/domains/study/hooks/useExecution';
+import { apiFetch } from '@/lib/api';
+import { toast } from 'sonner';
 
 interface TestCase {
     id: string;
     name: string;
     input: string;
+}
+
+interface SharedTestCase {
+    input: string;
+    expectedOutput: string;
 }
 
 interface CCConsolePanelProps {
@@ -35,6 +42,7 @@ export function CCConsolePanel({
     ]);
     const [activeTestCaseId, setActiveTestCaseId] = useState<string>('default');
     const [autoNewline, setAutoNewline] = useState<boolean>(true);
+    const [isSharing, setIsSharing] = useState<boolean>(false);
 
     // Load from LocalStorage
     useEffect(() => {
@@ -118,6 +126,85 @@ export function CCConsolePanel({
         }
     };
 
+    const handleShareTestcases = async (e: React.MouseEvent) => {
+        e.stopPropagation();
+
+        if (!roomId || !problemId) {
+            toast.error('문제를 선택한 뒤 테스트케이스를 공유할 수 있습니다.');
+            return;
+        }
+
+        if (testCases.length === 0) {
+            toast.error('공유할 테스트케이스가 없습니다.');
+            return;
+        }
+
+        setIsSharing(true);
+        try {
+            const toShare: SharedTestCase[] = testCases
+                .map((tc) => ({
+                    input: tc.input ?? '',
+                    expectedOutput: '',
+                }))
+                .filter((tc) => tc.input.trim().length > 0);
+
+            if (toShare.length === 0) {
+                toast.error('공유할 입력값이 없습니다.');
+                return;
+            }
+
+            const existingResponse = await apiFetch<SharedTestCase[]>(
+                `/api/studies/${roomId}/problems/${problemId}/testcases`,
+            );
+
+            const existing: SharedTestCase[] =
+                existingResponse.success && Array.isArray(existingResponse.data)
+                    ? existingResponse.data.map((tc) => ({
+                        input: tc.input ?? '',
+                        expectedOutput: tc.expectedOutput ?? '',
+                    }))
+                    : [];
+
+            const existingKeys = new Set(
+                existing.map((tc) => `${tc.input}\u0000${tc.expectedOutput}`),
+            );
+            const uniqueToShare = toShare.filter((tc) => {
+                const key = `${tc.input}\u0000${tc.expectedOutput}`;
+                if (existingKeys.has(key)) return false;
+                existingKeys.add(key);
+                return true;
+            });
+
+            if (uniqueToShare.length === 0) {
+                toast.info('이미 공유된 테스트케이스입니다.');
+                return;
+            }
+
+            const mergedPayload = [...existing, ...uniqueToShare];
+
+            const response = await apiFetch(`/api/studies/${roomId}/problems/${problemId}/testcases`, {
+                method: 'POST',
+                body: JSON.stringify(mergedPayload),
+            });
+
+            if (!response.success) {
+                toast.error(response.error?.message || '테스트케이스 공유에 실패했습니다.');
+                return;
+            }
+
+            toast.success(`테스트케이스 ${uniqueToShare.length}개를 공유했습니다.`);
+            window.dispatchEvent(
+                new CustomEvent('study-testcases-updated', {
+                    detail: { studyId: roomId },
+                }),
+            );
+        } catch {
+            toast.error('테스트케이스 공유 중 오류가 발생했습니다.');
+        } finally {
+            setIsSharing(false);
+        }
+    };
+
     return (
         <div className="flex flex-col h-full bg-background relative w-full overflow-hidden">
             {/* Header - Test Case Chips */}
@@ -195,9 +282,29 @@ export function CCConsolePanel({
                                     {currentTestCase.input.replace(/\n/g, ' ↵ ') || '입력값 없음'}
                                 </span>
                             </div>
-                            <Button variant="ghost" size="sm" className="h-6 px-2.5 text-xs text-muted-foreground font-medium hover:text-foreground hover:bg-background/80 shrink-0 border border-transparent hover:border-border">
-                                <Edit2 className="h-3 w-3 mr-1.5" />입력 편집
-                            </Button>
+                            <div className="flex items-center gap-1.5 shrink-0">
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-6 px-2.5 text-xs text-muted-foreground font-medium hover:text-foreground hover:bg-background/80 border border-transparent hover:border-border"
+                                    onClick={handleShareTestcases}
+                                    disabled={isExecuting || isSharing || !roomId || !problemId || testCases.length === 0}
+                                >
+                                    <Share2 className="h-3 w-3 mr-1.5" />
+                                    {isSharing ? '공유 중...' : '테스트케이스 공유'}
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-6 px-2.5 text-xs text-muted-foreground font-medium hover:text-foreground hover:bg-background/80 border border-transparent hover:border-border"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        setMode('input');
+                                    }}
+                                >
+                                    <Edit2 className="h-3 w-3 mr-1.5" />입력 편집
+                                </Button>
+                            </div>
                         </div>
 
                         {/* Output area */}

--- a/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
+++ b/apps/frontend/src/domains/study/components/CCIDEToolbar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Copy, Moon, Sun, Send, Eye, Archive, Minus, Plus, Play, TerminalSquare, Share2, Columns2, MoreHorizontal } from 'lucide-react';
+import { Copy, Moon, Sun, Send, Eye, Archive, Minus, Plus, Play, TerminalSquare, Share2, Columns2, MoreHorizontal, CheckSquare, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -38,8 +38,10 @@ export interface CCIDEToolbarProps {
   onExecute?: () => void;
   onToggleConsole?: () => void;
   onOpenProblemSplit?: () => void;
+  onOpenTestcaseRunner?: () => void;
   disabled?: boolean;
   showProblemSplit?: boolean;
+  showTestcaseRunner?: boolean;
 
   // View Mode Props
   viewingUser?: Participant | null;
@@ -70,12 +72,14 @@ export function CCIDEToolbar({
   onExecute,
   onToggleConsole,
   onOpenProblemSplit,
+  onOpenTestcaseRunner,
   viewingUser,
   viewMode,
   targetSubmission,
   onResetView,
   disabled = false,
   showProblemSplit = false,
+  showTestcaseRunner = false,
   problemExternalId,
 }: CCIDEToolbarProps) {
   const isMobile = useIsTouchMobile();
@@ -84,6 +88,7 @@ export function CCIDEToolbar({
   const isViewingOther = viewMode !== 'ONLY_MINE';
   const shouldShowLanguageSelect = !isViewingOther;
   const [isSplitSizedWindow, setIsSplitSizedWindow] = useState(false);
+  const [isTestToolsOpen, setIsTestToolsOpen] = useState(false);
 
   // Use local state for the input field to allow users to clear it while typing
   const [inputValue, setInputValue] = useState<string>(fontSize.toString());
@@ -116,6 +121,9 @@ export function CCIDEToolbar({
     ? '좌측 창에 현재 문제 열기'
     : '현재 문제를 분할 화면으로 열기';
   const isCompactToolbar = isSplitSizedWindow && !isMobile;
+  const compactProblemSplitButtonLabel = isCompactToolbar ? '문제 열기' : problemSplitButtonLabel;
+  const showConsoleTool = showExecute && showConsoleToggle;
+  const showTestTools = showConsoleTool || showTestcaseRunner;
 
   const handleDecreaseFont = () => {
     if (onFontSizeChange && fontSize > 5) {
@@ -412,17 +420,6 @@ export function CCIDEToolbar({
                     </Button>
                   )}
 
-                  {showProblemSplit && !isViewingOther && !isMobile && (
-                    <Button
-                      variant="ghost"
-                      onClick={onOpenProblemSplit}
-                      disabled={disabled}
-                      className="h-9 justify-start gap-2"
-                    >
-                      <Columns2 className="h-4 w-4" />
-                      <span className="text-sm">{problemSplitButtonLabel}</span>
-                    </Button>
-                  )}
                 </div>
               </PopoverContent>
             </Popover>
@@ -432,7 +429,7 @@ export function CCIDEToolbar({
           {!isViewingOther && (
             <>
               {/* Desktop-only Split Open */}
-              {showProblemSplit && !isMobile && !isCompactToolbar && (
+              {showProblemSplit && !isMobile && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
@@ -440,36 +437,91 @@ export function CCIDEToolbar({
                       variant="ghost"
                       onClick={onOpenProblemSplit}
                       disabled={disabled}
-                      className="ml-1 gap-1.5 focus:ring-0 transition-all active:scale-95 px-3 h-10 text-muted-foreground hover:text-foreground"
+                      className={cn(
+                        'ml-1 gap-1.5 focus:ring-0 transition-all active:scale-95 px-3 h-10',
+                        isCompactToolbar
+                          ? 'text-muted-foreground border border-border/70 hover:text-foreground hover:bg-accent'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
                     >
                       <Columns2 className="h-[18px] w-[18px]" />
-                      <span className="font-semibold text-sm">{problemSplitButtonLabel}</span>
+                      <span className="font-semibold text-sm whitespace-nowrap">
+                        {compactProblemSplitButtonLabel}
+                      </span>
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>{problemSplitTooltipLabel}</TooltipContent>
                 </Tooltip>
               )}
 
-              {/* Console Toggle */}
-              {showExecute && showConsoleToggle && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={onToggleConsole}
-                      disabled={disabled}
-                      className={cn(
-                        'ml-1 gap-1.5 focus:ring-0 transition-all active:scale-95 h-10 text-muted-foreground hover:text-foreground',
-                        isCompactToolbar ? 'w-10 px-0' : 'px-3',
+              {/* Test Tools */}
+              {showTestTools && (
+                <Popover open={isTestToolsOpen} onOpenChange={setIsTestToolsOpen}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={disabled}
+                          className={cn(
+                            'ml-1 gap-1.5 focus:ring-0 transition-all active:scale-95 h-10 px-3',
+                            isCompactToolbar
+                              ? 'text-muted-foreground border border-border/70 hover:text-foreground hover:bg-accent'
+                              : 'text-muted-foreground hover:text-foreground',
+                          )}
+                        >
+                          <TerminalSquare className="h-[18px] w-[18px]" />
+                          <span className="font-medium text-sm whitespace-nowrap">테스트</span>
+                          <ChevronDown className="h-3.5 w-3.5 opacity-70" />
+                        </Button>
+                      </PopoverTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>테스트 도구 열기</TooltipContent>
+                  </Tooltip>
+                  <PopoverContent align="end" className="w-72 p-2">
+                    <div className="flex flex-col gap-1">
+                      {showConsoleTool && (
+                        <Button
+                          variant="ghost"
+                          onClick={() => {
+                            onToggleConsole?.();
+                            setIsTestToolsOpen(false);
+                          }}
+                          disabled={disabled}
+                          className="h-auto items-start justify-start gap-2 px-3 py-2"
+                        >
+                          <TerminalSquare className="mt-0.5 h-4 w-4 shrink-0" />
+                          <div className="flex flex-col items-start text-left">
+                            <span className="text-sm font-semibold leading-5">테스트 케이스 편집</span>
+                            <span className="text-[11px] text-muted-foreground leading-4">
+                              입력값을 수정하고 빠르게 실행합니다.
+                            </span>
+                          </div>
+                        </Button>
                       )}
-                    >
-                      <TerminalSquare className="h-[18px] w-[18px]" />
-                      {!isCompactToolbar && <span className="font-semibold text-sm">테스트 케이스</span>}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>테스트 케이스 편집</TooltipContent>
-                </Tooltip>
+                      {showTestcaseRunner && (
+                        <Button
+                          variant="ghost"
+                          onClick={() => {
+                            onOpenTestcaseRunner?.();
+                            setIsTestToolsOpen(false);
+                          }}
+                          disabled={disabled}
+                          className="h-auto items-start justify-start gap-2 px-3 py-2"
+                        >
+                          <CheckSquare className="mt-0.5 h-4 w-4 shrink-0" />
+                          <div className="flex flex-col items-start text-left">
+                            <span className="text-sm font-semibold leading-5">전체 케이스 검증</span>
+                            <span className="text-[11px] text-muted-foreground leading-4">
+                              여러 케이스를 저장하고 일괄 비교 실행합니다.
+                            </span>
+                          </div>
+                        </Button>
+                      )}
+                    </div>
+                  </PopoverContent>
+                </Popover>
               )}
 
               {/* Execute */}

--- a/apps/frontend/src/domains/study/components/CCProblemCard.tsx
+++ b/apps/frontend/src/domains/study/components/CCProblemCard.tsx
@@ -8,8 +8,6 @@ import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
 import { Button } from '@/components/ui/button';
 import { ActionModal } from '@/components/common/Modal';
 import { Separator } from '@/components/ui/separator';
-import { CCTestcaseRunnerModal } from './CCTestcaseRunnerModal';
-import { CheckSquare } from 'lucide-react';
 
 interface CCProblemCardProps {
   problem: Problem;
@@ -33,7 +31,6 @@ export function CCProblemCard({
   isCompact = false,
 }: CCProblemCardProps) {
   const [showHint, setShowHint] = useState(false);
-  const [isTestcaseModalOpen, setIsTestcaseModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const myRole = useRoomStore((state) => state.myRole);
 
@@ -168,21 +165,6 @@ export function CCProblemCard({
             )}
             onClick={(e) => {
               e.stopPropagation();
-              setIsTestcaseModalOpen(true);
-            }}
-            title="테스트 케이스 검증"
-          >
-            <CheckSquare className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className={cn(
-              "h-7 w-7 p-0",
-              isSelected ? "hover:bg-background" : "hover:bg-accent"
-            )}
-            onClick={(e) => {
-              e.stopPropagation();
               onOpenDescription?.();
             }}
             title="메모"
@@ -231,15 +213,6 @@ export function CCProblemCard({
         confirmText="삭제"
         cancelText="취소"
         variant="destructive"
-      />
-
-      {/* Testcase Runner Modal */}
-      <CCTestcaseRunnerModal
-        roomId={useRoomStore.getState().roomId}
-        studyProblemId={(problem as any).studyProblemId || (problem as any).id || null}
-        problemTitle={displayTitle}
-        isOpen={isTestcaseModalOpen}
-        onClose={() => setIsTestcaseModalOpen(false)}
       />
     </div>
   );

--- a/apps/frontend/src/domains/study/components/CCTestcaseRunnerModal.tsx
+++ b/apps/frontend/src/domains/study/components/CCTestcaseRunnerModal.tsx
@@ -66,13 +66,33 @@ export function CCTestcaseRunnerModal({
     const [isExecuting, setIsExecuting] = useState(false);
     const [executingId, setExecutingId] = useState<string | null>(null);
 
+    const normalizeFetchedTestcases = useCallback((incoming: any[], prev: TestCase[]): TestCase[] => {
+        if (!Array.isArray(incoming) || incoming.length === 0) {
+            return [{ id: '1', input: '', expectedOutput: '' }];
+        }
+
+        return incoming.map((item, index) => {
+            const fallbackId = prev[index]?.id || `${Date.now()}-${index}`;
+            const rawId = item?.id;
+            const normalizedId = rawId !== undefined && rawId !== null && rawId !== ''
+                ? String(rawId)
+                : fallbackId;
+
+            return {
+                id: normalizedId,
+                input: String(item?.input ?? ''),
+                expectedOutput: String(item?.expectedOutput ?? ''),
+            };
+        });
+    }, []);
+
     // Memoized function to fetch testcases
     const fetchTestcases = useCallback(async () => {
         if (!roomId || !studyProblemId) return;
         try {
             const response = await apiFetch<TestCase[]>(`/api/studies/${roomId}/problems/${studyProblemId}/testcases`);
             if (response.success && response.data && response.data.length > 0) {
-                setTestcases(response.data);
+                setTestcases((prev) => normalizeFetchedTestcases(response.data as any[], prev));
             } else {
                 // Default empty case if none exist
                 setTestcases([{ id: '1', input: '', expectedOutput: '' }]);
@@ -86,41 +106,24 @@ export function CCTestcaseRunnerModal({
                 if (saved) {
                     const parsed = JSON.parse(saved);
                     if (parsed && parsed.length > 0) {
-                        setTestcases(parsed);
+                        setTestcases((prev) => normalizeFetchedTestcases(parsed, prev));
                     }
                 }
             } catch {
                 // ignore
             }
         }
-    }, [roomId, studyProblemId]);
+    }, [roomId, studyProblemId, normalizeFetchedTestcases]);
 
-    // Load from DB when modal opens
+    // Load latest saved testcases only when modal opens.
+    // While the modal is open, do not sync live websocket updates.
     useEffect(() => {
         if (!isOpen || !roomId || !studyProblemId) return;
 
         fetchTestcases();
         // Clear previous results on open
         setResults({});
-
-        // Listen for WebSocket updates from other users
-        const handleTestcasesUpdated = (e: Event) => {
-            const customEvent = e as CustomEvent;
-            // Only update if it's for the current room
-            if (customEvent.detail.studyId === roomId) {
-                // Optionally check if user is not the one who saved, but re-fetching is fine.
-                fetchTestcases();
-            }
-        };
-
-        window.addEventListener('study-testcases-updated', handleTestcasesUpdated);
-
-        return () => {
-            window.removeEventListener('study-testcases-updated', handleTestcasesUpdated);
-        };
     }, [isOpen, roomId, studyProblemId, fetchTestcases]);
-
-    if (!isOpen) return null;
 
     const handleAddTestcase = () => {
         const newId = Date.now().toString();
@@ -160,6 +163,8 @@ export function CCTestcaseRunnerModal({
         }
     }, [roomId, studyProblemId, testcases]);
 
+    if (!isOpen) return null;
+
     const handleSaveTestcase = async () => {
         await saveTestcases();
     };
@@ -177,90 +182,144 @@ export function CCTestcaseRunnerModal({
         setTestcases(prev => prev.map(tc => tc.id === id ? { ...tc, [field]: value } : tc));
     };
 
+    const requestCurrentCode = async (): Promise<{ code: string; language: string } | null> => {
+        const received = await new Promise<{ code: string; language: string } | null>((resolve) => {
+            const timeoutId = window.setTimeout(() => {
+                resolve(null);
+            }, 1000);
+
+            const handleReceiveCode = (e: Event) => {
+                window.clearTimeout(timeoutId);
+                const customEvent = e as CustomEvent;
+                resolve({
+                    code: customEvent.detail?.code || '',
+                    language: customEvent.detail?.language || 'python',
+                });
+            };
+
+            window.addEventListener('receive-ide-code', handleReceiveCode, { once: true });
+            window.dispatchEvent(new Event('request-ide-code'));
+        });
+
+        if (!received?.code || !received.code.trim()) {
+            toast.error('에디터 코드를 가져오지 못했습니다. 잠시 후 다시 시도해주세요.');
+            return null;
+        }
+
+        return received;
+    };
+
+    const executeTestcase = async (
+        testcase: TestCase,
+        currentCode: string,
+        currentLang: string,
+    ): Promise<TestResult> => {
+        try {
+            // Ensure input ends with newline if required, basic normalize
+            let finalInput = testcase.input;
+            if (finalInput && !finalInput.endsWith('\n')) finalInput += '\n';
+
+            const response = await apiFetch<ExecutionResponse>('/api/executions/run', {
+                method: 'POST',
+                body: JSON.stringify({
+                    language: currentLang,
+                    code: currentCode,
+                    input: finalInput
+                }),
+            });
+
+            const data = response.data;
+            const stdoutTrimmed = data?.stdout ? data.stdout.trim() : '';
+            const expectedTrimmed = testcase.expectedOutput ? testcase.expectedOutput.trim() : '';
+
+            let passed: boolean | null = null;
+            if (expectedTrimmed) {
+                passed = (stdoutTrimmed === expectedTrimmed) && data?.exitCode === 0;
+            }
+
+            return {
+                stdout: data?.stdout || '',
+                stderr: data?.stderr || response.error?.message || '',
+                exitCode: data?.exitCode ?? -1,
+                executionTime: data?.executionTime || 0,
+                memoryUsage: data?.memoryUsage || 0,
+                passed
+            };
+        } catch (error) {
+            return {
+                stdout: '',
+                stderr: error instanceof Error ? error.message : 'Execution failed',
+                exitCode: -1,
+                executionTime: 0,
+                memoryUsage: 0,
+                passed: false
+            };
+        }
+    };
+
+    const trySaveBeforeRun = (): void => {
+        if (!roomId || !studyProblemId) return;
+
+        void saveTestcases({
+            showSuccessToast: false,
+            showErrorToast: false
+        }).then((isSaved) => {
+            if (!isSaved) {
+                toast.warning('저장에는 실패했지만 현재 케이스로 실행을 계속합니다.');
+            }
+        });
+    };
+
+    const runSingleTestcase = async (testcaseId: string) => {
+        if (isExecuting) return;
+
+        const normalizedId = String(testcaseId);
+        const testcase = testcases.find((tc) => String(tc.id) === normalizedId);
+        if (!testcase) return;
+
+        trySaveBeforeRun();
+
+        const codeBundle = await requestCurrentCode();
+        if (!codeBundle) return;
+
+        setIsExecuting(true);
+        setExecutingId(normalizedId);
+
+        try {
+            const result = await executeTestcase(testcase, codeBundle.code, codeBundle.language);
+            setResults(prev => ({
+                ...prev,
+                [normalizedId]: result,
+            }));
+        } finally {
+            setExecutingId(null);
+            setIsExecuting(false);
+        }
+    };
+
     const runAllTestcases = async () => {
         if (testcases.length === 0) return;
+        const targetTestcases = testcases.map((tc) => ({ ...tc, id: String(tc.id) }));
 
-        if (roomId && studyProblemId) {
-            void saveTestcases({
-                showSuccessToast: false,
-                showErrorToast: false
-            });
-        }
+        trySaveBeforeRun();
 
-        // 1. Request current code from IDE
-        let currentCode = '';
-        let currentLang = 'python';
-
-        const handleReceiveCode = (e: Event) => {
-            const customEvent = e as CustomEvent;
-            currentCode = customEvent.detail.code;
-            currentLang = customEvent.detail.language;
-        };
-
-        window.addEventListener('receive-ide-code', handleReceiveCode, { once: true });
-        window.dispatchEvent(new Event('request-ide-code'));
-
-        // Wait a tiny bit for the synchronous event to process
-        await new Promise(resolve => setTimeout(resolve, 50));
-
-        if (!currentCode || !currentCode.trim()) {
-            alert('에디터에 작성된 코드가 없습니다.');
-            return;
-        }
+        const codeBundle = await requestCurrentCode();
+        if (!codeBundle) return;
 
         setIsExecuting(true);
         setResults({});
 
         const newResults: Record<string, TestResult> = {};
-
-        for (const tc of testcases) {
-            setExecutingId(tc.id);
-            try {
-                // Ensure input ends with newline if required, basic normalize
-                let finalInput = tc.input;
-                if (finalInput && !finalInput.endsWith('\n')) finalInput += '\n';
-
-                const response = await apiFetch<ExecutionResponse>('/api/executions/run', {
-                    method: 'POST',
-                    body: JSON.stringify({
-                        language: currentLang,
-                        code: currentCode,
-                        input: finalInput
-                    }),
-                });
-
-                const data = response.data;
-                const stdoutTrimmed = data?.stdout ? data.stdout.trim() : '';
-                const expectedTrimmed = tc.expectedOutput ? tc.expectedOutput.trim() : '';
-
-                let passed: boolean | null = null;
-                if (expectedTrimmed) {
-                    passed = (stdoutTrimmed === expectedTrimmed) && data?.exitCode === 0;
-                }
-
-                newResults[tc.id] = {
-                    stdout: data?.stdout || '',
-                    stderr: data?.stderr || response.error?.message || '',
-                    exitCode: data?.exitCode ?? -1,
-                    executionTime: data?.executionTime || 0,
-                    memoryUsage: data?.memoryUsage || 0,
-                    passed
-                };
-            } catch (error) {
-                newResults[tc.id] = {
-                    stdout: '',
-                    stderr: error instanceof Error ? error.message : 'Execution failed',
-                    exitCode: -1,
-                    executionTime: 0,
-                    memoryUsage: 0,
-                    passed: false
-                };
+        try {
+            for (const tc of targetTestcases) {
+                setExecutingId(tc.id);
+                newResults[tc.id] = await executeTestcase(tc, codeBundle.code, codeBundle.language);
             }
+            setResults(newResults);
+        } finally {
+            setExecutingId(null);
+            setIsExecuting(false);
         }
-
-        setResults(newResults);
-        setExecutingId(null);
-        setIsExecuting(false);
     };
 
     return (
@@ -314,6 +373,16 @@ export function CCTestcaseRunnerModal({
                                         )}
                                     </div>
                                     <div className="flex items-center gap-1">
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            className="h-7 w-7 text-muted-foreground hover:text-primary hover:bg-primary/10"
+                                            onClick={() => runSingleTestcase(tc.id)}
+                                            disabled={isExecuting}
+                                            title="이 케이스만 실행"
+                                        >
+                                            <Play className="h-3.5 w-3.5" />
+                                        </Button>
                                         <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground hover:text-primary hover:bg-primary/10" onClick={handleSaveTestcase} disabled={isExecuting} title="저장">
                                             <Save className="h-3.5 w-3.5" />
                                         </Button>


### PR DESCRIPTION
## 💡 의도 / 배경
스터디방 분할 화면에서 테스트 관련 액션이 과밀하고, `테스트 케이스 편집`과 `검증`의 목적이 직관적으로 구분되지 않는 문제가 있었습니다.  
또한 테스트 실행 결과가 갱신되지 않거나, 테스트 도구 팝오버가 닫히지 않는 UX 이슈, 콘솔에서 테스트케이스 공유 시 기존 1번 케이스가 덮어써지는 문제가 있어 개선이 필요했습니다.

## 🛠️ 작업 내용
- [x] IDE 툴바에서 테스트 액션을 `테스트` 드롭다운으로 통합하고, 편집/검증 설명 문구 추가
- [x] 테스트 드롭다운 항목 클릭 시 팝오버 즉시 닫히도록 수정
- [x] `CCTestcaseRunnerModal`에 개별 케이스 실행 추가 및 전체/개별 실행 로직 공통화
- [x] 테스트케이스 창은 열릴 때만 저장본 로드하도록 변경(열려 있는 동안 실시간 동기화 제거)
- [x] 코드 수집(`request-ide-code`) 로직을 이벤트 수신+타임아웃 방식으로 안정화
- [x] 콘솔 `테스트케이스 공유`를 덮어쓰기 방식에서 병합 저장 방식으로 변경(기존 케이스 유지, 중복 제외)

## 🔗 관련 이슈
- Closes #133 

## 🖼️ 스크린샷 (선택)
- 툴바 `테스트` 드롭다운 UI
- 테스트케이스 개별 실행 버튼 및 결과 표시
- 공유 후 기존 케이스 유지 확인 화면

## 🧪 테스트 방법
- [x] 스터디방 진입 후 문제 선택
- [x] 툴바 `테스트` 클릭 → `테스트 케이스 편집`, `전체 케이스 검증` 진입 확인
- [x] 테스트 드롭다운 항목 클릭 시 즉시 닫힘 확인
- [x] `전체 실행`/`개별 실행` 모두 결과 패널에 정상 반영 확인
- [x] 콘솔에서 `테스트케이스 공유` 실행 후 기존 케이스가 유지되고 신규 케이스만 추가되는지 확인
- [x] `pnpm --filter frontend type-check` 통과

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가? (type-check만 수행)

## 💬 리뷰어에게 (선택)