### PR TITLE
feat: cs 스터디 스테이지 문제 세트 세션 플로우 구현

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsController.java
@@ -1,12 +1,16 @@
 package com.peekle.domain.cs.controller;
 
+import com.peekle.domain.cs.dto.request.CsAttemptAnswerRequest;
 import com.peekle.domain.cs.dto.request.CsDomainIdRequest;
+import com.peekle.domain.cs.dto.response.CsAttemptAnswerResponse;
+import com.peekle.domain.cs.dto.response.CsAttemptCompleteResponse;
 import com.peekle.domain.cs.dto.response.CsAttemptStartResponse;
 import com.peekle.domain.cs.dto.response.CsBootstrapResponse;
 import com.peekle.domain.cs.dto.response.CsCurrentDomainChangeResponse;
 import com.peekle.domain.cs.dto.response.CsDomainResponse;
 import com.peekle.domain.cs.dto.response.CsDomainSubmitResponse;
 import com.peekle.domain.cs.dto.response.CsMyDomainItemResponse;
+import com.peekle.domain.cs.service.CsAttemptService;
 import com.peekle.domain.cs.service.CsDomainService;
 import com.peekle.global.dto.ApiResponse;
 import jakarta.validation.Valid;
@@ -28,6 +32,7 @@ import java.util.List;
 public class CsController {
 
     private final CsDomainService csDomainService;
+    private final CsAttemptService csAttemptService;
 
     @GetMapping("/bootstrap")
     public ApiResponse<CsBootstrapResponse> getBootstrap(@AuthenticationPrincipal Long userId) {
@@ -62,6 +67,21 @@ public class CsController {
     public ApiResponse<CsAttemptStartResponse> startStageAttempt(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long stageId) {
-        return ApiResponse.success(csDomainService.startStageAttempt(userId, stageId));
+        return ApiResponse.success(csAttemptService.startStageAttempt(userId, stageId));
+    }
+
+    @PostMapping("/stages/{stageId}/attempt/answer")
+    public ApiResponse<CsAttemptAnswerResponse> submitStageAnswer(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long stageId,
+            @Valid @RequestBody CsAttemptAnswerRequest request) {
+        return ApiResponse.success(csAttemptService.submitAnswer(userId, stageId, request));
+    }
+
+    @PostMapping("/stages/{stageId}/attempt/complete")
+    public ApiResponse<CsAttemptCompleteResponse> completeStageAttempt(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long stageId) {
+        return ApiResponse.success(csAttemptService.completeAttempt(userId, stageId));
     }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsAttemptAnswerRequest.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsAttemptAnswerRequest.java
@@ -1,0 +1,13 @@
+package com.peekle.domain.cs.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CsAttemptAnswerRequest(
+        @NotNull(message = "questionId는 필수입니다.")
+        @Positive(message = "questionId는 1 이상의 값이어야 합니다.")
+        Long questionId,
+        @Positive(message = "selectedChoiceNo는 1 이상의 값이어야 합니다.")
+        Integer selectedChoiceNo,
+        String answerText) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptAnswerResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptAnswerResponse.java
@@ -1,0 +1,15 @@
+package com.peekle.domain.cs.dto.response;
+
+import com.peekle.domain.cs.enums.CsAttemptPhase;
+import com.peekle.domain.cs.enums.CsQuestionType;
+
+public record CsAttemptAnswerResponse(
+        Long questionId,
+        CsQuestionType questionType,
+        CsAttemptProgressResponse progress,
+        CsAttemptPhase phase,
+        Boolean isCorrect,
+        String feedback,
+        Boolean isLast,
+        CsQuestionPayloadResponse nextQuestion) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptCompleteResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptCompleteResponse.java
@@ -1,0 +1,13 @@
+package com.peekle.domain.cs.dto.response;
+
+public record CsAttemptCompleteResponse(
+        Long stageId,
+        Boolean isTrackCompleted,
+        Integer correctRate,
+        Integer correctCount,
+        Integer wrongCount,
+        String messageCode,
+        Boolean streakEarnedToday,
+        Integer currentStreak,
+        Long nextStageId) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptProgressResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptProgressResponse.java
@@ -1,0 +1,6 @@
+package com.peekle.domain.cs.dto.response;
+
+public record CsAttemptProgressResponse(
+        Integer currentQuestionNo,
+        Integer totalQuestionCount) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptStartResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptStartResponse.java
@@ -2,5 +2,6 @@ package com.peekle.domain.cs.dto.response;
 
 public record CsAttemptStartResponse(
         Long stageId,
+        Integer totalQuestionCount,
         CsQuestionPayloadResponse firstQuestion) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsUserDomainProgress.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsUserDomainProgress.java
@@ -66,4 +66,10 @@ public class CsUserDomainProgress {
     public void preUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void advanceTo(Short trackNo, Short stageNo) {
+        this.currentTrackNo = trackNo;
+        this.currentStageNo = stageNo;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/enums/CsAttemptPhase.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/enums/CsAttemptPhase.java
@@ -1,0 +1,7 @@
+package com.peekle.domain.cs.enums;
+
+public enum CsAttemptPhase {
+    FIRST_PASS,
+    RETRY_WRONG,
+    COMPLETED
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionRepository.java
@@ -4,7 +4,10 @@ import com.peekle.domain.cs.entity.CsQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CsQuestionRepository extends JpaRepository<CsQuestion, Long> {
     List<CsQuestion> findByStage_IdAndIsActiveTrueOrderByIdAsc(Long stageId);
+
+    Optional<CsQuestion> findByIdAndStage_Id(Long questionId, Long stageId);
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsStageRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsStageRepository.java
@@ -19,4 +19,6 @@ public interface CsStageRepository extends JpaRepository<CsStage, Long> {
     Optional<CsStage> findByIdWithTrackAndDomain(@Param("stageId") Long stageId);
 
     List<CsStage> findByTrack_IdOrderByStageNoAsc(Long trackId);
+
+    Optional<CsStage> findByTrack_IdAndStageNo(Long trackId, Short stageNo);
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsWrongProblemRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsWrongProblemRepository.java
@@ -1,0 +1,11 @@
+package com.peekle.domain.cs.repository;
+
+import com.peekle.domain.cs.entity.CsWrongProblem;
+import com.peekle.domain.cs.entity.CsWrongProblemId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CsWrongProblemRepository extends JpaRepository<CsWrongProblem, CsWrongProblemId> {
+    Optional<CsWrongProblem> findByUser_IdAndQuestion_Id(Long userId, Long questionId);
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
@@ -1,0 +1,438 @@
+package com.peekle.domain.cs.service;
+
+import com.peekle.domain.cs.dto.request.CsAttemptAnswerRequest;
+import com.peekle.domain.cs.dto.response.CsAttemptAnswerResponse;
+import com.peekle.domain.cs.dto.response.CsAttemptCompleteResponse;
+import com.peekle.domain.cs.dto.response.CsAttemptProgressResponse;
+import com.peekle.domain.cs.dto.response.CsAttemptStartResponse;
+import com.peekle.domain.cs.dto.response.CsQuestionChoiceResponse;
+import com.peekle.domain.cs.dto.response.CsQuestionPayloadResponse;
+import com.peekle.domain.cs.entity.CsQuestion;
+import com.peekle.domain.cs.entity.CsStage;
+import com.peekle.domain.cs.entity.CsUserDomainProgress;
+import com.peekle.domain.cs.entity.CsWrongProblem;
+import com.peekle.domain.cs.enums.CsAttemptPhase;
+import com.peekle.domain.cs.enums.CsQuestionType;
+import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
+import com.peekle.domain.cs.repository.CsQuestionRepository;
+import com.peekle.domain.cs.repository.CsStageRepository;
+import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
+import com.peekle.domain.cs.repository.CsWrongProblemRepository;
+import com.peekle.domain.cs.service.store.CsAttemptSession;
+import com.peekle.domain.cs.service.store.CsAttemptStore;
+import com.peekle.domain.user.entity.User;
+import com.peekle.domain.user.repository.UserRepository;
+import com.peekle.global.exception.BusinessException;
+import com.peekle.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CsAttemptService {
+
+    private static final int ATTEMPT_QUESTION_COUNT = 10;
+    private static final int MESSAGE_SCORE_EXCELLENT = 90;
+    private static final int MESSAGE_SCORE_GOOD = 70;
+    private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
+
+    private static final String LOCK_REASON_PREVIOUS_STAGE = "이전 스테이지를 먼저 완료해야 합니다.";
+    private static final String LOCK_REASON_NOT_CURRENT_TRACK = "현재 학습 중인 트랙만 입장할 수 있습니다.";
+
+    private final CsStageRepository csStageRepository;
+    private final CsQuestionRepository csQuestionRepository;
+    private final CsQuestionChoiceRepository csQuestionChoiceRepository;
+    private final CsUserDomainProgressRepository csUserDomainProgressRepository;
+    private final CsWrongProblemRepository csWrongProblemRepository;
+    private final CsAttemptStore csAttemptStore;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CsAttemptStartResponse startStageAttempt(Long userId, Long stageId) {
+        User user = getUser(userId);
+        CsStage stage = getStage(stageId);
+
+        Integer domainId = stage.getTrack().getDomain().getId();
+        CsUserDomainProgress progress = csUserDomainProgressRepository
+                .findByUser_IdAndDomain_Id(user.getId(), domainId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_DOMAIN_NOT_STUDYING));
+
+        validateStageAccess(progress, stage);
+
+        List<CsQuestion> loadedQuestions = csQuestionRepository.findByStage_IdAndIsActiveTrueOrderByIdAsc(stageId);
+        if (loadedQuestions.isEmpty()) {
+            throw new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND, "스테이지에 등록된 문제가 없습니다.");
+        }
+
+        List<CsQuestion> questionSet = selectQuestionSet(loadedQuestions);
+        List<Long> questionIds = questionSet.stream()
+                .map(CsQuestion::getId)
+                .toList();
+
+        LocalDateTime now = LocalDateTime.now();
+        CsAttemptSession session = CsAttemptSession.builder()
+                .userId(userId)
+                .stageId(stageId)
+                .domainId(domainId)
+                .phase(CsAttemptPhase.FIRST_PASS)
+                .retryRound(0)
+                .questionOrder(questionIds)
+                .currentRoundQuestionIds(questionIds)
+                .currentRoundIndex(0)
+                .firstPassCorrectCount(0)
+                .firstPassWrongQuestionIds(new HashSet<>())
+                .wrongAttemptCountByQuestionId(new HashMap<>())
+                .latestCorrectByQuestionId(new HashMap<>())
+                .startedAt(now)
+                .updatedAt(now)
+                .build();
+
+        csAttemptStore.delete(userId, stageId);
+        csAttemptStore.save(session);
+
+        return new CsAttemptStartResponse(stageId, questionSet.size(), toQuestionPayload(questionSet.get(0)));
+    }
+
+    @Transactional
+    public CsAttemptAnswerResponse submitAnswer(Long userId, Long stageId, CsAttemptAnswerRequest request) {
+        getUser(userId);
+        CsAttemptSession session = getAttemptSession(userId, stageId);
+
+        if (session.getPhase() == CsAttemptPhase.COMPLETED) {
+            throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "이미 완료된 세션입니다.");
+        }
+
+        List<Long> currentRoundQuestionIds = session.getCurrentRoundQuestionIds();
+        int currentRoundIndex = session.getCurrentRoundIndex();
+
+        if (currentRoundQuestionIds == null || currentRoundQuestionIds.isEmpty() || currentRoundIndex >= currentRoundQuestionIds.size()) {
+            throw new BusinessException(ErrorCode.CS_ATTEMPT_EXPIRED, "유효하지 않은 세션 상태입니다.");
+        }
+
+        Long expectedQuestionId = currentRoundQuestionIds.get(currentRoundIndex);
+        if (!expectedQuestionId.equals(request.questionId())) {
+            throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "현재 순서의 문제를 제출해야 합니다.");
+        }
+
+        CsQuestion question = csQuestionRepository.findByIdAndStage_Id(request.questionId(), stageId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND));
+
+        int currentQuestionNo = currentRoundIndex + 1;
+        int totalQuestionCount = currentRoundQuestionIds.size();
+
+        boolean isCorrect = gradeAnswerByMockPolicy(question, request);
+        applyAnswerState(session, question.getId(), isCorrect);
+        moveToNextQuestion(session);
+
+        session.setUpdatedAt(LocalDateTime.now());
+        csAttemptStore.save(session);
+
+        CsQuestionPayloadResponse nextQuestion = null;
+        boolean isLast = session.getPhase() == CsAttemptPhase.COMPLETED;
+
+        if (!isLast) {
+            Long nextQuestionId = session.getCurrentRoundQuestionIds().get(session.getCurrentRoundIndex());
+            CsQuestion next = csQuestionRepository.findByIdAndStage_Id(nextQuestionId, stageId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND));
+            nextQuestion = toQuestionPayload(next);
+        }
+
+        return new CsAttemptAnswerResponse(
+                question.getId(),
+                question.getQuestionType(),
+                new CsAttemptProgressResponse(currentQuestionNo, totalQuestionCount),
+                session.getPhase(),
+                isCorrect,
+                isCorrect ? "정답입니다." : "오답입니다.",
+                isLast,
+                nextQuestion);
+    }
+
+    @Transactional
+    public CsAttemptCompleteResponse completeAttempt(Long userId, Long stageId) {
+        User user = getUser(userId);
+        CsStage stage = getStage(stageId);
+        CsAttemptSession session = getAttemptSession(userId, stageId);
+
+        if (session.getPhase() != CsAttemptPhase.COMPLETED) {
+            throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "아직 풀이가 완료되지 않았습니다.");
+        }
+
+        int totalQuestionCount = session.getQuestionOrder().size();
+        int correctCount = session.getFirstPassCorrectCount();
+        int wrongCount = Math.max(totalQuestionCount - correctCount, 0);
+        int correctRate = totalQuestionCount == 0
+                ? 0
+                : (int) Math.round((correctCount * 100.0) / totalQuestionCount);
+
+        persistWrongProblems(user, session);
+
+        Long nextStageId = resolveNextStageId(stage);
+        boolean isTrackCompleted = nextStageId == null;
+
+        updateDomainProgressIfNeeded(userId, stage, nextStageId);
+        StreakResult streak = applyStreak(user);
+
+        csAttemptStore.delete(userId, stageId);
+
+        return new CsAttemptCompleteResponse(
+                stageId,
+                isTrackCompleted,
+                correctRate,
+                correctCount,
+                wrongCount,
+                resolveMessageCode(correctRate),
+                streak.earnedToday(),
+                streak.currentStreak(),
+                nextStageId);
+    }
+
+    private CsAttemptSession getAttemptSession(Long userId, Long stageId) {
+        return csAttemptStore.find(userId, stageId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_ATTEMPT_NOT_FOUND));
+    }
+
+    private void applyAnswerState(CsAttemptSession session, Long questionId, boolean isCorrect) {
+        if (session.getPhase() == CsAttemptPhase.FIRST_PASS) {
+            if (isCorrect) {
+                session.setFirstPassCorrectCount(session.getFirstPassCorrectCount() + 1);
+            } else {
+                session.getFirstPassWrongQuestionIds().add(questionId);
+            }
+        }
+
+        if (!isCorrect) {
+            session.getWrongAttemptCountByQuestionId().merge(questionId, 1, Integer::sum);
+        }
+
+        session.getLatestCorrectByQuestionId().put(questionId, isCorrect);
+    }
+
+    private void moveToNextQuestion(CsAttemptSession session) {
+        int nextIndex = session.getCurrentRoundIndex() + 1;
+        List<Long> currentRound = session.getCurrentRoundQuestionIds();
+
+        if (nextIndex < currentRound.size()) {
+            session.setCurrentRoundIndex(nextIndex);
+            return;
+        }
+
+        List<Long> wrongQuestionIds = currentRound.stream()
+                .filter(questionId -> !Boolean.TRUE.equals(session.getLatestCorrectByQuestionId().get(questionId)))
+                .toList();
+
+        if (wrongQuestionIds.isEmpty()) {
+            session.setPhase(CsAttemptPhase.COMPLETED);
+            session.setCurrentRoundQuestionIds(List.of());
+            session.setCurrentRoundIndex(0);
+            return;
+        }
+
+        if (session.getPhase() == CsAttemptPhase.FIRST_PASS) {
+            session.setRetryRound(1);
+        } else {
+            session.setRetryRound(session.getRetryRound() + 1);
+        }
+
+        session.setPhase(CsAttemptPhase.RETRY_WRONG);
+        session.setCurrentRoundQuestionIds(wrongQuestionIds);
+        session.setCurrentRoundIndex(0);
+    }
+
+    private boolean gradeAnswerByMockPolicy(CsQuestion question, CsAttemptAnswerRequest request) {
+        CsQuestionType questionType = question.getQuestionType();
+
+        return switch (questionType) {
+            case MULTIPLE_CHOICE, OX -> {
+                Integer selectedChoiceNo = request.selectedChoiceNo();
+                if (selectedChoiceNo == null || selectedChoiceNo <= 0) {
+                    throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "객관식/OX는 selectedChoiceNo가 필요합니다.");
+                }
+
+                boolean existsChoice = csQuestionChoiceRepository.findByQuestion_IdOrderByChoiceNoAsc(question.getId())
+                        .stream()
+                        .anyMatch(choice -> choice.getChoiceNo() != null
+                                && choice.getChoiceNo().intValue() == selectedChoiceNo);
+                if (!existsChoice) {
+                    throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "존재하지 않는 선택지입니다.");
+                }
+
+                // #143 단계: 목 채점 정책(1번 선택지를 정답으로 가정)
+                yield selectedChoiceNo == 1;
+            }
+            case SHORT_ANSWER, ESSAY -> {
+                String answerText = request.answerText();
+                if (answerText == null || answerText.isBlank()) {
+                    throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "서술형/단답형은 answerText가 필요합니다.");
+                }
+                // #143 단계: 목 채점 정책("정답" 포함 텍스트를 정답으로 가정)
+                yield answerText.trim().contains("정답");
+            }
+        };
+    }
+
+    private void persistWrongProblems(User user, CsAttemptSession session) {
+        if (session.getWrongAttemptCountByQuestionId().isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        for (Map.Entry<Long, Integer> entry : session.getWrongAttemptCountByQuestionId().entrySet()) {
+            Long questionId = entry.getKey();
+            int wrongCount = entry.getValue() == null ? 0 : entry.getValue();
+
+            if (wrongCount <= 0) {
+                continue;
+            }
+
+            CsQuestion question = csQuestionRepository.findById(questionId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND));
+
+            CsWrongProblem wrongProblem = csWrongProblemRepository.findByUser_IdAndQuestion_Id(user.getId(), questionId)
+                    .orElseGet(() -> CsWrongProblem.builder()
+                            .user(user)
+                            .question(question)
+                            .domain(question.getStage().getTrack().getDomain())
+                            .wrongCount(0)
+                            .reviewCorrectCount(0)
+                            .lastWrongAt(now)
+                            .updatedAt(now)
+                            .build());
+
+            for (int i = 0; i < wrongCount; i++) {
+                wrongProblem.markWrong();
+            }
+            csWrongProblemRepository.save(wrongProblem);
+        }
+    }
+
+    private Long resolveNextStageId(CsStage stage) {
+        return csStageRepository.findByTrack_IdAndStageNo(stage.getTrack().getId(), (short) (stage.getStageNo() + 1))
+                .map(CsStage::getId)
+                .orElse(null);
+    }
+
+    private void updateDomainProgressIfNeeded(Long userId, CsStage stage, Long nextStageId) {
+        Integer domainId = stage.getTrack().getDomain().getId();
+        CsUserDomainProgress progress = csUserDomainProgressRepository.findByUser_IdAndDomain_Id(userId, domainId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_DOMAIN_PROGRESS_NOT_FOUND));
+
+        if (!progress.getCurrentTrackNo().equals(stage.getTrack().getTrackNo())) {
+            return;
+        }
+        if (!progress.getCurrentStageNo().equals(stage.getStageNo())) {
+            return;
+        }
+        if (nextStageId == null) {
+            return;
+        }
+
+        progress.advanceTo(progress.getCurrentTrackNo(), (short) (stage.getStageNo() + 1));
+    }
+
+    private StreakResult applyStreak(User user) {
+        ZonedDateTime now = ZonedDateTime.now(KST_ZONE);
+        if (now.getHour() < 6) {
+            now = now.minusDays(1);
+        }
+
+        LocalDate todayStreakDate = now.toLocalDate();
+        LocalDate yesterdayStreakDate = todayStreakDate.minusDays(1);
+
+        boolean alreadySolvedToday = user.getLastSolvedDate() != null
+                && user.getLastSolvedDate().equals(todayStreakDate);
+
+        if (alreadySolvedToday) {
+            return new StreakResult(false, safeInt(user.getStreakCurrent()));
+        }
+
+        boolean continuesStreak = user.getLastSolvedDate() != null
+                && user.getLastSolvedDate().equals(yesterdayStreakDate);
+
+        user.updateStreak(continuesStreak, todayStreakDate);
+        return new StreakResult(true, safeInt(user.getStreakCurrent()));
+    }
+
+    private int safeInt(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private String resolveMessageCode(int correctRate) {
+        if (correctRate >= MESSAGE_SCORE_EXCELLENT) {
+            return "CS_RESULT_EXCELLENT";
+        }
+        if (correctRate >= MESSAGE_SCORE_GOOD) {
+            return "CS_RESULT_GOOD";
+        }
+        return "CS_RESULT_KEEP_GOING";
+    }
+
+    private List<CsQuestion> selectQuestionSet(List<CsQuestion> loadedQuestions) {
+        if (loadedQuestions.size() <= ATTEMPT_QUESTION_COUNT) {
+            return loadedQuestions;
+        }
+        return new ArrayList<>(loadedQuestions.subList(0, ATTEMPT_QUESTION_COUNT));
+    }
+
+    private void validateStageAccess(CsUserDomainProgress progress, CsStage stage) {
+        short currentTrackNo = progress.getCurrentTrackNo();
+        short currentStageNo = progress.getCurrentStageNo();
+        short targetTrackNo = stage.getTrack().getTrackNo();
+        short targetStageNo = stage.getStageNo();
+
+        if (targetTrackNo != currentTrackNo) {
+            throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_NOT_CURRENT_TRACK);
+        }
+
+        if (targetStageNo > currentStageNo) {
+            throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_PREVIOUS_STAGE);
+        }
+    }
+
+    private User getUser(Long userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private CsStage getStage(Long stageId) {
+        return csStageRepository.findByIdWithTrackAndDomain(stageId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_STAGE_NOT_FOUND));
+    }
+
+    private CsQuestionPayloadResponse toQuestionPayload(CsQuestion question) {
+        List<CsQuestionChoiceResponse> choices = switch (question.getQuestionType()) {
+            case MULTIPLE_CHOICE, OX -> csQuestionChoiceRepository
+                    .findByQuestion_IdOrderByChoiceNoAsc(question.getId())
+                    .stream()
+                    .map(choice -> new CsQuestionChoiceResponse(
+                            (int) choice.getChoiceNo(),
+                            choice.getContent()))
+                    .toList();
+            default -> List.of();
+        };
+
+        return new CsQuestionPayloadResponse(
+                question.getId(),
+                question.getQuestionType(),
+                question.getPrompt(),
+                choices.isEmpty() ? null : choices);
+    }
+
+    private record StreakResult(boolean earnedToday, int currentStreak) {
+    }
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsDomainService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsDomainService.java
@@ -195,7 +195,7 @@ public class CsDomainService {
             throw new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND, "스테이지에 등록된 문제가 없습니다.");
         }
 
