### PR TITLE
feat: cs 스터디 스테이지 맵 구현

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsController.java
@@ -1,6 +1,7 @@
 package com.peekle.domain.cs.controller;
 
 import com.peekle.domain.cs.dto.request.CsDomainIdRequest;
+import com.peekle.domain.cs.dto.response.CsAttemptStartResponse;
 import com.peekle.domain.cs.dto.response.CsBootstrapResponse;
 import com.peekle.domain.cs.dto.response.CsCurrentDomainChangeResponse;
 import com.peekle.domain.cs.dto.response.CsDomainResponse;
@@ -12,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -54,5 +56,12 @@ public class CsController {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody CsDomainIdRequest request) {
         return ApiResponse.success(csDomainService.changeCurrentDomain(userId, request.domainId()));
+    }
+
+    @PostMapping("/stages/{stageId}/attempt/start")
+    public ApiResponse<CsAttemptStartResponse> startStageAttempt(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long stageId) {
+        return ApiResponse.success(csDomainService.startStageAttempt(userId, stageId));
     }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptStartResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptStartResponse.java
@@ -1,0 +1,6 @@
+package com.peekle.domain.cs.dto.response;
+
+public record CsAttemptStartResponse(
+        Long stageId,
+        CsQuestionPayloadResponse firstQuestion) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsBootstrapResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsBootstrapResponse.java
@@ -1,7 +1,10 @@
 package com.peekle.domain.cs.dto.response;
 
