### PR TITLE
feat: CS 스터디 상단 바 및 도메인 추가 구현

### DIFF
--- a/apps/frontend/src/app/(main)/cs/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/page.tsx
@@ -1,20 +1,33 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Loader2 } from 'lucide-react';
 import { fetchCSBootstrap, CSBootstrapResponse } from '@/domains/cs/api/csApi';
 import DomainSelection from '@/domains/cs/components/DomainSelection';
 import LearningMap from '@/domains/cs/components/LearningMap';
+import CSTopBar from '@/domains/cs/components/CSTopBar';
 import { toast } from 'sonner';
 
 export default function CSPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [bootstrapData, setBootstrapData] = useState<CSBootstrapResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const forceSelection = searchParams.get('mode') === 'add';
+
+  const setAddMode = (isAddMode: boolean) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (isAddMode) params.set('mode', 'add');
+    else params.delete('mode');
+    const query = params.toString();
+    router.replace(query ? `/cs?${query}` : '/cs', { scroll: false });
+  };
 
   const loadBootstrap = async () => {
     try {
       setLoading(true);
-      console.log('[DEBUG] Fetching CS Bootstrap data...');
+      console.log('[DEBUG] CSPage: fetchCSBootstrap 호출');
       const data = await fetchCSBootstrap();
       setBootstrapData(data);
     } catch (error) {
@@ -38,22 +51,50 @@ export default function CSPage() {
     );
   }
 
-  // API spec #141 says needsDomainSelection, or currentDomain will be null.
-  const needsSelection = bootstrapData?.needsDomainSelection ?? !bootstrapData?.currentDomain;
+  // API spec #141: needsDomainSelection이 true거나 currentDomain이 없으면 선택 화면
+  const needsSelection = forceSelection || (bootstrapData?.needsDomainSelection ?? !bootstrapData?.currentDomain);
 
   if (needsSelection) {
-    return <DomainSelection onSuccess={loadBootstrap} />;
+    return (
+      <DomainSelection
+        isAddMode={forceSelection}
+        onCancel={() => {
+          console.log('[DEBUG] CSPage: 도메인 추가 취소 → 맵 화면 복귀');
+          setAddMode(false);
+        }}
+        onSuccess={() => {
+          console.log('[DEBUG] CSPage: DomainSelection 완료 → bootstrap 재로드');
+          setAddMode(false);
+          loadBootstrap();
+        }}
+      />
+    );
   }
 
   return (
     <div className="flex flex-col animate-in fade-in duration-500">
+      {/* ── 상단바 ── */}
+      {bootstrapData?.currentDomain && (
+        <CSTopBar
+          currentDomain={bootstrapData.currentDomain}
+          onDomainChanged={() => {
+            console.log('[DEBUG] CSPage: 도메인 변경 완료 → bootstrap 재로드');
+            loadBootstrap();
+          }}
+          onRequestAddDomain={() => {
+            console.log('[DEBUG] CSPage: 도메인 추가 요청 → DomainSelection 표시');
+            setAddMode(true);
+          }}
+          onRequestWrongNote={() => {
+            console.log('[DEBUG] CSPage: 오답 보기 요청 → 오답노트 페이지 이동');
+            router.push('/cs/wrong-problems');
+          }}
+        />
+      )}
+
       <div className="bg-card rounded-2xl p-8 shadow-sm">
-        <h1 className="text-2xl font-bold mb-2">CS 학습</h1>
-        <p className="text-muted-foreground mb-6">
-          선택한 도메인: <span className="font-semibold text-primary">{bootstrapData?.currentDomain?.name}</span>
-        </p>
         {bootstrapData?.progress ? (
-          <div className="mt-4 pt-4 w-full flex flex-col items-center">
+          <div className="w-full flex flex-col items-center">
             <LearningMap progress={bootstrapData.progress} stages={bootstrapData.stages ?? []} />
           </div>
         ) : (

--- a/apps/frontend/src/app/(main)/cs/wrong-problems/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/wrong-problems/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft, NotebookPen } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function CSWrongProblemsPage() {
+  return (
+    <div className="w-full py-6 sm:py-8">
+      <div className="mx-auto w-full max-w-3xl rounded-2xl border border-border/60 bg-card p-6 sm:p-8 shadow-sm">
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-xl sm:text-2xl font-bold text-foreground flex items-center gap-2">
+            <NotebookPen className="h-5 w-5 text-primary" />
+            오답노트
+          </h1>
+          <Button asChild variant="outline" size="sm" className="gap-1.5">
+            <Link href="/cs">
+              <ArrowLeft className="h-4 w-4" />
+              CS 학습으로
+            </Link>
+          </Button>
+        </div>
+
+        <div className="rounded-xl border border-dashed border-border bg-background/60 px-4 py-8 text-center">
+          <p className="text-sm sm:text-base text-muted-foreground">
+            오답노트 목록은 다음 작업(#149)에서 연결됩니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/domains/cs/components/CSTopBar.tsx
+++ b/apps/frontend/src/domains/cs/components/CSTopBar.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { ChevronDown, Plus, Loader2, CheckCircle2, BookOpen, NotebookPen } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  CSDomain,
+  CSMyDomainItem,
+  fetchMyCSDomains,
+  changeCurrentCSDomain,
+} from '@/domains/cs/api/csApi';
+
+interface CSTopBarProps {
+  /** 현재 활성 도메인 */
+  currentDomain: CSDomain;
+  /** 도메인이 변경된 후 부모가 데이터를 새로 불러오기 위한 콜백 */
+  onDomainChanged: () => void;
+  /** 도메인 추가 화면으로 이동 요청 시 콜백 */
+  onRequestAddDomain: () => void;
+  /** 오답노트 화면으로 이동 요청 시 콜백 */
+  onRequestWrongNote: () => void;
+}
+
+export default function CSTopBar({
+  currentDomain,
+  onDomainChanged,
+  onRequestAddDomain,
+  onRequestWrongNote,
+}: CSTopBarProps) {
+  const [open, setOpen] = useState(false);
+  const [myDomains, setMyDomains] = useState<CSMyDomainItem[]>([]);
+  const [loadingDomains, setLoadingDomains] = useState(false);
+  const [changingId, setChangingId] = useState<number | null>(null);
+
+  /* ------------------------------------------------------------------ */
+  /* 내 도메인 목록 로드 (Popover 열릴 때)                                 */
+  /* ------------------------------------------------------------------ */
+  const loadMyDomains = useCallback(async () => {
+    setLoadingDomains(true);
+    try {
+      console.log('[DEBUG] CSTopBar: fetchMyCSDomains 호출');
+      const data = await fetchMyCSDomains();
+      setMyDomains(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error('[DEBUG] CSTopBar: fetchMyCSDomains 실패', err);
+      toast.error('도메인 목록을 불러오지 못했습니다.');
+      setMyDomains([]);
+    } finally {
+      setLoadingDomains(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      loadMyDomains();
+    }
+  }, [open, loadMyDomains]);
+
+  /* ------------------------------------------------------------------ */
+  /* 도메인 변경                                                           */
+  /* ------------------------------------------------------------------ */
+  const handleChangeDomain = async (item: CSMyDomainItem) => {
+    if (item.domain.id === currentDomain.id) {
+      setOpen(false);
+      return;
+    }
+
+    setChangingId(item.domain.id);
+    try {
+      console.log(`[DEBUG] CSTopBar: changeCurrentCSDomain(${item.domain.id}) 호출`);
+      await changeCurrentCSDomain(item.domain.id);
+      toast.success(`도메인이 "${item.domain.name}"(으)로 변경되었습니다.`);
+      setOpen(false);
+      onDomainChanged();
+    } catch (err) {
+      console.error('[DEBUG] CSTopBar: changeCurrentCSDomain 실패', err);
+      toast.error('도메인 변경에 실패했습니다.');
+    } finally {
+      setChangingId(null);
+    }
+  };
+
+  /* ------------------------------------------------------------------ */
+  /* 오답 보기                                                           */
+  /* ------------------------------------------------------------------ */
+  const handleWrongNote = () => {
+    console.log('[DEBUG] CSTopBar: 오답 보기 버튼 클릭');
+    onRequestWrongNote();
+  };
+
+  /* ------------------------------------------------------------------ */
+  /* 렌더                                                                 */
+  /* ------------------------------------------------------------------ */
+  return (
+    <header className="w-full flex items-center justify-between px-4 py-3 bg-background/80 backdrop-blur-md border-b border-border/50 sticky top-0 z-40">
+      {/* ── 좌측: 현재 도메인 + 변경 Popover ── */}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            id="cs-topbar-domain-trigger"
+            className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-primary/10 hover:bg-primary/20 transition-colors group"
+          >
+            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary text-primary-foreground">
+              <BookOpen className="w-3 h-3" />
+            </span>
+            <span className="text-sm font-semibold text-primary leading-none">
+              {currentDomain.name}
+            </span>
+            <ChevronDown
+              className={`w-4 h-4 text-primary/70 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+            />
+          </button>
+        </PopoverTrigger>
+
+        <PopoverContent
+          align="start"
+          sideOffset={8}
+          className="w-64 p-2 rounded-2xl shadow-xl border border-border/60"
+        >
+          {/* 타이틀 */}
+          <p className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            내 도메인
+          </p>
+
+          {/* 목록 */}
+          {loadingDomains ? (
+            <div className="flex items-center justify-center py-6">
+              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : myDomains.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              등록된 도메인이 없습니다.
+            </p>
+          ) : (
+            <ul className="space-y-0.5">
+              {myDomains.map((item) => {
+                const isActive = item.domain.id === currentDomain.id;
+                const isChanging = changingId === item.domain.id;
+
+                return (
+                  <li key={item.domain.id}>
+                    <button
+                      id={`cs-topbar-domain-item-${item.domain.id}`}
+                      onClick={() => handleChangeDomain(item)}
+                      disabled={!!changingId}
+                      className={`
+                        w-full flex items-center justify-between gap-2 px-3 py-2.5 rounded-xl text-sm text-left
+                        transition-colors duration-150
+                        ${isActive
+                          ? 'bg-primary/10 text-primary font-semibold'
+                          : 'hover:bg-muted text-foreground'
+                        }
+                        disabled:opacity-60 disabled:cursor-not-allowed
+                      `}
+                    >
+                      <span className="truncate">{item.domain.name}</span>
+
+                      {isChanging ? (
+                        <Loader2 className="w-4 h-4 animate-spin shrink-0 text-primary" />
+                      ) : isActive ? (
+                        <CheckCircle2 className="w-4 h-4 shrink-0 text-primary" />
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {/* 구분선 + 도메인 추가 버튼 */}
+          <div className="mt-1.5 pt-1.5 border-t border-border/50">
+            <button
+              id="cs-topbar-add-domain"
+              onClick={() => {
+                console.log('[DEBUG] CSTopBar: 도메인 추가 버튼 클릭');
+                setOpen(false);
+                onRequestAddDomain();
+              }}
+              className="w-full flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            >
+              <Plus className="w-4 h-4 shrink-0" />
+              도메인 추가
+            </button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* ── 우측: 오답 보기 버튼 ── */}
+      <Button
+        id="cs-topbar-wrong-note"
+        variant="outline"
+        size="sm"
+        onClick={handleWrongNote}
+        className="gap-1.5 rounded-full border-border/60 text-muted-foreground"
+      >
+        <NotebookPen className="w-4 h-4" />
+        오답 보기
+      </Button>
+    </header>
+  );
+}

--- a/apps/frontend/src/domains/cs/components/DomainSelection.tsx
+++ b/apps/frontend/src/domains/cs/components/DomainSelection.tsx
@@ -3,14 +3,20 @@
 import { useEffect, useState } from 'react';
 import { Loader2, TerminalSquare, CheckCircle2, ChevronRight, BookOpen } from 'lucide-react';
 import { toast } from 'sonner';
-import { CSDomain, fetchCSDomains, changeCSDomain } from '../api/csApi';
+import { CSDomain, fetchCSDomains, changeCSDomain, changeCurrentCSDomain } from '../api/csApi';
 import { Button } from '@/components/ui/button';
 
 interface DomainSelectionProps {
   onSuccess: () => void;
+  isAddMode?: boolean;
+  onCancel?: () => void;
 }
 
-export default function DomainSelection({ onSuccess }: DomainSelectionProps) {
+export default function DomainSelection({
+  onSuccess,
+  isAddMode = false,
+  onCancel,
+}: DomainSelectionProps) {
   const [domains, setDomains] = useState<CSDomain[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedId, setSelectedId] = useState<number | null>(null);
@@ -40,11 +46,18 @@ export default function DomainSelection({ onSuccess }: DomainSelectionProps) {
     setSubmitting(true);
     try {
       console.log(`[DEBUG] Submitting domain ID ${selectedId}`);
-      await changeCSDomain(selectedId);
-      toast.success('학습 도메인이 설정되었습니다!');
+      const submitResult = await changeCSDomain(selectedId);
+
+      // 도메인 "추가" 모드에서는 현재 도메인이 자동 전환되지 않을 수 있어
+      // 명시적으로 현재 도메인을 선택한 도메인으로 맞춰준다.
+      if (isAddMode && !submitResult.isCurrent) {
+        await changeCurrentCSDomain(selectedId);
+      }
+
+      toast.success(`학습 도메인이 "${submitResult.domain.name}"(으)로 설정되었습니다!`);
       onSuccess();
     } catch (error) {
-      toast.error('도메인 선택 중 오류가 발생했습니다.');
+      toast.error('도메인 설정 중 오류가 발생했습니다.');
       console.error(error);
     } finally {
       setSubmitting(false);
@@ -61,10 +74,16 @@ export default function DomainSelection({ onSuccess }: DomainSelectionProps) {
   }
 
   const safeDomains = Array.isArray(domains) ? domains : [];
+  const titleText = isAddMode
+    ? '추가로 학습할 도메인을 선택하세요'
+    : '무엇을 먼저 학습할까요?';
+  const descriptionText = isAddMode
+    ? '현재 도메인은 유지되고, 선택한 도메인이 학습 목록에 추가됩니다.'
+    : '원하는 도메인을 선택하여 맞춤형 CS 학습 여정을 시작하세요. 선택한 도메인은 언제든 변경할 수 있습니다.';
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[80vh] px-4 w-full animate-in fade-in zoom-in-95 duration-500">
-      <div className="max-w-3xl w-full space-y-8">
+    <div className="relative w-full min-h-[100dvh] px-4 pt-[max(1.5rem,calc(env(safe-area-inset-top)+1rem))] pb-[calc(7.5rem+env(safe-area-inset-bottom))] md:flex md:flex-col md:items-center md:justify-center md:min-h-[80vh] md:pt-0 md:pb-0 animate-in fade-in zoom-in-95 duration-500">
+      <div className="max-w-3xl w-full space-y-6 md:space-y-8">
         
         {/* Header Section */}
         <div className="text-center space-y-4">
@@ -72,10 +91,10 @@ export default function DomainSelection({ onSuccess }: DomainSelectionProps) {
             <TerminalSquare className="w-12 h-12 text-primary" />
           </div>
           <h1 className="text-3xl lg:text-4xl font-extrabold tracking-tight text-foreground">
-            무엇을 먼저 학습할까요?
+            {titleText}
           </h1>
           <p className="text-base lg:text-lg text-muted-foreground max-w-xl mx-auto">
-            원하는 도메인을 선택하여 맞춤형 CS 학습 여정을 시작하세요. 선택한 도메인은 언제든 변경할 수 있습니다.
+            {descriptionText}
           </p>
         </div>
 
@@ -119,29 +138,43 @@ export default function DomainSelection({ onSuccess }: DomainSelectionProps) {
         </div>
 
         {/* Action Bottom */}
-        <div className="flex justify-center pt-8">
-          <Button
-            size="lg"
-            disabled={!selectedId || submitting}
-            onClick={handleSubmit}
-            className={`
-              h-14 px-8 text-base font-bold rounded-full gap-2 transition-all duration-300
-              ${selectedId ? 'shadow-lg shadow-primary/25 hover:shadow-primary/40' : ''}
-              min-w-[200px]
-            `}
-          >
-            {submitting ? (
-              <>
-                <Loader2 className="w-5 h-5 animate-spin" />
-                적용 중...
-              </>
-            ) : (
-              <>
-                학습 시작하기
-                <ChevronRight className={`w-5 h-5 transition-transform duration-300 ${selectedId ? 'translate-x-1' : ''}`} />
-              </>
+        <div className="fixed inset-x-0 bottom-0 z-50 border-t border-border/60 bg-background/95 px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] backdrop-blur supports-[backdrop-filter]:bg-background/80 md:static md:border-0 md:bg-transparent md:p-0 md:backdrop-blur-0">
+          <div className="mx-auto flex w-full max-w-3xl items-center gap-3 md:justify-center md:pt-8">
+            {isAddMode && onCancel && (
+              <Button
+                type="button"
+                size="lg"
+                variant="outline"
+                disabled={submitting}
+                onClick={onCancel}
+                className="h-12 md:h-14 px-6 md:px-8 text-base font-semibold rounded-full flex-1 md:flex-none md:min-w-[140px]"
+              >
+                취소
+              </Button>
             )}
-          </Button>
+            <Button
+              size="lg"
+              disabled={!selectedId || submitting}
+              onClick={handleSubmit}
+              className={`
+                h-12 md:h-14 px-6 md:px-8 text-base font-bold rounded-full gap-2 transition-all duration-300
+                ${selectedId ? 'shadow-lg shadow-primary/25 hover:shadow-primary/40' : ''}
+                ${isAddMode ? 'flex-1' : 'w-full md:w-auto md:min-w-[200px]'}
+              `}
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                  적용 중...
+                </>
+              ) : (
+                <>
+                  학습 시작하기
+                  <ChevronRight className={`w-5 h-5 transition-transform duration-300 ${selectedId ? 'translate-x-1' : ''}`} />
+                </>
+              )}
+            </Button>
+          </div>
         </div>
 
       </div>

--- a/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
+++ b/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { Settings } from 'lucide-react';
 import { NAV_ITEMS } from './Sidebar';
 import { cn } from '@/lib/utils';
@@ -13,6 +13,7 @@ const MOBILE_ITEMS = NAV_ITEMS.filter((item) =>
 
 export default function MobileBottomNav() {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const openModal = useSettingsStore((state) => state.openModal);
 
   const isItemActive = (href: string) => {
@@ -20,7 +21,8 @@ export default function MobileBottomNav() {
     return pathname.startsWith(href);
   };
 
-  const isHiddenRoute = pathname.startsWith('/cs/stage/');
+  const isCsAddMode = pathname === '/cs' && searchParams.get('mode') === 'add';
+  const isHiddenRoute = pathname.startsWith('/cs/stage/') || isCsAddMode;
 
   if (isHiddenRoute) {
     return null;


### PR DESCRIPTION
## 💡 의도 / 배경
학습 중 도메인 전환과 오답노트 이동 동선이 없어 탐색 비용이 컸습니다.  
#150 요구사항(상단바에서 핵심 액션 수행)을 우선 충족하고, #149(오답노트 목록/재도전) 구현을 연결할 수 있는 진입 동선을 먼저 확보했습니다.

## 🛠️ 작업 내용
- [x] CS 학습 화면 상단바(`CSTopBar`) 추가
- [x] 현재 도메인 표시 및 내 도메인 드롭다운(도메인 전환) 구현
- [x] `도메인 추가` 진입 플로우 구현 (`/cs?mode=add`)
- [x] 도메인 추가 모드 전용 문구/취소 버튼/모바일 고정 CTA 적용
- [x] 도메인 추가 완료 시 선택 도메인이 현재 도메인으로 반영되도록 보정 로직 추가
- [x] `오답 보기` 버튼 활성화 및 오답노트 경로 이동 연결 (`/cs/wrong-problems`)
- [x] 오답노트 임시 페이지 라우트 추가 (후속 #149에서 실제 목록/재도전 UI로 대체 예정)
- [x] CS 메인 카드의 `CS 학습` 타이틀 제거

## 🔗 관련 이슈
- Closes #150
- Related to #149

## 🖼️ 스크린샷 (선택)
<img width="1193" height="326" alt="image" src="https://github.com/user-attachments/assets/20fea4de-bc70-4cfa-bf05-9273756c2052" />

## 🧪 테스트 방법
- [x] `pnpm --filter frontend run type-check`
- [x] `/cs` 진입 후 현재 도메인 표시 확인
- [x] 상단바 드롭다운에서 도메인 변경 후 반영 확인
- [x] 상단바 `도메인 추가` 진입 시 `/cs?mode=add` 전환 및 취소 복귀 확인
- [x] 도메인 추가 완료 후 현재 도메인 변경 반영 확인
- [x] 상단바 `오답 보기` 클릭 시 `/cs/wrong-problems` 이동 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가? (`type-check`만 수행)

## 💬 리뷰어에게 (선택)
오답노트 페이지는 #150의 이동 동선 검증을 위한 임시 라우트입니다.  
#149에서 해당 페이지를 실제 오답 목록/재도전 UI로 교체할 예정입니다.