-        return new CsAttemptStartResponse(stage.getId(), toQuestionPayload(questions.get(0)));
+        return new CsAttemptStartResponse(stage.getId(), questions.size(), toQuestionPayload(questions.get(0)));
     }
 
     private CsUserProfile getOrCreateUserProfile(Long userId, User user) {

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/store/CsAttemptSession.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/store/CsAttemptSession.java
@@ -1,0 +1,35 @@
+package com.peekle.domain.cs.service.store;
+
+import com.peekle.domain.cs.enums.CsAttemptPhase;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CsAttemptSession {
+    private Long userId;
+    private Long stageId;
+    private Integer domainId;
+    private CsAttemptPhase phase;
+    private Integer retryRound;
+    private List<Long> questionOrder;
+    private List<Long> currentRoundQuestionIds;
+    private Integer currentRoundIndex;
+    private Integer firstPassCorrectCount;
+    private Set<Long> firstPassWrongQuestionIds;
+    private Map<Long, Integer> wrongAttemptCountByQuestionId;
+    private Map<Long, Boolean> latestCorrectByQuestionId;
+    private LocalDateTime startedAt;
+    private LocalDateTime updatedAt;
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/store/CsAttemptStore.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/store/CsAttemptStore.java
@@ -1,0 +1,11 @@
+package com.peekle.domain.cs.service.store;
+
+import java.util.Optional;
+
+public interface CsAttemptStore {
+    void save(CsAttemptSession session);
+
+    Optional<CsAttemptSession> find(Long userId, Long stageId);
+
+    void delete(Long userId, Long stageId);
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/store/InMemoryCsAttemptStore.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/store/InMemoryCsAttemptStore.java
@@ -1,0 +1,34 @@
+package com.peekle.domain.cs.service.store;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+@Profile("test")
+public class InMemoryCsAttemptStore implements CsAttemptStore {
+
+    private final ConcurrentMap<String, CsAttemptSession> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(CsAttemptSession session) {
+        storage.put(key(session.getUserId(), session.getStageId()), session);
+    }
+
+    @Override
+    public Optional<CsAttemptSession> find(Long userId, Long stageId) {
+        return Optional.ofNullable(storage.get(key(userId, stageId)));
+    }
+
+    @Override
+    public void delete(Long userId, Long stageId) {
+        storage.remove(key(userId, stageId));
+    }
+
+    private String key(Long userId, Long stageId) {
+        return userId + ":" + stageId;
+    }
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/store/RedisCsAttemptStore.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/store/RedisCsAttemptStore.java
@@ -1,0 +1,54 @@
+package com.peekle.domain.cs.service.store;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.peekle.global.redis.RedisKeyConst;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class RedisCsAttemptStore implements CsAttemptStore {
+
+    private static final Duration ATTEMPT_TTL = Duration.ofHours(6);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void save(CsAttemptSession session) {
+        redisTemplate.opsForValue().set(key(session.getUserId(), session.getStageId()), session, ATTEMPT_TTL);
+    }
+
+    @Override
+    public Optional<CsAttemptSession> find(Long userId, Long stageId) {
+        Object value = redisTemplate.opsForValue().get(key(userId, stageId));
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        if (value instanceof CsAttemptSession session) {
+            return Optional.of(session);
+        }
+
+        try {
+            return Optional.of(objectMapper.convertValue(value, CsAttemptSession.class));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void delete(Long userId, Long stageId) {
+        redisTemplate.delete(key(userId, stageId));
+    }
+
+    private String key(Long userId, Long stageId) {
+        return String.format(RedisKeyConst.CS_ATTEMPT, userId, stageId);
+    }
+}

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
@@ -1,0 +1,212 @@
+package com.peekle.domain.cs.service;
+
+import com.peekle.domain.cs.dto.request.CsAttemptAnswerRequest;
+import com.peekle.domain.cs.dto.response.CsAttemptAnswerResponse;
+import com.peekle.domain.cs.dto.response.CsAttemptCompleteResponse;
+import com.peekle.domain.cs.dto.response.CsAttemptStartResponse;
+import com.peekle.domain.cs.entity.CsDomain;
+import com.peekle.domain.cs.entity.CsDomainTrack;
+import com.peekle.domain.cs.entity.CsQuestion;
+import com.peekle.domain.cs.entity.CsQuestionChoice;
+import com.peekle.domain.cs.entity.CsStage;
+import com.peekle.domain.cs.entity.CsWrongProblem;
+import com.peekle.domain.cs.enums.CsAttemptPhase;
+import com.peekle.domain.cs.enums.CsQuestionType;
+import com.peekle.domain.cs.enums.CsWrongProblemStatus;
+import com.peekle.domain.cs.repository.CsDomainRepository;
+import com.peekle.domain.cs.repository.CsDomainTrackRepository;
+import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
+import com.peekle.domain.cs.repository.CsQuestionRepository;
+import com.peekle.domain.cs.repository.CsStageRepository;
+import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
+import com.peekle.domain.cs.repository.CsWrongProblemRepository;
+import com.peekle.domain.user.entity.User;
+import com.peekle.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class CsAttemptFlowIntegrationTest {
+
+    @Autowired
+    private CsAttemptService csAttemptService;
+
+    @Autowired
+    private CsDomainService csDomainService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CsDomainRepository csDomainRepository;
+
+    @Autowired
+    private CsDomainTrackRepository csDomainTrackRepository;
+
+    @Autowired
+    private CsStageRepository csStageRepository;
+
+    @Autowired
+    private CsQuestionRepository csQuestionRepository;
+
+    @Autowired
+    private CsQuestionChoiceRepository csQuestionChoiceRepository;
+
+    @Autowired
+    private CsWrongProblemRepository csWrongProblemRepository;
+
+    @Autowired
+    private CsUserDomainProgressRepository csUserDomainProgressRepository;
+
+    @Test
+    @DisplayName("오답이 남아있으면 재풀이 라운드를 반복하고 완료 시 오답노트에 누적 저장한다")
+    void attemptFlow_retriesAndPersistsWrongProblems() {
+        User user = createUser("attempt-flow");
+        CsDomain domain = createDomain(401, "CS 시도 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "CS 시도 트랙");
+        CsStage stage = createStage(track, 1);
+        CsQuestion firstQuestion = createMultipleChoiceQuestion(stage, "첫 번째 문제");
+        createMultipleChoiceQuestion(stage, "두 번째 문제");
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+
+        CsAttemptStartResponse startResponse = csAttemptService.startStageAttempt(user.getId(), stage.getId());
+        assertThat(startResponse.firstQuestion().questionId()).isEqualTo(firstQuestion.getId());
+
+        CsAttemptAnswerResponse firstAnswer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(firstQuestion.getId(), 2, null));
+        assertThat(firstAnswer.isCorrect()).isFalse();
+        assertThat(firstAnswer.phase()).isEqualTo(CsAttemptPhase.FIRST_PASS);
+
+        Long secondQuestionId = firstAnswer.nextQuestion().questionId();
+        CsAttemptAnswerResponse secondAnswer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(secondQuestionId, 1, null));
+        assertThat(secondAnswer.isCorrect()).isTrue();
+        assertThat(secondAnswer.phase()).isEqualTo(CsAttemptPhase.RETRY_WRONG);
+        assertThat(secondAnswer.nextQuestion().questionId()).isEqualTo(firstQuestion.getId());
+
+        CsAttemptAnswerResponse thirdAnswer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(firstQuestion.getId(), 2, null));
+        assertThat(thirdAnswer.isCorrect()).isFalse();
+        assertThat(thirdAnswer.phase()).isEqualTo(CsAttemptPhase.RETRY_WRONG);
+
+        CsAttemptAnswerResponse fourthAnswer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(firstQuestion.getId(), 1, null));
+        assertThat(fourthAnswer.isCorrect()).isTrue();
+        assertThat(fourthAnswer.isLast()).isTrue();
+        assertThat(fourthAnswer.phase()).isEqualTo(CsAttemptPhase.COMPLETED);
+
+        CsAttemptCompleteResponse completeResponse = csAttemptService.completeAttempt(user.getId(), stage.getId());
+        assertThat(completeResponse.correctCount()).isEqualTo(1);
+        assertThat(completeResponse.wrongCount()).isEqualTo(1);
+        assertThat(completeResponse.correctRate()).isEqualTo(50);
+
+        CsWrongProblem wrongProblem = csWrongProblemRepository.findByUser_IdAndQuestion_Id(user.getId(), firstQuestion.getId())
+                .orElseThrow();
+        assertThat(wrongProblem.getStatus()).isEqualTo(CsWrongProblemStatus.ACTIVE);
+        assertThat(wrongProblem.getWrongCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("현재 진행 스테이지 완료 시 다음 스테이지가 해금되고 결과 응답에 nextStageId가 포함된다")
+    void completeAttempt_unlocksNextStage() {
+        User user = createUser("attempt-progress");
+        CsDomain domain = createDomain(402, "진행도 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "진행도 트랙");
+        CsStage stage1 = createStage(track, 1);
+        CsStage stage2 = createStage(track, 2);
+        CsQuestion question = createMultipleChoiceQuestion(stage1, "진행도 문제");
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+
+        csAttemptService.startStageAttempt(user.getId(), stage1.getId());
+        CsAttemptAnswerResponse answer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage1.getId(),
+                new CsAttemptAnswerRequest(question.getId(), 1, null));
+        assertThat(answer.isLast()).isTrue();
+        assertThat(answer.phase()).isEqualTo(CsAttemptPhase.COMPLETED);
+
+        CsAttemptCompleteResponse completeResponse = csAttemptService.completeAttempt(user.getId(), stage1.getId());
+        assertThat(completeResponse.isTrackCompleted()).isFalse();
+        assertThat(completeResponse.nextStageId()).isEqualTo(stage2.getId());
+
+        assertThat(csUserDomainProgressRepository.findByUser_IdAndDomain_Id(user.getId(), domain.getId()))
+                .get()
+                .satisfies(progress -> assertThat(progress.getCurrentStageNo()).isEqualTo((short) 2));
+    }
+
+    private User createUser(String suffix) {
+        return userRepository.save(User.builder()
+                .socialId("social-" + suffix)
+                .provider("TEST")
+                .nickname("nick-" + suffix)
+                .bojId("boj-" + suffix)
+                .profileImg("default.png")
+                .profileImgThumb("default-thumb.png")
+                .build());
+    }
+
+    private CsDomain createDomain(int domainId, String name) {
+        return csDomainRepository.save(CsDomain.builder()
+                .id(domainId)
+                .name(name)
+                .build());
+    }
+
+    private CsDomainTrack createTrack(CsDomain domain, int trackNo, String name) {
+        return csDomainTrackRepository.save(CsDomainTrack.builder()
+                .domain(domain)
+                .trackNo((short) trackNo)
+                .name(name)
+                .build());
+    }
+
+    private CsStage createStage(CsDomainTrack track, int stageNo) {
+        return csStageRepository.save(CsStage.builder()
+                .track(track)
+                .stageNo((short) stageNo)
+                .build());
+    }
+
+    private CsQuestion createMultipleChoiceQuestion(CsStage stage, String prompt) {
+        CsQuestion question = csQuestionRepository.save(CsQuestion.builder()
+                .stage(stage)
+                .questionType(CsQuestionType.MULTIPLE_CHOICE)
+                .prompt(prompt)
+                .explanation("테스트 해설")
+                .isActive(true)
+                .build());
+
+        csQuestionChoiceRepository.save(CsQuestionChoice.builder()
+                .question(question)
+                .choiceNo((short) 1)
+                .content("선지 1")
+                .isAnswer(true)
+                .build());
+        csQuestionChoiceRepository.save(CsQuestionChoice.builder()
+                .question(question)
+                .choiceNo((short) 2)
+                .content("선지 2")
+                .isAnswer(false)
+                .build());
+
+        return question;
+    }
+}

--- a/apps/frontend/src/app/(main)/MainContentWrapper.tsx
+++ b/apps/frontend/src/app/(main)/MainContentWrapper.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+import { usePathname } from 'next/navigation';
+
+export default function MainContentWrapper({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isHiddenRoute = pathname.startsWith('/cs/stage/');
+
+  return (
+    <div className={`flex min-w-0 flex-1 flex-col ${isHiddenRoute ? '' : 'lg:ml-[240px]'}`}>
+      {children}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/(main)/cs/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/page.tsx
@@ -54,7 +54,7 @@ export default function CSPage() {
         </p>
         {bootstrapData?.progress ? (
           <div className="mt-4 pt-4 w-full flex flex-col items-center">
-            <LearningMap progress={bootstrapData.progress} />
+            <LearningMap progress={bootstrapData.progress} stages={bootstrapData.stages ?? []} />
           </div>
         ) : (
           <div className="p-8 border border-dashed border-primary/30 rounded-xl bg-primary/5 text-center">

--- a/apps/frontend/src/app/(main)/cs/stage/[stageId]/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/stage/[stageId]/page.tsx
@@ -1,7 +1,12 @@
 import CSLearningSession from '@/domains/cs/components/session/CSLearningSession';
 
-export default function CSStagePage({ params }: { params: { stageId: string } }) {
-  const stageId = parseInt(params.stageId, 10);
+interface CSStagePageProps {
+  params: Promise<{ stageId: string }>;
+}
+
+export default async function CSStagePage({ params }: CSStagePageProps) {
+  const { stageId: rawStageId } = await params;
+  const stageId = parseInt(rawStageId, 10);
   
   if (isNaN(stageId)) {
     return (

--- a/apps/frontend/src/app/(main)/cs/stage/[stageId]/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/stage/[stageId]/page.tsx
@@ -1,0 +1,15 @@
+import CSLearningSession from '@/domains/cs/components/session/CSLearningSession';
+
+export default function CSStagePage({ params }: { params: { stageId: string } }) {
+  const stageId = parseInt(params.stageId, 10);
+  
+  if (isNaN(stageId)) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh]">
+        <p className="text-destructive font-bold">잘못된 스테이지 ID입니다.</p>
+      </div>
+    );
+  }
+
+  return <CSLearningSession stageId={stageId} />;
+}

--- a/apps/frontend/src/app/(main)/layout.tsx
+++ b/apps/frontend/src/app/(main)/layout.tsx
@@ -2,6 +2,7 @@ import Sidebar from '@/domains/lnb/components/Sidebar';
 import MobileBottomNav from '@/domains/lnb/components/MobileBottomNav';
 import LeagueResultModal from '@/domains/league/components/LeagueResultModal';
 import { getMyProfile } from '@/domains/profile/actions/profile';
+import MainContentWrapper from './MainContentWrapper';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,14 +16,14 @@ export default async function MainLayout({
   return (
     <div className="flex h-[100dvh] min-h-screen overflow-hidden lg:h-auto lg:min-h-screen lg:overflow-visible">
       <Sidebar user={user} />
-      <div className="flex min-w-0 flex-1 flex-col lg:ml-[240px]">
+      <MainContentWrapper>
         <main className="flex-1 min-h-0 w-full max-w-7xl mx-auto overflow-y-auto px-4 py-0 lg:px-8 lg:overflow-visible">
           {children}
         </main>
         <div className="shrink-0 lg:hidden">
           <MobileBottomNav />
         </div>
-      </div>
+      </MainContentWrapper>
       <LeagueResultModal />
     </div>
   );

--- a/apps/frontend/src/domains/cs/api/csApi.ts
+++ b/apps/frontend/src/domains/cs/api/csApi.ts
@@ -7,6 +7,7 @@ export interface CSDomain {
 }
 
 export type CSQuestionType = 'MULTIPLE_CHOICE' | 'SHORT_ANSWER' | 'ESSAY' | 'OX';
+export type CSAttemptPhase = 'FIRST_PASS' | 'RETRY_WRONG' | 'COMPLETED';
 
 export interface CSProgress {
   currentTrackNo: number;
@@ -14,10 +15,20 @@ export interface CSProgress {
   currentStageNo: number;
 }
 
+export type CSStageStatus = 'COMPLETED' | 'IN_PROGRESS' | 'LOCKED';
+
+export interface CSStageStatusItem {
+  stageId: number;
+  stageNo: number;
+  status: CSStageStatus;
+  lockReason: string | null;
+}
+
 export interface CSBootstrapResponse {
   needsDomainSelection: boolean;
   currentDomain: CSDomain | null;
   progress: CSProgress | null;
+  stages: CSStageStatusItem[];
 }
 
 export interface CSMyDomainItem {
@@ -52,6 +63,7 @@ export interface CSQuestionPayload {
 
 export interface CSAttemptStartResponse {
   stageId: number;
+  totalQuestionCount: number;
   firstQuestion: CSQuestionPayload;
 }
 
@@ -70,6 +82,7 @@ export interface CSAttemptAnswerResponse {
   questionId: number;
   questionType: CSQuestionType;
   progress: CSAttemptProgress;
+  phase: CSAttemptPhase;
   isCorrect: boolean;
   feedback: string;
   isLast: boolean;

--- a/apps/frontend/src/domains/cs/components/LearningMap.tsx
+++ b/apps/frontend/src/domains/cs/components/LearningMap.tsx
@@ -2,16 +2,17 @@
 
 import React from 'react';
 import { useEffect, useRef } from 'react';
-import { CSProgress } from '@/domains/cs/api/csApi';
+import { CSProgress, CSStageStatusItem } from '@/domains/cs/api/csApi';
 import { cn } from '@/lib/utils';
 import { Check, Lock, Play } from 'lucide-react';
 import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
 
 interface LearningMapProps {
   progress: CSProgress;
+  stages: CSStageStatusItem[];
 }
 
-const STAGE_COUNT = 10;
 const STAGE_WIDTH = 96; // w-24 (96px)
 const STAGE_HEIGHT = 80; // h-20 (80px)
 const GAP_Y = 48; // 48px
@@ -42,13 +43,15 @@ const getConnectorStyle = (i: number): React.CSSProperties => {
   };
 };
 
-export default function LearningMap({ progress }: LearningMapProps) {
+export default function LearningMap({ progress, stages }: LearningMapProps) {
+  const router = useRouter();
   const { currentTrackNo, currentStageNo } = progress;
   const stageButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const stageCount = stages.length;
 
   useEffect(() => {
-    const targetIndex = currentStageNo - 1;
-    if (targetIndex < 0 || targetIndex >= STAGE_COUNT) return;
+    const targetIndex = stages.findIndex((stage) => stage.stageNo === currentStageNo);
+    if (targetIndex < 0 || targetIndex >= stageCount) return;
 
     const target = stageButtonRefs.current[targetIndex];
     if (!target) return;
@@ -64,19 +67,20 @@ export default function LearningMap({ progress }: LearningMapProps) {
         inline: 'nearest',
       });
     });
-  }, [currentStageNo]);
+  }, [currentStageNo, stageCount, stages]);
 
-  const handleStageClick = (stageNo: number, state: 'COMPLETED' | 'IN_PROGRESS' | 'LOCKED') => {
+  const handleStageClick = (stage: CSStageStatusItem) => {
     // [DEBUG] 사용자 요청사항: 중간 과정 출력용 디버깅 로직 포함
-    console.log(`[DEBUG] LearningMap Stage Clicked: Track ${currentTrackNo}, Stage ${stageNo}, State: ${state}`);
+    console.log(
+      `[DEBUG] LearningMap Stage Clicked: Track ${currentTrackNo}, StageNo ${stage.stageNo}, StageId ${stage.stageId}, State: ${stage.status}`,
+    );
     
-    if (state === 'LOCKED') {
-      toast.info('이전 단계를 먼저 클리어해주세요 🔒');
+    if (stage.status === 'LOCKED') {
+      toast.info(stage.lockReason || '이전 단계를 먼저 클리어해주세요 🔒');
       return;
     }
 
-    // TODO: MVP 단계에서는 문제 세트 진입 화면이 없으므로 토스트 알림으로 임시 처리
-    toast.success(`${currentTrackNo}-${stageNo} 스테이지 진입! (준비중)`);
+    router.push(`/cs/stage/${stage.stageId}`);
   };
 
   return (
@@ -88,20 +92,16 @@ export default function LearningMap({ progress }: LearningMapProps) {
         className="flex flex-col relative w-full max-w-sm items-center"
         style={{ gap: `${GAP_Y}px` }}
       >
-        {Array.from({ length: STAGE_COUNT }).map((_, i) => {
-          const stageNo = i + 1;
-          let state: 'COMPLETED' | 'IN_PROGRESS' | 'LOCKED' = 'LOCKED';
-          if (stageNo < currentStageNo) state = 'COMPLETED';
-          else if (stageNo === currentStageNo) state = 'IN_PROGRESS';
-
+        {stages.map((stage, i) => {
+          const stageNo = stage.stageNo;
+          const state = stage.status;
           const offsetX = getOffset(i);
-          const isNotLast = i < STAGE_COUNT - 1;
+          const isNotLast = i < stageCount - 1;
 
           // 다음 스테이지로 이어지는 커넥터의 스타일 판별
           let bridgeClass = 'bg-surface-3 opacity-60';
           if (state === 'COMPLETED' || state === 'IN_PROGRESS') {
-            const nextState = stageNo + 1 <= currentStageNo ? 'COMPLETED' : 
-                               (stageNo + 1 === currentStageNo ? 'IN_PROGRESS' : 'LOCKED');
+            const nextState = stages[i + 1]?.status;
             if (nextState === 'COMPLETED' || nextState === 'IN_PROGRESS') {
               bridgeClass = 'bg-primary/50 shadow-[0_0_8px_rgba(var(--primary),0.4)]';
             }
@@ -109,7 +109,7 @@ export default function LearningMap({ progress }: LearningMapProps) {
 
           return (
             <div
-              key={stageNo}
+              key={stage.stageId}
               className="relative flex items-center justify-center shrink-0"
               style={{
                 width: STAGE_WIDTH,
@@ -133,7 +133,7 @@ export default function LearningMap({ progress }: LearningMapProps) {
                 ref={(element) => {
                   stageButtonRefs.current[i] = element;
                 }}
-                onClick={() => handleStageClick(stageNo, state)}
+                onClick={() => handleStageClick(stage)}
                 className={cn(
                   'relative z-10 w-full h-full rounded-2xl flex flex-col items-center justify-center transition-all duration-200 font-bold border-[3px] select-none text-sm tracking-wider',
                   {

--- a/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { Loader2, X, AlertCircle } from 'lucide-react';
+import { toast } from 'sonner';
+
+import {
+  startCSStageAttempt,
+  answerCSStageQuestion,
+  completeCSStageAttempt,
+  CSQuestionPayload,
+  CSAttemptCompleteResponse,
+  CSAttemptAnswerRequest,
+  CSAttemptAnswerResponse,
+} from '@/domains/cs/api/csApi';
+
+import CSMockProblem from './CSMockProblem';
+import CSResultScreen from './CSResultScreen';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+
+interface CSLearningSessionProps {
+  stageId: number;
+}
+
+type Phase = 'loading' | 'playing' | 'submitting_complete' | 'result' | 'error';
+
+export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
+  const router = useRouter();
+
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [currentQuestion, setCurrentQuestion] = useState<CSQuestionPayload | null>(null);
+  const [totalQuestionCount, setTotalQuestionCount] = useState(0);
+  const [solvedQuestionIds, setSolvedQuestionIds] = useState<number[]>([]);
+  const [resultData, setResultData] = useState<CSAttemptCompleteResponse | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showExitAlert, setShowExitAlert] = useState(false);
+  const [answerResult, setAnswerResult] = useState<CSAttemptAnswerResponse | null>(null);
+
+  const initSession = useCallback(async () => {
+    try {
+      setPhase('loading');
+      const res = await startCSStageAttempt(stageId);
+      setCurrentQuestion(res.firstQuestion);
+      setTotalQuestionCount(res.totalQuestionCount);
+      setSolvedQuestionIds([]);
+      setPhase('playing');
+    } catch (err) {
+      console.error('Failed to start session:', err);
+      toast.error('스테이지 세션을 시작하지 못했습니다.');
+      setPhase('error');
+    }
+  }, [stageId]);
+
+  useEffect(() => {
+    initSession();
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [initSession]);
+
+  const handleCompleteSession = async () => {
+    try {
+      setPhase('submitting_complete');
+      const res = await completeCSStageAttempt(stageId);
+      setResultData(res);
+      setPhase('result');
+    } catch (err) {
+      console.error(err);
+      toast.error('스테이지 결과를 불러오는 데 실패했습니다.');
+      setPhase('error');
+    }
+  };
+
+  const handleAnswerSubmit = async (payload: CSAttemptAnswerRequest) => {
+    if (!currentQuestion) return;
+
+    setIsSubmitting(true);
+    try {
+      console.log(`[DEBUG] Submitting answer for question ${currentQuestion.questionId}...`);
+      const res = await answerCSStageQuestion(stageId, payload);
+      
+      // 피드백 모달이 떠 있는 동안엔 진행도를 바꾸지 않고 대기
+      setAnswerResult(res);
+    } catch (err) {
+      console.error(err);
+      toast.error('답안 제출에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleNextAfterFeedback = async () => {
+    if (!answerResult) return;
+    const { isLast, nextQuestion, isCorrect, questionId } = answerResult;
+    
+    // 계속하기 버튼을 누른 후 상태 업데이트
+    if (isCorrect) {
+      setSolvedQuestionIds((previous) =>
+        previous.includes(questionId) ? previous : [...previous, questionId],
+      );
+    }
+    
+    setAnswerResult(null);
+
+    if (isLast) {
+      await handleCompleteSession();
+    } else if (nextQuestion) {
+      setCurrentQuestion(nextQuestion);
+    }
+  };
+
+  const handleExitConfirm = () => {
+    router.replace('/cs');
+  };
+
+  if (phase === 'error') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <AlertCircle className="w-12 h-12 text-destructive" />
+        <h2 className="text-xl font-bold">오류가 발생했습니다</h2>
+        <Button onClick={() => router.replace('/cs')} variant="outline">
+          돌아가기
+        </Button>
+      </div>
+    );
+  }
+
+  if (phase === 'loading') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 animate-pulse">
+        <Loader2 className="w-10 h-10 animate-spin text-primary" />
+        <p className="text-muted-foreground font-medium">스테이지를 준비하고 있습니다...</p>
+      </div>
+    );
+  }
+
+  if (phase === 'submitting_complete') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <Loader2 className="w-10 h-10 animate-spin text-primary" />
+        <p className="text-muted-foreground font-medium animate-pulse">결과를 집계하고 있습니다...</p>
+      </div>
+    );
+  }
+
+  if (phase === 'result' && resultData) {
+    return <CSResultScreen result={resultData} />;
+  }
+
+  return (
+    <div className="flex flex-col w-full animate-in fade-in relative min-h-[80vh] pb-10">
+      <header className="flex items-center justify-between py-4 px-6 bg-background/80 backdrop-blur-md sticky top-0 z-50 border-b border-border/50">
+        <div className="flex flex-col">
+          <span className="text-sm font-semibold text-muted-foreground">스테이지 {stageId}</span>
+          {phase === 'playing' && totalQuestionCount > 0 && (
+            <div className="flex items-center gap-3">
+              <h1 className="text-lg font-bold">
+                진행도: {solvedQuestionIds.length} / {totalQuestionCount}
+              </h1>
+            </div>
+          )}
+        </div>
+        <button
+          onClick={() => setShowExitAlert(true)}
+          className="p-2 bg-muted hover:bg-muted/80 rounded-full transition-colors group"
+        >
+          <X className="w-6 h-6 text-muted-foreground group-hover:text-foreground transition-colors" />
+        </button>
+      </header>
+
+      <main className="flex-1 flex flex-col justify-center items-center p-4">
+        {phase === 'playing' && currentQuestion && (
+          <CSMockProblem
+            question={currentQuestion}
+            onSubmit={handleAnswerSubmit}
+            isSubmitting={isSubmitting}
+          />
+        )}
+      </main>
+
+      <AlertDialog open={showExitAlert} onOpenChange={setShowExitAlert}>
+        <AlertDialogContent className="rounded-2xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertCircle className="w-5 h-5 text-destructive" />
+              학습을 중단하시겠습니까?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              지금 나가시면 현재까지의 풀이 진행 상황이 모두 사라집니다.
+              <br />
+              다음에 다시 들어오면 처음부터 시작해야 합니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="gap-2 sm:gap-0 mt-2">
+            <AlertDialogCancel className="rounded-xl">계속 풀기</AlertDialogCancel>
+            <AlertDialogAction
+              className="rounded-xl bg-destructive hover:bg-destructive/90 text-destructive-foreground"
+              onClick={handleExitConfirm}
+            >
+              나가기
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* 피드백 모달 */}
+      {answerResult && (
+        <div className="fixed inset-0 z-[100] flex animate-in fade-in bg-black/40 items-end sm:items-center justify-center p-0 sm:p-4 pointer-events-auto">
+          <div
+            className={`w-full sm:max-w-lg p-6 sm:p-8 flex flex-col gap-4 shadow-2xl rounded-t-3xl sm:rounded-2xl ${
+              answerResult.isCorrect ? 'bg-green-50' : 'bg-red-50'
+            } animate-in slide-in-from-bottom sm:slide-in-from-bottom-8 duration-300 pointer-events-auto`}
+          >
+            <div className="flex flex-col gap-2">
+              <h2
+                className={`text-2xl font-black tracking-tight ${
+                  answerResult.isCorrect ? 'text-green-600' : 'text-red-500'
+                }`}
+              >
+                {answerResult.isCorrect ? '정답입니다!' : '틀렸습니다.'}
+              </h2>
+              {answerResult.feedback && (
+                <div className="mt-2 p-4 rounded-xl bg-white/60 text-foreground text-[15px] leading-relaxed whitespace-pre-wrap">
+                  <span className="font-bold block mb-1 text-sm text-muted-foreground">설명</span>
+                  {answerResult.feedback}
+                </div>
+              )}
+            </div>
+            <Button
+              onClick={handleNextAfterFeedback}
+              className={`w-full h-14 mt-4 font-bold text-lg rounded-xl shadow-sm hover:shadow-md transition-all ${
+                answerResult.isCorrect
+                  ? 'bg-green-500 hover:bg-green-600'
+                  : 'bg-red-500 hover:bg-red-600'
+              } text-white`}
+            >
+              계속하기
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/domains/cs/components/session/CSMockProblem.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSMockProblem.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React, { useState } from 'react';
+import { CSQuestionPayload, CSAttemptAnswerRequest } from '@/domains/cs/api/csApi';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+
+interface CSMockProblemProps {
+  question: CSQuestionPayload;
+  onSubmit: (payload: CSAttemptAnswerRequest) => void;
+  isSubmitting: boolean;
+}
+
+export default function CSMockProblem({ question, onSubmit, isSubmitting }: CSMockProblemProps) {
+  const [answerText, setAnswerText] = useState('');
+  const [selectedChoiceNo, setSelectedChoiceNo] = useState<number | null>(null);
+
+  const handleSubmitMockCorrect = () => {
+    // 임의의 정답 제출 (테스트용)
+    const payload: CSAttemptAnswerRequest = {
+      questionId: question.questionId,
+    };
+
+    if (question.questionType === 'MULTIPLE_CHOICE' || question.questionType === 'OX') {
+      // 선택지 중 첫 번째를 임시 정답으로 보냄 (또는 사용자가 선택한 값)
+      payload.selectedChoiceNo = selectedChoiceNo ?? (question.choices?.[0]?.choiceNo || 1);
+    } else {
+      const normalized = answerText.trim();
+      payload.answerText = normalized ? `정답 ${normalized}` : '정답';
+    }
+
+    onSubmit(payload);
+  };
+
+  const handleSubmitMockWrong = () => {
+    // 임의의 오답 제출 (테스트용)
+    const payload: CSAttemptAnswerRequest = {
+      questionId: question.questionId,
+    };
+
+    if (question.questionType === 'MULTIPLE_CHOICE' || question.questionType === 'OX') {
+      payload.selectedChoiceNo = selectedChoiceNo ?? (question.choices?.[1]?.choiceNo || 2);
+    } else {
+      const normalized = answerText.trim();
+      payload.answerText = normalized ? `오답 ${normalized}` : '오답';
+    }
+
+    onSubmit(payload);
+  };
+
+  return (
+    <Card className="w-full max-w-2xl mx-auto p-6 md:p-8 flex flex-col gap-6 animate-in fade-in zoom-in-95 duration-300">
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-semibold text-primary px-3 py-1 bg-primary/10 w-fit rounded-full">
+          {question.questionType}
+        </span>
+        <h2 className="text-xl md:text-2xl font-bold whitespace-pre-wrap leading-relaxed">
+          {question.prompt}
+        </h2>
+      </div>
+
+      {question.choices && question.choices.length > 0 && (
+        <div className="flex flex-col gap-3 mt-4">
+          {question.choices.map((choice) => (
+            <button
+              key={choice.choiceNo}
+              onClick={() => setSelectedChoiceNo(choice.choiceNo)}
+              className={`p-4 rounded-xl border-2 text-left transition-all duration-200 ${
+                selectedChoiceNo === choice.choiceNo
+                  ? 'border-primary bg-primary/5 text-foreground font-medium shadow-[0_2px_0_rgba(var(--primary),0.5)] translate-y-[2px]'
+                  : 'border-border bg-card text-muted-foreground hover:border-primary/50'
+              }`}
+            >
+              <span className="font-bold mr-3">{choice.choiceNo}.</span>
+              {choice.content}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {(question.questionType === 'SHORT_ANSWER' || question.questionType === 'ESSAY') && (
+        <div className="mt-4">
+          <textarea
+            className="w-full min-h-[120px] p-4 rounded-xl border-2 border-border focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/20 resize-none transition-shadow"
+            placeholder="답안을 입력하세요 (테스트용)"
+            value={answerText}
+            onChange={(e) => setAnswerText(e.target.value)}
+          />
+        </div>
+      )}
+
+      {/* Mock Tests Buttons */}
+      <div className="mt-8 flex flex-col sm:flex-row gap-4 pt-6 border-t border-dashed">
+        <p className="w-full text-sm text-muted-foreground text-center sm:text-left mb-2 sm:mb-0 sm:hidden">
+          [Mock 테스트 패널]
+        </p>
+        <Button
+          onClick={handleSubmitMockCorrect}
+          disabled={isSubmitting}
+          className="flex-1 font-bold text-base h-12"
+          variant="default"
+        >
+          {isSubmitting ? '채점 중...' : '정답 제출 (Mock)'}
+        </Button>
+        <Button
+          onClick={handleSubmitMockWrong}
+          disabled={isSubmitting}
+          className="flex-1 font-bold text-base h-12"
+          variant="destructive"
+        >
+          오답 제출 (Mock)
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/apps/frontend/src/domains/cs/components/session/CSResultScreen.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSResultScreen.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React from 'react';
+import { CSAttemptCompleteResponse } from '@/domains/cs/api/csApi';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Trophy, Flame, CheckCircle, ArrowRight, RotateCcw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+interface CSResultScreenProps {
+  result: CSAttemptCompleteResponse;
+}
+
+export default function CSResultScreen({ result }: CSResultScreenProps) {
+  const router = useRouter();
+
+  const handleReturnToCS = () => {
+    router.replace('/cs');
+  };
+
+  const handleNextStage = () => {
+    if (result.nextStageId) {
+      router.replace(`/cs/stage/${result.nextStageId}`);
+    }
+  };
+
+  return (
+    <div className="w-full flex-1 flex flex-col items-center justify-center max-w-lg mx-auto py-12 animate-in fade-in zoom-in px-4 min-h-[80vh]">
+      <Card className="w-full border-none shadow-xl bg-background/50 backdrop-blur-xl relative overflow-hidden flex flex-col items-center p-8 text-center rounded-3xl">
+        <div className="absolute inset-0 bg-gradient-to-b from-primary/10 to-transparent -z-10" />
+
+        <div className="w-24 h-24 bg-primary/20 rounded-full flex items-center justify-center mb-6 relative">
+          <Trophy className="w-12 h-12 text-primary" />
+          {result.correctRate >= 80 && (
+            <div className="absolute -top-2 -right-2 bg-yellow-400 text-yellow-900 text-xs font-bold px-2 py-1 rounded-full shadow-lg rotate-12">
+              Excellent!
+            </div>
+          )}
+        </div>
+
+        <h1 className="text-3xl font-extrabold mb-2 text-foreground tracking-tight">스테이지 완료!</h1>
+        <p className="text-muted-foreground mb-8">
+          정답률 <span className="font-bold text-primary">{result.correctRate}%</span> ({result.correctCount}문제 정답)
+        </p>
+
+        {result.streakEarnedToday && (
+          <div className="w-full bg-amber-500/10 border border-amber-500/20 text-amber-600 rounded-2xl p-4 flex items-center justify-center gap-3 mb-8 animate-pulse">
+            <Flame className="w-6 h-6 fill-amber-500" />
+            <span className="font-bold">오늘 스트릭 획득! (진행 중: {result.currentStreak}일)</span>
+          </div>
+        )}
+
+        <div className="flex flex-col w-full gap-3">
+          {result.isTrackCompleted ? (
+            <Button
+              className="w-full h-14 text-lg font-bold rounded-2xl"
+              onClick={handleReturnToCS}
+            >
+              <CheckCircle className="w-5 h-5 mr-2" />
+              트랙 완료 (학습 맵으로)
+            </Button>
+          ) : (
+            <>
+              {result.nextStageId && (
+                <Button
+                  className="w-full h-14 text-lg font-bold rounded-2xl"
+                  onClick={handleNextStage}
+                >
+                  다음 스테이지 풀기
+                  <ArrowRight className="w-5 h-5 ml-2" />
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                className="w-full h-14 text-lg font-bold rounded-2xl"
+                onClick={handleReturnToCS}
+              >
+                <RotateCcw className="w-5 h-5 mr-2" />
+                목록으로 돌아가기
+              </Button>
+            </>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
+++ b/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
@@ -20,6 +20,12 @@ export default function MobileBottomNav() {
     return pathname.startsWith(href);
   };
 
+  const isHiddenRoute = pathname.startsWith('/cs/stage/');
+
+  if (isHiddenRoute) {
+    return null;
+  }
+
   return (
     <div className="lg:hidden border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80">
       <nav className="mx-auto flex max-w-7xl items-center gap-1 overflow-x-auto px-2 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] no-scrollbar">

--- a/apps/frontend/src/domains/lnb/components/Sidebar.tsx
+++ b/apps/frontend/src/domains/lnb/components/Sidebar.tsx
@@ -34,6 +34,12 @@ const Sidebar = ({ user }: SidebarProps) => {
 
   const { openModal, isOpen } = useSettingsStore();
 
+  const isHiddenRoute = pathname.startsWith('/cs/stage/');
+
+  if (isHiddenRoute) {
+    return null;
+  }
+
   return (
     <aside className="hidden lg:flex w-[240px] h-screen bg-card border-r border-border flex-col fixed left-0 top-0 z-50 overflow-y-auto font-sans transition-colors duration-300">
       {/* User Logic Section */}


### PR DESCRIPTION
## 💡 의도 / 배경
CS 스테이지 진입 후 문제를 연속 풀이하고 결과 화면으로 종료하는 세션 플로우가 없어 학습 흐름이 끊기는 문제가 있었습니다.  
또한 오답 발생 시 재풀이/종료 조건이 명확하지 않아 FE/BE 동작 일관성이 부족했습니다.  

## 🛠️ 작업 내용
- [x] 스테이지 세션 시작 API 구현 (`/api/cs/stages/{stageId}/attempt/start`)
- [x] 문제 제출/채점/다음 문제 반환 API 구현 (`/api/cs/stages/{stageId}/attempt/answer`)
- [x] 오답 재풀이 반복 로직 구현 (오답이 남아있으면 다음 재풀이 라운드 진행)
- [x] 세션 완료/결과 API 구현 (`/api/cs/stages/{stageId}/attempt/complete`)
- [x] 세션 완료 시 오답 문제 `cs_wrong_problems` 반영
- [x] 스테이지 맵에서 `stageId` 기반 진입으로 라우팅 수정
- [x] 세션 화면/결과 화면 연동 및 진행도 표시 보정
- [x] CS 세션 통합 테스트 추가

## 🔗 관련 이슈
- Closes #143
- Relates #139 

## 🖼️ 스크린샷 (선택)
<img width="1241" height="857" alt="image" src="https://github.com/user-attachments/assets/2cbd0e51-3694-4fcb-8e8c-31ef01813db0" />
<img width="718" height="643" alt="image" src="https://github.com/user-attachments/assets/5e9e9d13-0bb8-4460-aa34-044dfa696878" />
<img width="632" height="524" alt="image" src="https://github.com/user-attachments/assets/70ed8f55-c17a-4760-a5ae-b3517d41a0bc" />

## 🧪 테스트 방법
- [x] 백엔드: `./gradlew test --tests "com.peekle.domain.cs.service.*"`
- [x] 프론트: `pnpm --filter frontend type-check`
- [x] 수동 테스트:
  1) CS 맵에서 스테이지 클릭 시 첫 문제 로드 확인
  2) 정답/오답 제출 후 다음 문제 이동 확인
  3) 1차 풀이 완료 후 오답 재풀이 단계 진입 확인
  4) 오답 모두 해결 후 결과 화면 진입 확인
  5) 중도 이탈 경고 모달 노출 확인
  6) 재진입 시 새 세션 시작 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- 중도 이탈 시 세션은 즉시 abort API로 삭제하지 않고, 재진입 시 새 세션으로 초기화하는 정책으로 구현했습니다.
- #144(실제 객관식 정답 비교) 이전 단계라 현재 채점은 목 정책 기반입니다.