### PR TITLE
feat: CS 스터디 시 스트릭 및 점수가 쌓이게 변경

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptCompleteResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAttemptCompleteResponse.java
@@ -9,5 +9,7 @@ public record CsAttemptCompleteResponse(
         String messageCode,
         Boolean streakEarnedToday,
         Integer currentStreak,
+        Integer earnedScore,
+        Integer totalScore,
         Long nextStageId) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
@@ -187,6 +187,7 @@ public class CsAttemptService {
         int correctRate = totalQuestionCount == 0
                 ? 0
                 : (int) Math.round((correctCount * 100.0) / totalQuestionCount);
+        int earnedScore = correctCount;
 
         persistWrongProblems(user, session);
 
@@ -195,6 +196,10 @@ public class CsAttemptService {
 
         updateDomainProgressIfNeeded(userId, stage, nextStageId);
         StreakResult streak = applyStreak(user);
+        if (earnedScore > 0) {
+            user.addLeaguePoint(earnedScore);
+        }
+        int totalScore = safeInt(user.getLeaguePoint());
 
         csAttemptStore.delete(userId, stageId);
 
@@ -207,6 +212,8 @@ public class CsAttemptService {
                 resolveMessageCode(correctRate),
                 streak.earnedToday(),
                 streak.currentStreak(),
+                earnedScore,
+                totalScore,
                 nextStageId);
     }
 

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
@@ -124,11 +124,16 @@ class CsAttemptFlowIntegrationTest {
         assertThat(completeResponse.correctCount()).isEqualTo(1);
         assertThat(completeResponse.wrongCount()).isEqualTo(1);
         assertThat(completeResponse.correctRate()).isEqualTo(50);
+        assertThat(completeResponse.earnedScore()).isEqualTo(1);
+        assertThat(completeResponse.totalScore()).isEqualTo(1);
 
         CsWrongProblem wrongProblem = csWrongProblemRepository.findByUser_IdAndQuestion_Id(user.getId(), firstQuestion.getId())
                 .orElseThrow();
         assertThat(wrongProblem.getStatus()).isEqualTo(CsWrongProblemStatus.ACTIVE);
         assertThat(wrongProblem.getWrongCount()).isEqualTo(2);
+        assertThat(userRepository.findById(user.getId()))
+                .get()
+                .satisfies(savedUser -> assertThat(savedUser.getLeaguePoint()).isEqualTo(1));
     }
 
     @Test
@@ -154,6 +159,8 @@ class CsAttemptFlowIntegrationTest {
         CsAttemptCompleteResponse completeResponse = csAttemptService.completeAttempt(user.getId(), stage1.getId());
         assertThat(completeResponse.isTrackCompleted()).isFalse();
         assertThat(completeResponse.nextStageId()).isEqualTo(stage2.getId());
+        assertThat(completeResponse.earnedScore()).isEqualTo(1);
+        assertThat(completeResponse.totalScore()).isEqualTo(1);
 
         assertThat(csUserDomainProgressRepository.findByUser_IdAndDomain_Id(user.getId(), domain.getId()))
                 .get()

--- a/apps/frontend/src/domains/cs/api/csApi.ts
+++ b/apps/frontend/src/domains/cs/api/csApi.ts
@@ -101,6 +101,8 @@ export interface CSAttemptCompleteResponse {
   messageCode: string;
   streakEarnedToday: boolean;
   currentStreak: number;
+  earnedScore: number;
+  totalScore: number;
   nextStageId: number | null;
 }
 

--- a/apps/frontend/src/domains/cs/components/session/CSResultScreen.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSResultScreen.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { CSAttemptCompleteResponse } from '@/domains/cs/api/csApi';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { Trophy, Flame, CheckCircle, ArrowRight, RotateCcw } from 'lucide-react';
+import { Trophy, Flame, CheckCircle, ArrowRight, RotateCcw, Coins } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 interface CSResultScreenProps {
@@ -50,6 +50,17 @@ export default function CSResultScreen({ result }: CSResultScreenProps) {
               <span className="font-bold">오늘 스트릭 획득! (진행 중: {result.currentStreak}일)</span>
             </div>
           )}
+
+          <div className="w-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 rounded-2xl p-4 flex items-center justify-between gap-3 mb-8">
+            <div className="flex items-center gap-2">
+              <Coins className="w-5 h-5" />
+              <span className="font-bold">이번 세션 점수</span>
+            </div>
+            <div className="text-right">
+              <div className="font-extrabold text-lg">+{result.earnedScore}점</div>
+              <div className="text-xs text-emerald-700/80">누적 {result.totalScore}점</div>
+            </div>
+          </div>
 
           <div className="flex flex-col w-full gap-3">
             {result.isTrackCompleted ? (

--- a/docs/spec/cs-learning-api.md
+++ b/docs/spec/cs-learning-api.md
@@ -389,7 +389,7 @@ Base: `/api/cs`
 - 최종 결과 생성
 - 틀린 문제를 `cs_wrong_problems`에 반영
 - 진행도 갱신 후 Redis 키 삭제
-- 결과창은 "정답률 + 조건부 스트릭 + 랜덤 문구" 중심으로 단순 노출
+- 결과창은 "정답률 + 조건부 스트릭 + 점수 + 랜덤 문구" 중심으로 단순 노출
 
 결과창 표시 규칙:
 
@@ -400,6 +400,11 @@ Base: `/api/cs`
   - `streakEarnedToday=true`일 때만 "오늘 스트릭 +1" 강조 UI 노출
   - `streakEarnedToday=false`이면 스트릭 관련 문구/UI 미노출
   - 스트릭 증감/중복 판정은 서버 권한이며 KST(Asia/Seoul) 06:00 경계 기준
+- 점수:
+  - 세션 완료 시 `FIRST_PASS`에서 맞춘 문제 1개당 `+1점` 적립
+  - 오답 재시도(`RETRY_WRONG`)로 맞춘 문제는 점수 미적립
+  - 같은 문제는 세션 내 최대 1점만 적립
+  - 결과창에 `earnedScore`(이번 세션 획득)와 `totalScore`(적립 후 누적)를 함께 표시
 - 틀린 문제 개별 목록은 결과창에서 미노출(오답노트 화면에서만 조회)
 - CTA:
   - `isTrackCompleted=false`: `다음 스테이지 풀기` + `CS 탭으로 돌아가기`
@@ -422,6 +427,8 @@ Base: `/api/cs`
     "messageCode": "CS_RESULT_GOOD",
     "streakEarnedToday": true,
     "currentStreak": 5,
+    "earnedScore": 7,
+    "totalScore": 128,
     "nextStageId": 13
   }
 }
@@ -441,6 +448,8 @@ Base: `/api/cs`
     "messageCode": "CS_RESULT_EXCELLENT",
     "streakEarnedToday": false,
     "currentStreak": 5,
+    "earnedScore": 8,
+    "totalScore": 136,
     "nextStageId": null
   }
 }