+import java.util.List;
+
 public record CsBootstrapResponse(
         boolean needsDomainSelection,
         CsDomainResponse currentDomain,
-        CsProgressResponse progress) {
+        CsProgressResponse progress,
+        List<CsStageStatusResponse> stages) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsQuestionChoiceResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsQuestionChoiceResponse.java
@@ -1,0 +1,6 @@
+package com.peekle.domain.cs.dto.response;
+
+public record CsQuestionChoiceResponse(
+        Integer choiceNo,
+        String content) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsQuestionPayloadResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsQuestionPayloadResponse.java
@@ -1,0 +1,12 @@
+package com.peekle.domain.cs.dto.response;
+
+import com.peekle.domain.cs.enums.CsQuestionType;
+
+import java.util.List;
+
+public record CsQuestionPayloadResponse(
+        Long questionId,
+        CsQuestionType questionType,
+        String prompt,
+        List<CsQuestionChoiceResponse> choices) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsStageStatusResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsStageStatusResponse.java
@@ -1,0 +1,10 @@
+package com.peekle.domain.cs.dto.response;
+
+import com.peekle.domain.cs.enums.CsStageStatus;
+
+public record CsStageStatusResponse(
+        Long stageId,
+        Integer stageNo,
+        CsStageStatus status,
+        String lockReason) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/enums/CsStageStatus.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/enums/CsStageStatus.java
@@ -1,0 +1,7 @@
+package com.peekle.domain.cs.enums;
+
+public enum CsStageStatus {
+    COMPLETED,
+    IN_PROGRESS,
+    LOCKED
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionChoiceRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionChoiceRepository.java
@@ -1,0 +1,10 @@
+package com.peekle.domain.cs.repository;
+
+import com.peekle.domain.cs.entity.CsQuestionChoice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CsQuestionChoiceRepository extends JpaRepository<CsQuestionChoice, Long> {
+    List<CsQuestionChoice> findByQuestion_IdOrderByChoiceNoAsc(Long questionId);
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionRepository.java
@@ -1,0 +1,10 @@
+package com.peekle.domain.cs.repository;
+
+import com.peekle.domain.cs.entity.CsQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CsQuestionRepository extends JpaRepository<CsQuestion, Long> {
+    List<CsQuestion> findByStage_IdAndIsActiveTrueOrderByIdAsc(Long stageId);
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsStageRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsStageRepository.java
@@ -1,0 +1,22 @@
+package com.peekle.domain.cs.repository;
+
+import com.peekle.domain.cs.entity.CsStage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CsStageRepository extends JpaRepository<CsStage, Long> {
+    @Query("""
+            select s
+            from CsStage s
+            join fetch s.track t
+            join fetch t.domain
+            where s.id = :stageId
+            """)
+    Optional<CsStage> findByIdWithTrackAndDomain(@Param("stageId") Long stageId);
+
+    List<CsStage> findByTrack_IdOrderByStageNoAsc(Long trackId);
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsDomainService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsDomainService.java
@@ -1,16 +1,27 @@
 package com.peekle.domain.cs.service;
 
+import com.peekle.domain.cs.dto.response.CsAttemptStartResponse;
 import com.peekle.domain.cs.dto.response.CsBootstrapResponse;
 import com.peekle.domain.cs.dto.response.CsCurrentDomainChangeResponse;
 import com.peekle.domain.cs.dto.response.CsDomainResponse;
 import com.peekle.domain.cs.dto.response.CsDomainSubmitResponse;
 import com.peekle.domain.cs.dto.response.CsMyDomainItemResponse;
 import com.peekle.domain.cs.dto.response.CsProgressResponse;
+import com.peekle.domain.cs.dto.response.CsQuestionChoiceResponse;
+import com.peekle.domain.cs.dto.response.CsQuestionPayloadResponse;
+import com.peekle.domain.cs.dto.response.CsStageStatusResponse;
 import com.peekle.domain.cs.entity.CsDomain;
+import com.peekle.domain.cs.entity.CsDomainTrack;
+import com.peekle.domain.cs.entity.CsQuestion;
+import com.peekle.domain.cs.entity.CsStage;
 import com.peekle.domain.cs.entity.CsUserDomainProgress;
 import com.peekle.domain.cs.entity.CsUserProfile;
+import com.peekle.domain.cs.enums.CsStageStatus;
 import com.peekle.domain.cs.repository.CsDomainRepository;
 import com.peekle.domain.cs.repository.CsDomainTrackRepository;
+import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
+import com.peekle.domain.cs.repository.CsQuestionRepository;
+import com.peekle.domain.cs.repository.CsStageRepository;
 import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
 import com.peekle.domain.cs.repository.CsUserProfileRepository;
 import com.peekle.domain.user.entity.User;
@@ -21,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,9 +44,14 @@ public class CsDomainService {
 
     private static final short INITIAL_TRACK_NO = 1;
     private static final short INITIAL_STAGE_NO = 1;
+    private static final String LOCK_REASON_PREVIOUS_STAGE = "이전 스테이지를 먼저 완료해야 합니다.";
+    private static final String LOCK_REASON_NOT_CURRENT_TRACK = "현재 학습 중인 트랙만 입장할 수 있습니다.";
 
     private final CsDomainRepository csDomainRepository;
     private final CsDomainTrackRepository csDomainTrackRepository;
+    private final CsStageRepository csStageRepository;
+    private final CsQuestionRepository csQuestionRepository;
+    private final CsQuestionChoiceRepository csQuestionChoiceRepository;
     private final CsUserProfileRepository csUserProfileRepository;
     private final CsUserDomainProgressRepository csUserDomainProgressRepository;
     private final UserRepository userRepository;
@@ -54,7 +71,7 @@ public class CsDomainService {
         }
 
         if (currentDomain == null) {
-            return new CsBootstrapResponse(true, null, null);
+            return new CsBootstrapResponse(true, null, null, List.of());
         }
 
         Integer currentDomainId = currentDomain.getId();
@@ -63,10 +80,16 @@ public class CsDomainService {
                 .findFirst()
                 .orElse(null);
 
+        CsProgressResponse progressResponse = currentProgress != null ? toProgressResponse(currentProgress) : null;
+        List<CsStageStatusResponse> stages = currentProgress != null
+                ? toStageStatusResponses(currentProgress)
+                : List.of();
+
         return new CsBootstrapResponse(
                 false,
                 toDomainResponse(currentDomain),
-                currentProgress != null ? toProgressResponse(currentProgress) : null);
+                progressResponse,
+                stages);
     }
 
     public List<CsDomainResponse> getAvailableDomains(Long userId) {
@@ -155,6 +178,26 @@ public class CsDomainService {
                 toProgressResponse(progress));
     }
 
+    public CsAttemptStartResponse startStageAttempt(Long userId, Long stageId) {
+        User user = getUser(userId);
+        CsStage stage = csStageRepository.findByIdWithTrackAndDomain(stageId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_STAGE_NOT_FOUND));
+
+        Integer domainId = stage.getTrack().getDomain().getId();
+        CsUserDomainProgress progress = csUserDomainProgressRepository
+                .findByUser_IdAndDomain_Id(user.getId(), domainId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_DOMAIN_NOT_STUDYING));
+
+        validateStageAccess(progress, stage);
+
+        List<CsQuestion> questions = csQuestionRepository.findByStage_IdAndIsActiveTrueOrderByIdAsc(stageId);
+        if (questions.isEmpty()) {
+            throw new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND, "스테이지에 등록된 문제가 없습니다.");
+        }
+
+        return new CsAttemptStartResponse(stage.getId(), toQuestionPayload(questions.get(0)));
+    }
+
     private CsUserProfile getOrCreateUserProfile(Long userId, User user) {
         return csUserProfileRepository.findById(userId)
                 .orElseGet(() -> csUserProfileRepository.save(CsUserProfile.builder()
@@ -189,5 +232,73 @@ public class CsDomainService {
                 (int) progress.getCurrentTrackNo(),
                 trackName,
                 (int) progress.getCurrentStageNo());
+    }
+
+    private List<CsStageStatusResponse> toStageStatusResponses(CsUserDomainProgress progress) {
+        CsDomainTrack track = csDomainTrackRepository
+                .findByDomain_IdAndTrackNo(progress.getDomain().getId(), progress.getCurrentTrackNo())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_TRACK_NOT_FOUND));
+
+        List<CsStage> stages = csStageRepository.findByTrack_IdOrderByStageNoAsc(track.getId());
+        List<CsStageStatusResponse> responses = new ArrayList<>(stages.size());
+        short currentStageNo = progress.getCurrentStageNo();
+
+        for (CsStage stage : stages) {
+            short stageNo = stage.getStageNo();
+            if (stageNo < currentStageNo) {
+                responses.add(new CsStageStatusResponse(
+                        stage.getId(),
+                        (int) stageNo,
+                        CsStageStatus.COMPLETED,
+                        null));
+            } else if (stageNo == currentStageNo) {
+                responses.add(new CsStageStatusResponse(
+                        stage.getId(),
+                        (int) stageNo,
+                        CsStageStatus.IN_PROGRESS,
+                        null));
+            } else {
+                responses.add(new CsStageStatusResponse(
+                        stage.getId(),
+                        (int) stageNo,
+                        CsStageStatus.LOCKED,
+                        LOCK_REASON_PREVIOUS_STAGE));
+            }
+        }
+        return responses;
+    }
+
+    private void validateStageAccess(CsUserDomainProgress progress, CsStage stage) {
+        short currentTrackNo = progress.getCurrentTrackNo();
+        short currentStageNo = progress.getCurrentStageNo();
+        short targetTrackNo = stage.getTrack().getTrackNo();
+        short targetStageNo = stage.getStageNo();
+
+        if (targetTrackNo != currentTrackNo) {
+            throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_NOT_CURRENT_TRACK);
+        }
+
+        if (targetStageNo > currentStageNo) {
+            throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_PREVIOUS_STAGE);
+        }
+    }
+
+    private CsQuestionPayloadResponse toQuestionPayload(CsQuestion question) {
+        List<CsQuestionChoiceResponse> choices = switch (question.getQuestionType()) {
+            case MULTIPLE_CHOICE, OX -> csQuestionChoiceRepository
+                    .findByQuestion_IdOrderByChoiceNoAsc(question.getId())
+                    .stream()
+                    .map(choice -> new CsQuestionChoiceResponse(
+                            (int) choice.getChoiceNo(),
+                            choice.getContent()))
+                    .toList();
+            default -> List.of();
+        };
+
+        return new CsQuestionPayloadResponse(
+                question.getId(),
+                question.getQuestionType(),
+                question.getPrompt(),
+                choices.isEmpty() ? null : choices);
     }
 }

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsStageMapAndStartIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsStageMapAndStartIntegrationTest.java
@@ -1,0 +1,190 @@
+package com.peekle.domain.cs.service;
+
+import com.peekle.domain.cs.dto.response.CsAttemptStartResponse;
+import com.peekle.domain.cs.dto.response.CsBootstrapResponse;
+import com.peekle.domain.cs.entity.CsDomain;
+import com.peekle.domain.cs.entity.CsDomainTrack;
+import com.peekle.domain.cs.entity.CsQuestion;
+import com.peekle.domain.cs.entity.CsQuestionChoice;
+import com.peekle.domain.cs.entity.CsStage;
+import com.peekle.domain.cs.enums.CsQuestionType;
+import com.peekle.domain.cs.enums.CsStageStatus;
+import com.peekle.domain.cs.repository.CsDomainRepository;
+import com.peekle.domain.cs.repository.CsDomainTrackRepository;
+import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
+import com.peekle.domain.cs.repository.CsQuestionRepository;
+import com.peekle.domain.cs.repository.CsStageRepository;
+import com.peekle.domain.user.entity.User;
+import com.peekle.domain.user.repository.UserRepository;
+import com.peekle.global.exception.BusinessException;
+import com.peekle.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class CsStageMapAndStartIntegrationTest {
+
+    @Autowired
+    private CsDomainService csDomainService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CsDomainRepository csDomainRepository;
+
+    @Autowired
+    private CsDomainTrackRepository csDomainTrackRepository;
+
+    @Autowired
+    private CsStageRepository csStageRepository;
+
+    @Autowired
+    private CsQuestionRepository csQuestionRepository;
+
+    @Autowired
+    private CsQuestionChoiceRepository csQuestionChoiceRepository;
+
+    @Test
+    @DisplayName("bootstrap 응답에 완료/진행/잠금 스테이지 상태가 포함된다")
+    void bootstrap_includesStageStatuses() {
+        User user = createUser("stage-map");
+        CsDomain domain = createDomain(301, "테스트 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "테스트 트랙");
+        CsStage stage1 = createStage(track, 1);
+        CsStage stage2 = createStage(track, 2);
+        CsStage stage3 = createStage(track, 3);
+        createMultipleChoiceQuestion(stage1);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+        CsBootstrapResponse bootstrap = csDomainService.getBootstrap(user.getId());
+
+        assertThat(bootstrap.stages()).hasSize(3);
+        assertThat(bootstrap.stages().get(0).stageId()).isEqualTo(stage1.getId());
+        assertThat(bootstrap.stages().get(0).status()).isEqualTo(CsStageStatus.IN_PROGRESS);
+        assertThat(bootstrap.stages().get(1).stageId()).isEqualTo(stage2.getId());
+        assertThat(bootstrap.stages().get(1).status()).isEqualTo(CsStageStatus.LOCKED);
+        assertThat(bootstrap.stages().get(1).lockReason()).isEqualTo("이전 스테이지를 먼저 완료해야 합니다.");
+        assertThat(bootstrap.stages().get(2).stageId()).isEqualTo(stage3.getId());
+        assertThat(bootstrap.stages().get(2).status()).isEqualTo(CsStageStatus.LOCKED);
+    }
+
+    @Test
+    @DisplayName("잠금 스테이지 시작 시 CS_010과 안내 메시지를 반환한다")
+    void startAttempt_lockedStage_throwsForbidden() {
+        User user = createUser("locked-stage");
+        CsDomain domain = createDomain(302, "잠금 테스트 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "잠금 테스트 트랙");
+        createStage(track, 1);
+        CsStage lockedStage = createStage(track, 2);
+        createMultipleChoiceQuestion(lockedStage);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+
+        assertThatThrownBy(() -> csDomainService.startStageAttempt(user.getId(), lockedStage.getId()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS);
+                    assertThat(businessException.getMessage()).isEqualTo("이전 스테이지를 먼저 완료해야 합니다.");
+                });
+    }
+
+    @Test
+    @DisplayName("해금된 스테이지 시작 시 첫 문제를 반환한다")
+    void startAttempt_unlockedStage_returnsFirstQuestion() {
+        User user = createUser("unlocked-stage");
+        CsDomain domain = createDomain(303, "진입 테스트 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "진입 테스트 트랙");
+        CsStage stage1 = createStage(track, 1);
+        CsQuestion question = createMultipleChoiceQuestion(stage1);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+
+        CsAttemptStartResponse response = csDomainService.startStageAttempt(user.getId(), stage1.getId());
+
+        assertThat(response.stageId()).isEqualTo(stage1.getId());
+        assertThat(response.firstQuestion().questionId()).isEqualTo(question.getId());
+        assertThat(response.firstQuestion().questionType()).isEqualTo(CsQuestionType.MULTIPLE_CHOICE);
+        assertThat(response.firstQuestion().choices()).hasSize(4);
+    }
+
+    private User createUser(String suffix) {
+        return userRepository.save(User.builder()
+                .socialId("social-" + suffix)
+                .provider("TEST")
+                .nickname("nick-" + suffix)
+                .bojId("boj-" + suffix)
+                .profileImg("default.png")
+                .profileImgThumb("default-thumb.png")
+                .build());
+    }
+
+    private CsDomain createDomain(int domainId, String name) {
+        return csDomainRepository.save(CsDomain.builder()
+                .id(domainId)
+                .name(name)
+                .build());
+    }
+
+    private CsDomainTrack createTrack(CsDomain domain, int trackNo, String name) {
+        return csDomainTrackRepository.save(CsDomainTrack.builder()
+                .domain(domain)
+                .trackNo((short) trackNo)
+                .name(name)
+                .build());
+    }
+
+    private CsStage createStage(CsDomainTrack track, int stageNo) {
+        return csStageRepository.save(CsStage.builder()
+                .track(track)
+                .stageNo((short) stageNo)
+                .build());
+    }
+
+    private CsQuestion createMultipleChoiceQuestion(CsStage stage) {
+        CsQuestion question = csQuestionRepository.save(CsQuestion.builder()
+                .stage(stage)
+                .questionType(CsQuestionType.MULTIPLE_CHOICE)
+                .prompt("테스트 문제")
+                .explanation("테스트 해설")
+                .isActive(true)
+                .build());
+
+        csQuestionChoiceRepository.save(CsQuestionChoice.builder()
+                .question(question)
+                .choiceNo((short) 1)
+                .content("선지 1")
+                .isAnswer(true)
+                .build());
+        csQuestionChoiceRepository.save(CsQuestionChoice.builder()
+                .question(question)
+                .choiceNo((short) 2)
+                .content("선지 2")
+                .isAnswer(false)
+                .build());
+        csQuestionChoiceRepository.save(CsQuestionChoice.builder()
+                .question(question)
+                .choiceNo((short) 3)
+                .content("선지 3")
+                .isAnswer(false)
+                .build());
+        csQuestionChoiceRepository.save(CsQuestionChoice.builder()
+                .question(question)
+                .choiceNo((short) 4)
+                .content("선지 4")
+                .isAnswer(false)
+                .build());
+
+        return question;
+    }
+}

--- a/apps/frontend/src/app/(main)/cs/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { fetchCSBootstrap, CSBootstrapResponse } from '@/domains/cs/api/csApi';
 import DomainSelection from '@/domains/cs/components/DomainSelection';
+import LearningMap from '@/domains/cs/components/LearningMap';
 import { toast } from 'sonner';
 
 export default function CSPage() {
@@ -46,15 +47,20 @@ export default function CSPage() {
 
   return (
     <div className="flex flex-col animate-in fade-in duration-500">
-      <div className="bg-card border border-border rounded-2xl p-8 shadow-sm">
+      <div className="bg-card rounded-2xl p-8 shadow-sm">
         <h1 className="text-2xl font-bold mb-2">CS 학습</h1>
         <p className="text-muted-foreground mb-6">
           선택한 도메인: <span className="font-semibold text-primary">{bootstrapData?.currentDomain?.name}</span>
         </p>
-        <div className="p-8 border border-dashed border-primary/30 rounded-xl bg-primary/5 text-center">
-          <p className="text-lg font-medium text-foreground mb-2">학습 맵이 준비 중입니다! 🚀</p>
-          <p className="text-sm text-muted-foreground">금방 추가될 예정이니 조금만 기다려주세요.</p>
-        </div>
+        {bootstrapData?.progress ? (
+          <div className="mt-4 pt-4 w-full flex flex-col items-center">
+            <LearningMap progress={bootstrapData.progress} />
+          </div>
+        ) : (
+          <div className="p-8 border border-dashed border-primary/30 rounded-xl bg-primary/5 text-center">
+            <p className="text-lg font-medium text-foreground mb-2">진행도 정보를 불러올 수 없습니다. 🚨</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/domains/cs/components/LearningMap.tsx
+++ b/apps/frontend/src/domains/cs/components/LearningMap.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import React from 'react';
+import { useEffect, useRef } from 'react';
+import { CSProgress } from '@/domains/cs/api/csApi';
+import { cn } from '@/lib/utils';
+import { Check, Lock, Play } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface LearningMapProps {
+  progress: CSProgress;
+}
+
+const STAGE_COUNT = 10;
+const STAGE_WIDTH = 96; // w-24 (96px)
+const STAGE_HEIGHT = 80; // h-20 (80px)
+const GAP_Y = 48; // 48px
+
+const getOffset = (i: number) => {
+  const pattern = [-64, 0, 64, 0];
+  return pattern[i % 4];
+};
+
+const getConnectorStyle = (i: number): React.CSSProperties => {
+  const currentX = getOffset(i);
+  const nextX = getOffset(i + 1);
+  const dx = nextX - currentX;
+  const dy = STAGE_HEIGHT + GAP_Y;
+
+  const length = Math.sqrt(dx * dx + dy * dy);
+  const angle = Math.atan2(dy, dx) * (180 / Math.PI);
+
+  return {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    width: `${length}px`,
+    height: '14px',
+    transformOrigin: '0 50%',
+    transform: `rotate(${angle}deg)`,
+    zIndex: -1,
+  };
+};
+
+export default function LearningMap({ progress }: LearningMapProps) {
+  const { currentTrackNo, currentStageNo } = progress;
+  const stageButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    const targetIndex = currentStageNo - 1;
+    if (targetIndex < 0 || targetIndex >= STAGE_COUNT) return;
+
+    const target = stageButtonRefs.current[targetIndex];
+    if (!target) return;
+
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    requestAnimationFrame(() => {
+      target.scrollIntoView({
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        block: 'center',
+        inline: 'nearest',
+      });
+    });
+  }, [currentStageNo]);
+
+  const handleStageClick = (stageNo: number, state: 'COMPLETED' | 'IN_PROGRESS' | 'LOCKED') => {
+    // [DEBUG] 사용자 요청사항: 중간 과정 출력용 디버깅 로직 포함
+    console.log(`[DEBUG] LearningMap Stage Clicked: Track ${currentTrackNo}, Stage ${stageNo}, State: ${state}`);
+    
+    if (state === 'LOCKED') {
+      toast.info('이전 단계를 먼저 클리어해주세요 🔒');
+      return;
+    }
+
+    // TODO: MVP 단계에서는 문제 세트 진입 화면이 없으므로 토스트 알림으로 임시 처리
+    toast.success(`${currentTrackNo}-${stageNo} 스테이지 진입! (준비중)`);
+  };
+
+  return (
+    <div className="relative w-full py-10 flex flex-col items-center">
+      {/* 
+        지그재그 배치를 위한 Flex Column 컨테이너
+      */}
+      <div 
+        className="flex flex-col relative w-full max-w-sm items-center"
+        style={{ gap: `${GAP_Y}px` }}
+      >
+        {Array.from({ length: STAGE_COUNT }).map((_, i) => {
+          const stageNo = i + 1;
+          let state: 'COMPLETED' | 'IN_PROGRESS' | 'LOCKED' = 'LOCKED';
+          if (stageNo < currentStageNo) state = 'COMPLETED';
+          else if (stageNo === currentStageNo) state = 'IN_PROGRESS';
+
+          const offsetX = getOffset(i);
+          const isNotLast = i < STAGE_COUNT - 1;
+
+          // 다음 스테이지로 이어지는 커넥터의 스타일 판별
+          let bridgeClass = 'bg-surface-3 opacity-60';
+          if (state === 'COMPLETED' || state === 'IN_PROGRESS') {
+            const nextState = stageNo + 1 <= currentStageNo ? 'COMPLETED' : 
+                               (stageNo + 1 === currentStageNo ? 'IN_PROGRESS' : 'LOCKED');
+            if (nextState === 'COMPLETED' || nextState === 'IN_PROGRESS') {
+              bridgeClass = 'bg-primary/50 shadow-[0_0_8px_rgba(var(--primary),0.4)]';
+            }
+          }
+
+          return (
+            <div
+              key={stageNo}
+              className="relative flex items-center justify-center shrink-0"
+              style={{
+                width: STAGE_WIDTH,
+                height: STAGE_HEIGHT,
+                transform: `translateX(${offsetX}px)`,
+              }}
+            >
+              {/* 커넥터 라인 */}
+              {isNotLast && (
+                <div
+                  className={cn(
+                    'rounded-full transition-colors duration-500',
+                    bridgeClass
+                  )}
+                  style={getConnectorStyle(i)}
+                />
+              )}
+
+              {/* 본체 버튼 (사각형) */}
+              <button
+                ref={(element) => {
+                  stageButtonRefs.current[i] = element;
+                }}
+                onClick={() => handleStageClick(stageNo, state)}
+                className={cn(
+                  'relative z-10 w-full h-full rounded-2xl flex flex-col items-center justify-center transition-all duration-200 font-bold border-[3px] select-none text-sm tracking-wider',
+                  {
+                    'bg-primary border-primary text-primary-foreground shadow-[0_5px_0_rgba(0,0,0,0.15)] hover:bg-primary/95 hover:brightness-110 active:shadow-none active:translate-y-[5px]': state === 'COMPLETED',
+                    'bg-background border-primary text-primary shadow-[0_5px_0_hsl(var(--primary)/0.6)] active:shadow-none active:translate-y-[5px] animate-float': state === 'IN_PROGRESS',
+                    'bg-surface-2 border-border text-muted-foreground shadow-[0_5px_0_hsl(var(--border))] active:shadow-none active:translate-y-[5px] opacity-80 cursor-not-allowed': state === 'LOCKED',
+                  }
+                )}
+              >
+                {state === 'COMPLETED' && <Check className="w-7 h-7 mb-1" strokeWidth={3} />}
+                {state === 'IN_PROGRESS' && <Play className="w-6 h-6 mb-1 ml-1" strokeWidth={3} fill="currentColor" />}
+                {state === 'LOCKED' && <Lock className="w-5 h-5 mb-1 opacity-50" strokeWidth={2.5} />}
+                
+                <span>
+                  {currentTrackNo}-{stageNo}
+                </span>
+
+                {/* 진행 중인 단계 강조 글로우 효과 */}
+                {state === 'IN_PROGRESS' && (
+                  <div className="absolute inset-0 rounded-2xl ring-[6px] ring-primary/20 blur-sm -z-10" />
+                )}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 💡 의도 / 배경
도메인 선택 이후 현재 학습 위치와 잠금 상태를 직관적으로 보여주는 UI/API가 부족해 사용자가 진척도를 파악하기 어려운 문제를 해결했습니다.  
#142 요구사항(상태 구분, 잠금 안내, 진입 제어, 반응형)을 만족하도록 CS 스테이지 맵을 구현했습니다.

## 🛠️ 작업 내용
- [x] CS 학습 맵 UI 구현 (완료/진행/잠금 상태 시각 구분, 징검다리 형태 렌더링)
- [x] 진행 스테이지 자동 스크롤 구현 (모바일/데스크탑 공통, `currentStageNo` 기준)
- [x] 잠금 스테이지 클릭 시 안내 메시지 노출
- [x] 백엔드 `POST /api/cs/stages/{stageId}/attempt/start` 추가 및 잠금 접근 차단(`CS_010`)
- [x] 백엔드 bootstrap 응답 확장(스테이지 상태 목록 포함)
- [x] CS 도메인 통합 테스트 추가

## 🔗 관련 이슈
- Closes #142
- Related #139
- Related #141

## 🖼️ 스크린샷 (선택)
<img width="373" height="669" alt="image" src="https://github.com/user-attachments/assets/775276ff-9358-4562-9295-95f05a438591" />

## 🧪 테스트 방법
- [x] 백엔드 테스트: `./gradlew test --tests "com.peekle.domain.cs.service.*"`
- [x] 프론트 타입체크: `pnpm -C apps/frontend exec tsc --noEmit`
- [x] 수동 확인
- [x] CS 페이지 진입 시 현재 스테이지 자동 스크롤 동작 확인
- [x] 잠금 스테이지 클릭 시 안내 메시지 확인
- [x] 해금 스테이지 클릭 시 진입 동작 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
자동 스크롤은 접근성을 고려해 `prefers-reduced-motion` 환경에서 `smooth` 대신 `auto`로 동작하도록 처리했습니다.  
모바일에서 스테이지 카드 중앙 정렬(`block: center`) 체감이 적절한지 함께 확인 부탁드립니다.
