### PR TITLE
feat: 프리조인 카메라 기본값 추가

### DIFF
--- a/apps/frontend/src/components/common/CCPreJoinModal.tsx
+++ b/apps/frontend/src/components/common/CCPreJoinModal.tsx
@@ -282,6 +282,24 @@ export const CCPreJoinModal = ({
     return () => navigator.mediaDevices.removeEventListener('devicechange', getDevices);
   }, [getDevices]);
 
+  // Camera selection policy:
+  // - Keep previously selected device if it still exists.
+  // - Otherwise select the first available camera.
+  // - If no camera exists, fall back to 'default'.
+  useEffect(() => {
+    if (videoDevices.length === 0) {
+      if (selectedCameraId !== 'default') {
+        setCamera('default');
+      }
+      return;
+    }
+
+    const hasSelectedCamera = videoDevices.some((device) => device.deviceId === selectedCameraId);
+    if (!hasSelectedCamera) {
+      setCamera(videoDevices[0].deviceId);
+    }
+  }, [videoDevices, selectedCameraId, setCamera]);
+
   // ---------------------------------------------------------------------------
   // 2. Camera Preview Logic
   // ---------------------------------------------------------------------------
@@ -572,9 +590,13 @@ export const CCPreJoinModal = ({
                   </label>
                 </div>
                 {/* 2. Brighter input surface + 3. Stronger border */}
-                <Select value={selectedCameraId} onValueChange={setCamera}>
+                <Select
+                  value={selectedCameraId}
+                  onValueChange={setCamera}
+                  disabled={videoDevices.length === 0}
+                >
                   <SelectTrigger className="w-full bg-zinc-800 border-zinc-600 text-zinc-100 h-10 hover:border-zinc-500 focus:border-primary focus:ring-1 focus:ring-primary/20">
-                    <SelectValue placeholder="카메라 선택" />
+                    <SelectValue placeholder={videoDevices.length === 0 ? '사용 가능한 카메라 없음' : '카메라 선택'} />
                   </SelectTrigger>
                   <SelectContent>
                     {videoDevices.map((d) => (


### PR DESCRIPTION
## 💡 의도 / 배경
프리조인 모달에서 마이크/스피커는 기본값이 표시되는데, 카메라는 선택값이 비어 보이는 문제가 있었습니다.
`selectedCameraId` 초기값이 `default`일 때 실제 `videoinput` 목록에 매칭되지 않아 사용자 입장에서 “카메라가 없는지 / 선택이 안 된 건지” 구분이 어려웠고, 미팅 시작 전 설정 신뢰도가 떨어졌습니다.

## 🛠️ 작업 내용
- [x] 카메라 디바이스 목록 로드 후 자동 선택 정책 추가
- [x] 저장된 카메라가 유효하면 유지, 유효하지 않으면 첫 `videoinput` 자동 선택
- [x] 카메라 장치가 0개일 때 `default`로 fallback 하도록 처리
- [x] 카메라 장치가 없으면 Select 비활성화 및 `사용 가능한 카메라 없음` placeholder 표시

## 🔗 관련 이슈
- Closes #135 

## 🖼️ 스크린샷 (선택)
- 프리조인 모달 진입 시 카메라 드롭다운 자동 선택 상태
- 카메라 미연결 환경에서 `사용 가능한 카메라 없음` 표시 상태

## 🧪 테스트 방법
- [x] 카메라가 있는 환경에서 프리조인 진입 시 카메라 기본 선택 표시 확인
- [x] 저장된 카메라 장치 연결/해제 후 재진입 시 fallback 동작 확인
- [x] 카메라가 없는 환경(또는 비활성화)에서 Select 비활성화/placeholder 확인
- [x] `pnpm --filter frontend type-check` 통과

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가? (type-check만 수행)

## 💬 리뷰어에게 (선택)
카메라 “기본값”은 오디오의 `Windows 기본 설정`처럼 추상 디바이스가 아니라 실제 `videoinput` 중 하나를 선택하는 방식으로 처리했습니다.
현재 정책은 `기존 선택 유지 -> 없으면 첫 장치 fallback`이며, 장치가 없는 경우는 명시적으로 비활성화했습니다.