### PR DESCRIPTION
## 💡 의도 / 배경
CS 스테이지 완료 시 기존에는 스트릭만 반영되고 점수 보상이 없어 학습 보상 체감이 약했습니다.  
이번 변경으로 `하루 1회 스트릭 적립` 규칙을 유지하면서, `첫 시도 정답 수 기반 점수 적립`을 추가해 결과 화면과 프로필 점수에 즉시 반영되도록 했습니다.

## 🛠️ 작업 내용
- [x] CS 완료 API 응답 확장: `earnedScore`, `totalScore` 필드 추가
- [x] 점수 적립 로직 추가: `FIRST_PASS` 정답 1문제당 +1점 (`RETRY_WRONG` 정답은 미적립)
- [x] 결과 화면 UI 반영: 이번 세션 획득 점수/누적 점수 표시
- [x] 통합 테스트 보강: 점수 적립값 및 유저 누적 점수(`leaguePoint`) 검증 추가
- [x] CS API 스펙 문서 업데이트 (`docs/spec/cs-learning-api.md`)

## 🔗 관련 이슈
- Closes #148
- Related #139
- Related #141
- Related #147

## 🖼️ 스크린샷 (선택)
<img width="517" height="541" alt="image" src="https://github.com/user-attachments/assets/d4b3f27b-4406-40f1-a743-0105fe7abf54" />


## 🧪 테스트 방법
- [x] 백엔드 통합 테스트 실행  
  `.\gradlew test --tests "com.peekle.domain.cs.service.CsAttemptFlowIntegrationTest"` (in `apps/backend`)
- [x] 프론트 타입 체크 실행  
  `pnpm --filter frontend type-check`
- [ ] 프론트 전체 lint 통과 (`pnpm --filter frontend lint`)  
  저장소 내 기존 전역 lint/prettier 이슈로 실패(이번 변경 범위 외 다수 파일)

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
이번 PR은 CS 완료 흐름의 점수 반영/표시를 최소 범위로 연결한 변경입니다.  