### PR TITLE
feat: 주관식 문제 구현

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionShortAnswerRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionShortAnswerRepository.java
@@ -1,0 +1,10 @@
+package com.peekle.domain.cs.repository;
+
+import com.peekle.domain.cs.entity.CsQuestionShortAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CsQuestionShortAnswerRepository extends JpaRepository<CsQuestionShortAnswer, Long> {
+    List<CsQuestionShortAnswer> findByQuestion_IdOrderByIsPrimaryDescIdAsc(Long questionId);
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
@@ -9,6 +9,7 @@ import com.peekle.domain.cs.dto.response.CsQuestionChoiceResponse;
 import com.peekle.domain.cs.dto.response.CsQuestionPayloadResponse;
 import com.peekle.domain.cs.entity.CsQuestion;
 import com.peekle.domain.cs.entity.CsQuestionChoice;
+import com.peekle.domain.cs.entity.CsQuestionShortAnswer;
 import com.peekle.domain.cs.entity.CsStage;
 import com.peekle.domain.cs.entity.CsUserDomainProgress;
 import com.peekle.domain.cs.entity.CsWrongProblem;
@@ -16,6 +17,7 @@ import com.peekle.domain.cs.enums.CsAttemptPhase;
 import com.peekle.domain.cs.enums.CsQuestionType;
 import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
 import com.peekle.domain.cs.repository.CsQuestionRepository;
+import com.peekle.domain.cs.repository.CsQuestionShortAnswerRepository;
 import com.peekle.domain.cs.repository.CsStageRepository;
 import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
 import com.peekle.domain.cs.repository.CsWrongProblemRepository;
@@ -34,10 +36,13 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -55,6 +60,7 @@ public class CsAttemptService {
     private final CsStageRepository csStageRepository;
     private final CsQuestionRepository csQuestionRepository;
     private final CsQuestionChoiceRepository csQuestionChoiceRepository;
+    private final CsQuestionShortAnswerRepository csQuestionShortAnswerRepository;
     private final CsUserDomainProgressRepository csUserDomainProgressRepository;
     private final CsWrongProblemRepository csWrongProblemRepository;
     private final CsAttemptStore csAttemptStore;
@@ -297,11 +303,45 @@ public class CsAttemptService {
                         correctAnswer,
                         question.getExplanation());
             }
-            case SHORT_ANSWER, ESSAY -> {
+            case SHORT_ANSWER -> {
                 String answerText = request.answerText();
                 if (answerText == null || answerText.isBlank()) {
                     throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "서술형/단답형은 answerText가 필요합니다.");
                 }
+
+                List<CsQuestionShortAnswer> acceptableAnswers = csQuestionShortAnswerRepository
+                        .findByQuestion_IdOrderByIsPrimaryDescIdAsc(question.getId());
+                if (acceptableAnswers.isEmpty()) {
+                    throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "단답형 정답 구성이 올바르지 않습니다.");
+                }
+
+                String submitted = answerText.strip();
+                String strictSubmitted = normalizeStrict(submitted);
+                String relaxedSubmitted = normalizeRelaxed(strictSubmitted);
+
+                Set<String> strictCandidates = new HashSet<>();
+                Set<String> relaxedCandidates = new HashSet<>();
+
+                for (CsQuestionShortAnswer acceptableAnswer : acceptableAnswers) {
+                    addCandidateNormalization(strictCandidates, relaxedCandidates, acceptableAnswer.getNormalizedAnswer());
+                    addCandidateNormalization(strictCandidates, relaxedCandidates, acceptableAnswer.getAnswerText());
+                }
+
+                boolean isCorrect = strictCandidates.contains(strictSubmitted)
+                        || (!relaxedSubmitted.isBlank() && relaxedCandidates.contains(relaxedSubmitted));
+
+                yield new GradingResult(
+                        isCorrect,
+                        null,
+                        isCorrect ? null : resolvePrimaryShortAnswer(acceptableAnswers),
+                        question.getExplanation());
+            }
+            case ESSAY -> {
+                String answerText = request.answerText();
+                if (answerText == null || answerText.isBlank()) {
+                    throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "서술형/단답형은 answerText가 필요합니다.");
+                }
+
                 // #143 단계: 목 채점 정책("정답" 포함 텍스트를 정답으로 가정)
                 yield new GradingResult(
                         answerText.trim().contains("정답"),
@@ -479,6 +519,56 @@ public class CsAttemptService {
         }
 
         return feedback.isEmpty() ? "오답입니다." : feedback.toString();
+    }
+
+    private void addCandidateNormalization(Set<String> strictCandidates, Set<String> relaxedCandidates, String candidate) {
+        String strictCandidate = normalizeStrict(candidate);
+        if (strictCandidate.isBlank()) {
+            return;
+        }
+
+        strictCandidates.add(strictCandidate);
+
+        String relaxedCandidate = normalizeRelaxed(strictCandidate);
+        if (!relaxedCandidate.isBlank()) {
+            relaxedCandidates.add(relaxedCandidate);
+        }
+    }
+
+    private String resolvePrimaryShortAnswer(List<CsQuestionShortAnswer> answers) {
+        return answers.stream()
+                .sorted(Comparator
+                        .comparing((CsQuestionShortAnswer answer) -> !Boolean.TRUE.equals(answer.getIsPrimary()))
+                        .thenComparing(CsQuestionShortAnswer::getId))
+                .map(this::resolveDisplayAnswerText)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String resolveDisplayAnswerText(CsQuestionShortAnswer answer) {
+        if (answer.getAnswerText() != null && !answer.getAnswerText().isBlank()) {
+            return answer.getAnswerText().trim();
+        }
+        if (answer.getNormalizedAnswer() != null && !answer.getNormalizedAnswer().isBlank()) {
+            return answer.getNormalizedAnswer().trim();
+        }
+        return null;
+    }
+
+    private String normalizeStrict(String input) {
+        if (input == null) {
+            return "";
+        }
+        return input.strip()
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("\\s+", "");
+    }
+
+    private String normalizeRelaxed(String input) {
+        if (input == null || input.isBlank()) {
+            return "";
+        }
+        return input.replaceAll("[^\\p{L}\\p{N}]", "");
     }
 
     private record StreakResult(boolean earnedToday, int currentStreak) {

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
@@ -8,6 +8,7 @@ import com.peekle.domain.cs.entity.CsDomain;
 import com.peekle.domain.cs.entity.CsDomainTrack;
 import com.peekle.domain.cs.entity.CsQuestion;
 import com.peekle.domain.cs.entity.CsQuestionChoice;
+import com.peekle.domain.cs.entity.CsQuestionShortAnswer;
 import com.peekle.domain.cs.entity.CsStage;
 import com.peekle.domain.cs.entity.CsWrongProblem;
 import com.peekle.domain.cs.enums.CsAttemptPhase;
@@ -17,11 +18,14 @@ import com.peekle.domain.cs.repository.CsDomainRepository;
 import com.peekle.domain.cs.repository.CsDomainTrackRepository;
 import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
 import com.peekle.domain.cs.repository.CsQuestionRepository;
+import com.peekle.domain.cs.repository.CsQuestionShortAnswerRepository;
 import com.peekle.domain.cs.repository.CsStageRepository;
 import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
 import com.peekle.domain.cs.repository.CsWrongProblemRepository;
 import com.peekle.domain.user.entity.User;
 import com.peekle.domain.user.repository.UserRepository;
+import com.peekle.global.exception.BusinessException;
+import com.peekle.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -59,6 +64,9 @@ class CsAttemptFlowIntegrationTest {
 
     @Autowired
     private CsQuestionChoiceRepository csQuestionChoiceRepository;
+
+    @Autowired
+    private CsQuestionShortAnswerRepository csQuestionShortAnswerRepository;
 
     @Autowired
     private CsWrongProblemRepository csWrongProblemRepository;
@@ -196,6 +204,102 @@ class CsAttemptFlowIntegrationTest {
         assertThat(response.feedback()).contains("해설: 정답은 2번입니다.");
     }
 
+    @Test
+    @DisplayName("단답형 채점은 공백/대소문자/특수문자 정규화 정책을 적용한다")
+    void shortAnswer_grading_appliesNormalizationPolicy() {
+        User user = createUser("short-normalize");
+        CsDomain domain = createDomain(404, "단답형 정규화 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "단답형 정규화 트랙");
+        CsStage stage = createStage(track, 1);
+
+        CsQuestion firstQuestion = createShortAnswerQuestion(stage, "중복 제거 키워드를 작성하시오.");
+        addShortAnswer(firstQuestion, "DISTINCT", "distinct", true);
+
+        CsQuestion secondQuestion = createShortAnswerQuestion(stage, "깊은 복사 코드를 작성하시오.");
+        addShortAnswer(secondQuestion, "copy.deepcopy(a)", "copy.deepcopy(a)", true);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+        csAttemptService.startStageAttempt(user.getId(), stage.getId());
+
+        CsAttemptAnswerResponse firstAnswer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(firstQuestion.getId(), null, "   diST inCt   "));
+        assertThat(firstAnswer.isCorrect()).isTrue();
+        assertThat(firstAnswer.phase()).isEqualTo(CsAttemptPhase.FIRST_PASS);
+
+        CsAttemptAnswerResponse secondAnswer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(secondQuestion.getId(), null, "COPY DEEPCOPY A"));
+        assertThat(secondAnswer.isCorrect()).isTrue();
+        assertThat(secondAnswer.phase()).isEqualTo(CsAttemptPhase.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("단답형 오답 제출 시 대표 정답을 반환하고 완료 시 오답노트에 저장된다")
+    void shortAnswer_wrongAnswer_returnsPrimaryAnswerAndPersistsWrongProblem() {
+        User user = createUser("short-wrong");
+        CsDomain domain = createDomain(405, "단답형 오답 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "단답형 오답 트랙");
+        CsStage stage = createStage(track, 1);
+
+        CsQuestion question = createShortAnswerQuestion(stage, "트랜잭션 4대 성질 약어를 작성하시오.");
+        addShortAnswer(question, "ACID", "acid", true);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+        csAttemptService.startStageAttempt(user.getId(), stage.getId());
+
+        CsAttemptAnswerResponse firstAnswer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(question.getId(), null, "BASE"));
+        assertThat(firstAnswer.isCorrect()).isFalse();
+        assertThat(firstAnswer.correctAnswer()).isEqualTo("ACID");
+        assertThat(firstAnswer.feedback()).contains("정답: ACID");
+        assertThat(firstAnswer.phase()).isEqualTo(CsAttemptPhase.RETRY_WRONG);
+
+        CsAttemptAnswerResponse retryAnswer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(question.getId(), null, "acid"));
+        assertThat(retryAnswer.isCorrect()).isTrue();
+        assertThat(retryAnswer.phase()).isEqualTo(CsAttemptPhase.COMPLETED);
+
+        csAttemptService.completeAttempt(user.getId(), stage.getId());
+
+        CsWrongProblem wrongProblem = csWrongProblemRepository
+                .findByUser_IdAndQuestion_Id(user.getId(), question.getId())
+                .orElseThrow();
+        assertThat(wrongProblem.getWrongCount()).isEqualTo(1);
+        assertThat(wrongProblem.getStatus()).isEqualTo(CsWrongProblemStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("단답형 빈값 또는 공백만 입력은 CS_INVALID_ANSWER_PAYLOAD를 반환한다")
+    void shortAnswer_blankInput_throwsInvalidPayload() {
+        User user = createUser("short-blank");
+        CsDomain domain = createDomain(406, "단답형 빈값 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "단답형 빈값 트랙");
+        CsStage stage = createStage(track, 1);
+
+        CsQuestion question = createShortAnswerQuestion(stage, "정답을 입력하시오.");
+        addShortAnswer(question, "JSON", "json", true);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+        csAttemptService.startStageAttempt(user.getId(), stage.getId());
+
+        assertThatThrownBy(() -> csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(question.getId(), null, "   ")))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.CS_INVALID_ANSWER_PAYLOAD);
+                });
+    }
+
     private User createUser(String suffix) {
         return userRepository.save(User.builder()
                 .socialId("social-" + suffix)
@@ -252,5 +356,24 @@ class CsAttemptFlowIntegrationTest {
                 .build());
 
         return question;
+    }
+
+    private CsQuestion createShortAnswerQuestion(CsStage stage, String prompt) {
+        return csQuestionRepository.save(CsQuestion.builder()
+                .stage(stage)
+                .questionType(CsQuestionType.SHORT_ANSWER)
+                .prompt(prompt)
+                .explanation("단답형 테스트 해설")
+                .isActive(true)
+                .build());
+    }
+
+    private void addShortAnswer(CsQuestion question, String answerText, String normalizedAnswer, boolean isPrimary) {
+        csQuestionShortAnswerRepository.save(CsQuestionShortAnswer.builder()
+                .question(question)
+                .answerText(answerText)
+                .normalizedAnswer(normalizedAnswer)
+                .isPrimary(isPrimary)
+                .build());
     }
 }

--- a/apps/frontend/src/domains/cs/components/session/CSQuestionPresenter.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSQuestionPresenter.tsx
@@ -57,6 +57,10 @@ export default function CSQuestionPresenter({ question, onSubmit, isSubmitting }
   };
 
   const typeLabel = QUESTION_TYPE_LABEL[question.questionType] || question.questionType;
+  const isChoiceQuestion = question.questionType === 'MULTIPLE_CHOICE' || question.questionType === 'OX';
+  const hasTextAnswer = answerText.trim().length > 0;
+  const isAnswerReady = isChoiceQuestion ? selectedChoiceNo !== null : hasTextAnswer;
+  const isSubmitDisabled = isSubmitting || !isAnswerReady;
 
   return (
     <Card className="w-full max-w-2xl mx-auto p-6 md:p-8 flex flex-col gap-6 animate-in fade-in zoom-in-95 duration-300">
@@ -107,8 +111,8 @@ export default function CSQuestionPresenter({ question, onSubmit, isSubmitting }
         <div className="w-full max-w-2xl px-2">
           <Button
             onClick={handleSubmit}
-            disabled={isSubmitting}
-            className="w-full font-bold text-lg h-14 rounded-xl shadow-lg"
+            disabled={isSubmitDisabled}
+            className="w-full font-bold text-lg h-14 rounded-xl shadow-lg disabled:bg-gray-300 disabled:text-gray-500 disabled:opacity-100 disabled:shadow-none"
             variant="default"
           >
             {isSubmitting ? '채점 중...' : '제출하기'}


### PR DESCRIPTION
## 💡 의도 / 배경
CS 학습 탭에서 단답형(SHORT_ANSWER) 채점이 목 로직이라 실제 학습 경험이 떨어지고, 빈 입력 제출 UX도 부족해서 #145 요구사항(정규화 채점/오답 연동/입력 검증)을 반영했습니다.

## 🛠️ 작업 내용
- [x] 백엔드 단답형 채점 로직 구현
- [x] 단답형 정규화 정책 적용(공백/대소문자/특수문자 완화 비교)
- [x] 단답형 오답 시 대표 정답(primary) 피드백 반환
- [x] 오답노트 저장 연동 유지 및 통합 테스트 추가
- [x] 프론트 제출 버튼 UX 개선(선택지 미선택/주관식 빈값 시 비활성화 + 회색 스타일)

## 🔗 관련 이슈
- Closes #145
- Relates #139 
## 🖼️ 스크린샷 (선택)
<img width="1174" height="1265" alt="image" src="https://github.com/user-attachments/assets/6c1cec70-e356-4010-be9b-e17dfc9f79ea" />
<img width="764" height="591" alt="image" src="https://github.com/user-attachments/assets/0fb6797f-33ea-4aee-b43e-c07bec8b7be3" />


## 🧪 테스트 방법
- [x] `cd apps/backend && ./gradlew.bat test --tests com.peekle.domain.cs.service.CsAttemptFlowIntegrationTest`
- [x] `cd apps/backend && ./gradlew.bat test --tests com.peekle.domain.cs.service.*`
- [x] `pnpm --filter frontend exec tsc --noEmit`

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- 이번 검증은 CS 도메인 관련 백엔드 테스트 + 프론트 타입체크 중심으로 진행했습니다.