### PR TITLE
feat: CS 결과 화면 분리 및 새로고침 안전 라우팅 적용

### DIFF
--- a/apps/frontend/src/app/(main)/cs/stage/[stageId]/result/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/stage/[stageId]/result/page.tsx
@@ -1,0 +1,21 @@
+import CSStageResultPageClient from '@/domains/cs/components/session/CSStageResultPageClient';
+
+interface CSStageResultPageProps {
+  params: Promise<{ stageId: string }>;
+}
+
+export default async function CSStageResultPage({ params }: CSStageResultPageProps) {
+  const { stageId: rawStageId } = await params;
+  const stageId = parseInt(rawStageId, 10);
+
+  if (Number.isNaN(stageId)) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center">
+        <p className="font-bold text-destructive">잘못된 스테이지 ID입니다.</p>
+      </div>
+    );
+  }
+
+  return <CSStageResultPageClient stageId={stageId} />;
+}
+

--- a/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
@@ -10,13 +10,12 @@ import {
   answerCSStageQuestion,
   completeCSStageAttempt,
   CSQuestionPayload,
-  CSAttemptCompleteResponse,
   CSAttemptAnswerRequest,
   CSAttemptAnswerResponse,
 } from '@/domains/cs/api/csApi';
 
 import CSQuestionPresenter from './CSQuestionPresenter';
-import CSResultScreen from './CSResultScreen';
+import { getCSStageResultStorageKey } from '@/domains/cs/utils/stageResultStorage';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,7 +32,7 @@ interface CSLearningSessionProps {
   stageId: number;
 }
 
-type Phase = 'loading' | 'playing' | 'submitting_complete' | 'result' | 'error';
+type Phase = 'loading' | 'playing' | 'submitting_complete' | 'error';
 
 interface WrongFeedbackContent {
   answer: string | null;
@@ -91,7 +90,6 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
   const [currentQuestion, setCurrentQuestion] = useState<CSQuestionPayload | null>(null);
   const [totalQuestionCount, setTotalQuestionCount] = useState(0);
   const [solvedQuestionIds, setSolvedQuestionIds] = useState<number[]>([]);
-  const [resultData, setResultData] = useState<CSAttemptCompleteResponse | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showExitAlert, setShowExitAlert] = useState(false);
   const [answerResult, setAnswerResult] = useState<CSAttemptAnswerResponse | null>(null);
@@ -126,8 +124,10 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
     try {
       setPhase('submitting_complete');
       const res = await completeCSStageAttempt(stageId);
-      setResultData(res);
-      setPhase('result');
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem(getCSStageResultStorageKey(stageId), JSON.stringify(res));
+      }
+      router.replace(`/cs/stage/${stageId}/result`);
     } catch (err) {
       console.error(err);
       toast.error('스테이지 결과를 불러오는 데 실패했습니다.');
@@ -205,10 +205,6 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
         <p className="text-muted-foreground font-medium animate-pulse">결과를 집계하고 있습니다...</p>
       </div>
     );
-  }
-
-  if (phase === 'result' && resultData) {
-    return <CSResultScreen result={resultData} />;
   }
 
   return (

--- a/apps/frontend/src/domains/cs/components/session/CSStageResultPageClient.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSStageResultPageClient.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+
+import { CSAttemptCompleteResponse } from '@/domains/cs/api/csApi';
+import { getCSStageResultStorageKey } from '@/domains/cs/utils/stageResultStorage';
+import CSResultScreen from './CSResultScreen';
+
+interface CSStageResultPageClientProps {
+  stageId: number;
+}
+
+export default function CSStageResultPageClient({ stageId }: CSStageResultPageClientProps) {
+  const router = useRouter();
+  const [result, setResult] = useState<CSAttemptCompleteResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const key = getCSStageResultStorageKey(stageId);
+    const raw = sessionStorage.getItem(key);
+
+    if (!raw) {
+      router.replace('/cs');
+      return;
+    }
+
+    sessionStorage.removeItem(key);
+
+    try {
+      const parsed = JSON.parse(raw) as CSAttemptCompleteResponse;
+      setResult(parsed);
+      setIsLoading(false);
+    } catch (error) {
+      console.error('Failed to parse CS stage result:', error);
+      router.replace('/cs');
+    }
+  }, [router, stageId]);
+
+  if (isLoading || !result) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4">
+        <Loader2 className="h-10 w-10 animate-spin text-primary" />
+        <p className="font-medium text-muted-foreground">결과 화면을 준비하고 있습니다...</p>
+      </div>
+    );
+  }
+
+  return <CSResultScreen result={result} />;
+}

--- a/apps/frontend/src/domains/cs/utils/stageResultStorage.ts
+++ b/apps/frontend/src/domains/cs/utils/stageResultStorage.ts
@@ -1,0 +1,4 @@
+export function getCSStageResultStorageKey(stageId: number): string {
+  return `cs:stage-result:${stageId}`;
+}
+


### PR DESCRIPTION
## 💡 의도 / 배경
CS 스테이지 완료 후 결과 화면이 세션 상태에만 의존해, 새로고침 시 다시 문제 풀이 화면으로 돌아가는 UX 이슈가 있었습니다.  
결과 화면을 라우트로 분리해 학습 종료 흐름을 명확히 하고, 상태 유실 시 안전하게 CS 탭으로 복귀하도록 개선했습니다.

## 🛠️ 작업 내용
- [x] 스테이지 결과 전용 라우트 추가: `/cs/stage/[stageId]/result`
- [x] 완료 시점에 결과 데이터를 `sessionStorage`에 임시 저장 후 결과 라우트로 이동
- [x] 결과 라우트에서 데이터 1회 소비 후 제거(새로고침/직접 진입 시 재사용 방지)
- [x] 결과 데이터가 없거나 파싱 실패 시 `/cs`로 안전 라우팅
- [x] 기존 결과 화면(`CSResultScreen`)은 유지하고 라우팅 흐름만 분리
- [x] 모바일 결과 화면 풀스크린/상단 그라데이션 표현 조정

## 🔗 관련 이슈
- Closes #147
- Relates #139 

## 🖼️ 스크린샷 (선택)
- 모바일 스테이지 완료 화면(풀스크린 + 상단 그라데이션)
- 결과 라우트 직접 진입/새로고침 시 `/cs` 복귀 동작

## 🧪 테스트 방법
- [x] 타입 체크
  - `pnpm -C apps/frontend exec tsc --noEmit`
- [x] 수동 시나리오 확인
  1. 스테이지 완료 후 결과 화면으로 이동되는지 확인 (`/cs/stage/{id}/result`)
  2. 결과 화면에서 새로고침 시 `/cs`로 이동되는지 확인
  3. 결과 URL 직접 접근 시 `/cs`로 이동되는지 확인
  4. CTA 동작 확인
     - `다음 스테이지 풀기` → 다음 스테이지 진입
     - `목록으로 돌아가기` → `/cs` 이동

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
결과 데이터는 서버 영속 저장 대신 클라이언트 `sessionStorage` 1회 소비 방식으로 처리했습니다.  
의도적으로 결과 페이지는 “재방문 불가(새로고침 시 CS 복귀)” 정책입니다.