### PR TITLE
fix: 과거에 푼 문제 다시 추가할 때 푼사람이 집계 되지 않는 문제 수정

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/study/service/StudyCurriculumService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/study/service/StudyCurriculumService.java
@@ -247,8 +247,12 @@ public class StudyCurriculumService {
                 List<SubmissionLog> logs = problemIds.isEmpty() ? List.of()
                                 : submissionLogRepository.findAllByRoomIdAndProblemIdIn(studyId, problemIds);
 
+                List<SubmissionLog> solvedLogs = logs.stream()
+                                .filter(log -> !Boolean.FALSE.equals(log.getIsSuccess()))
+                                .collect(Collectors.toList());
+
                 // 4. 문제 ID -> 푼 유저 ID 매핑
-                Map<Long, List<Long>> solvedUserMap = logs.stream()
+                Map<Long, List<Long>> solvedUserMap = solvedLogs.stream()
                                 .collect(Collectors.groupingBy(
                                                 log -> log.getProblem().getId(),
                                                 Collectors.mapping(log -> log.getUser().getId(), Collectors.toList())));

--- a/apps/backend/src/main/java/com/peekle/domain/submission/repository/SubmissionLogRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/submission/repository/SubmissionLogRepository.java
@@ -16,6 +16,30 @@ public interface SubmissionLogRepository extends JpaRepository<SubmissionLog, Lo
                         Long studyProblemId,
                         Pageable pageable);
 
+        @Query("""
+                        SELECT s FROM SubmissionLog s
+                        WHERE s.roomId = :roomId
+                          AND s.studyProblemId = :studyProblemId
+                          AND (s.isSuccess = true OR s.isSuccess IS NULL)
+                        ORDER BY s.submittedAt DESC
+                        """)
+        Page<SubmissionLog> findSolvedByRoomIdAndStudyProblemId(
+                        @Param("roomId") Long roomId,
+                        @Param("studyProblemId") Long studyProblemId,
+                        Pageable pageable);
+
+        @Query("""
+                        SELECT s FROM SubmissionLog s
+                        WHERE s.roomId = :roomId
+                          AND s.problem.id = :problemId
+                          AND (s.isSuccess = true OR s.isSuccess IS NULL)
+                        ORDER BY s.submittedAt DESC
+                        """)
+        Page<SubmissionLog> findSolvedByRoomIdAndProblemId(
+                        @Param("roomId") Long roomId,
+                        @Param("problemId") Long problemId,
+                        Pageable pageable);
+
         // 특정 유저가 특정 문제에 대해 제출한 기록 개수 조회 (result 컬럼 없음 = 모두 성공)
         long countByUserIdAndProblemId(Long userId, Long problemId);
 

--- a/apps/backend/src/main/java/com/peekle/domain/submission/service/SubmissionService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/submission/service/SubmissionService.java
@@ -4,6 +4,8 @@ import com.peekle.domain.ai.repository.RecommendProblemRepository;
 import com.peekle.domain.league.service.LeagueService;
 import com.peekle.domain.problem.entity.Problem;
 import com.peekle.domain.problem.repository.ProblemRepository;
+import com.peekle.domain.study.entity.StudyProblem;
+import com.peekle.domain.study.repository.StudyProblemRepository;
 import com.peekle.domain.submission.dto.SubmissionLogResponse;
 import com.peekle.domain.submission.dto.SubmissionRequest;
 import com.peekle.domain.submission.dto.SubmissionResponse;
@@ -49,6 +51,7 @@ public class SubmissionService {
 
     private final SubmissionLogRepository submissionLogRepository;
     private final ProblemRepository problemRepository;
+    private final StudyProblemRepository studyProblemRepository;
     private final UserRepository userRepository;
     private final LeagueService leagueService;
     private final SubmissionValidator submissionValidator;
@@ -326,8 +329,28 @@ public class SubmissionService {
     public Page<SubmissionLogResponse> getStudyProblemSubmissions(
             Long studyId, Long studyProblemId, Pageable pageable) {
 
-        Page<SubmissionLog> logs = submissionLogRepository
-                .findAllByRoomIdAndStudyProblemIdOrderBySubmittedAtDesc(studyId, studyProblemId, pageable);
+        StudyProblem studyProblem = studyProblemRepository.findById(studyProblemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_PROBLEM_NOT_FOUND));
+
+        if (studyProblem.getStudy() == null || !studyId.equals(studyProblem.getStudy().getId())) {
+            throw new BusinessException(ErrorCode.STUDY_PROBLEM_NOT_FOUND);
+        }
+
+        Page<SubmissionLog> logs;
+        if (studyProblem.getProblemId() != null) {
+            // 같은 BOJ 문제를 다른 날짜에 다시 등록해도 풀이 보관함에서 함께 확인할 수 있게
+            // roomId + problemId 기준으로 조회한다.
+            logs = submissionLogRepository.findSolvedByRoomIdAndProblemId(
+                    studyId,
+                    studyProblem.getProblemId(),
+                    pageable);
+        } else {
+            // 커스텀 문제는 원본 problemId가 없으므로 기존처럼 studyProblemId 기준으로 조회한다.
+            logs = submissionLogRepository.findSolvedByRoomIdAndStudyProblemId(
+                    studyId,
+                    studyProblemId,
+                    pageable);
+        }
 
         return logs.map(SubmissionLogResponse::from);
     }


### PR DESCRIPTION
## 💡 의도 / 배경
과거 날짜에 이미 풀이한 BOJ 문제를 다시 커리큘럼에 추가하면 새로운 `studyProblemId`가 생성됩니다.  
기존 로직은 일부 화면(풀이 보관함)은 `studyProblemId` 기준, 일부 집계(해결 n/m)는 `problemId` 기준으로 동작해, 해결자 수/목록이 서로 다르게 보이는 문제가 있었습니다.

## 🛠️ 작업 내용
- [x] 제출 목록 조회 로직 보강
- [x] `studyProblemId`로 `StudyProblem`을 조회한 뒤, BOJ 문제는 `roomId + problemId` 기준으로 성공 제출 목록을 조회하도록 변경
- [x] Custom 문제는 기존처럼 `roomId + studyProblemId` 기준 조회 유지
- [x] 일별 해결자 집계에서 `isSuccess=false` 제출을 제외해 성공 제출만 카운트하도록 수정
- [x] `studyId`와 `studyProblemId` 소속 불일치 검증 추가

## 🔗 관련 이슈
- Closes #137 

## 🖼️ 스크린샷 (선택)
- 백엔드 로직 수정 건으로 스크린샷 없음

## 🧪 테스트 방법
- [x] `apps/backend`에서 `.\gradlew.bat compileJava` 실행 (성공)
- [x] 재현 시나리오 수동 확인
1. 과거 날짜에 문제 A를 추가하고 1명 이상이 풀이 완료
2. 오늘 동일 문제 A를 다시 추가
3. 문제 카드의 `해결 n/m`이 과거 해결자를 반영하는지 확인
4. 풀이 보관함에서 과거 제출 이력이 함께 조회되는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [ ] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가? (`compileJava`만 수행)

## 💬 리뷰어에게 (선택)
`studyProblemId`는 날짜별 인스턴스 식별자이고, 실제 동일 문제 재사용 케이스를 고려해 BOJ 문제는 `problemId` 기준으로 조회 범위를 확장했습니다.  
Custom 문제는 의도적으로 기존 동작(`studyProblemId` 기준)을 유지했습니다.