### PR TITLE
feat: cs 스터디 오답 풀이 구현

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsController.java
@@ -2,6 +2,8 @@ package com.peekle.domain.cs.controller;
 
 import com.peekle.domain.cs.dto.request.CsAttemptAnswerRequest;
 import com.peekle.domain.cs.dto.request.CsDomainIdRequest;
+import com.peekle.domain.cs.dto.request.CsWrongReviewAnswerRequest;
+import com.peekle.domain.cs.dto.request.CsWrongReviewStartRequest;
 import com.peekle.domain.cs.dto.response.CsAttemptAnswerResponse;
 import com.peekle.domain.cs.dto.response.CsAttemptCompleteResponse;
 import com.peekle.domain.cs.dto.response.CsAttemptStartResponse;
@@ -10,8 +12,14 @@ import com.peekle.domain.cs.dto.response.CsCurrentDomainChangeResponse;
 import com.peekle.domain.cs.dto.response.CsDomainResponse;
 import com.peekle.domain.cs.dto.response.CsDomainSubmitResponse;
 import com.peekle.domain.cs.dto.response.CsMyDomainItemResponse;
+import com.peekle.domain.cs.dto.response.CsWrongProblemPageResponse;
+import com.peekle.domain.cs.dto.response.CsWrongReviewAnswerResponse;
+import com.peekle.domain.cs.dto.response.CsWrongReviewCompleteResponse;
+import com.peekle.domain.cs.dto.response.CsWrongReviewStartResponse;
+import com.peekle.domain.cs.enums.CsWrongProblemStatus;
 import com.peekle.domain.cs.service.CsAttemptService;
 import com.peekle.domain.cs.service.CsDomainService;
+import com.peekle.domain.cs.service.CsWrongProblemService;
 import com.peekle.global.dto.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +29,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,6 +42,7 @@ public class CsController {
 
     private final CsDomainService csDomainService;
     private final CsAttemptService csAttemptService;
+    private final CsWrongProblemService csWrongProblemService;
 
     @GetMapping("/bootstrap")
     public ApiResponse<CsBootstrapResponse> getBootstrap(@AuthenticationPrincipal Long userId) {
@@ -83,5 +93,44 @@ public class CsController {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long stageId) {
         return ApiResponse.success(csAttemptService.completeAttempt(userId, stageId));
+    }
+
+    @GetMapping("/wrong-problems")
+    public ApiResponse<CsWrongProblemPageResponse> getWrongProblems(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) Integer domainId,
+            @RequestParam(required = false) Long stageId,
+            @RequestParam(required = false, defaultValue = "ACTIVE") CsWrongProblemStatus status,
+            @RequestParam(required = false, defaultValue = "0") Integer page,
+            @RequestParam(required = false, defaultValue = "20") Integer size) {
+        return ApiResponse.success(csWrongProblemService.getWrongProblems(
+                userId,
+                domainId,
+                stageId,
+                status,
+                page == null ? 0 : page,
+                size == null ? 20 : size));
+    }
+
+    @PostMapping("/wrong-problems/review/start")
+    public ApiResponse<CsWrongReviewStartResponse> startWrongReview(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody(required = false) CsWrongReviewStartRequest request) {
+        return ApiResponse.success(csWrongProblemService.startWrongReview(userId, request));
+    }
+
+    @PostMapping("/wrong-problems/review/{reviewId}/answer")
+    public ApiResponse<CsWrongReviewAnswerResponse> submitWrongReviewAnswer(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable String reviewId,
+            @Valid @RequestBody CsWrongReviewAnswerRequest request) {
+        return ApiResponse.success(csWrongProblemService.submitWrongReviewAnswer(userId, reviewId, request));
+    }
+
+    @PostMapping("/wrong-problems/review/{reviewId}/complete")
+    public ApiResponse<CsWrongReviewCompleteResponse> completeWrongReview(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable String reviewId) {
+        return ApiResponse.success(csWrongProblemService.completeWrongReview(userId, reviewId));
     }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsWrongReviewAnswerRequest.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsWrongReviewAnswerRequest.java
@@ -1,0 +1,13 @@
+package com.peekle.domain.cs.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CsWrongReviewAnswerRequest(
+        @NotNull(message = "questionId는 필수입니다.")
+        @Positive(message = "questionId는 1 이상의 값이어야 합니다.")
+        Long questionId,
+        @Positive(message = "selectedChoiceNo는 1 이상의 값이어야 합니다.")
+        Integer selectedChoiceNo,
+        String answerText) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsWrongReviewStartRequest.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsWrongReviewStartRequest.java
@@ -1,0 +1,11 @@
+package com.peekle.domain.cs.dto.request;
+
+import jakarta.validation.constraints.Positive;
+
+public record CsWrongReviewStartRequest(
+        Integer domainId,
+        @Positive(message = "stageId는 1 이상의 값이어야 합니다.")
+        Long stageId,
+        @Positive(message = "questionCount는 1 이상의 값이어야 합니다.")
+        Integer questionCount) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongProblemItemResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongProblemItemResponse.java
@@ -9,14 +9,13 @@ public record CsWrongProblemItemResponse(
         Long questionId,
         CsQuestionType questionType,
         String prompt,
+        String correctAnswer,
         Integer domainId,
         String domainName,
         Integer trackNo,
         Long stageId,
         Integer stageNo,
         CsWrongProblemStatus status,
-        Integer wrongCount,
-        Integer reviewCorrectCount,
         LocalDateTime lastWrongAt,
         LocalDateTime clearedAt) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongProblemItemResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongProblemItemResponse.java
@@ -1,0 +1,22 @@
+package com.peekle.domain.cs.dto.response;
+
+import com.peekle.domain.cs.enums.CsQuestionType;
+import com.peekle.domain.cs.enums.CsWrongProblemStatus;
+
+import java.time.LocalDateTime;
+
+public record CsWrongProblemItemResponse(
+        Long questionId,
+        CsQuestionType questionType,
+        String prompt,
+        Integer domainId,
+        String domainName,
+        Integer trackNo,
+        Long stageId,
+        Integer stageNo,
+        CsWrongProblemStatus status,
+        Integer wrongCount,
+        Integer reviewCorrectCount,
+        LocalDateTime lastWrongAt,
+        LocalDateTime clearedAt) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongProblemPageResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongProblemPageResponse.java
@@ -1,0 +1,10 @@
+package com.peekle.domain.cs.dto.response;
+
+import java.util.List;
+
+public record CsWrongProblemPageResponse(
+        List<CsWrongProblemItemResponse> content,
+        Integer page,
+        Integer size,
+        Long totalElements) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongReviewAnswerResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongReviewAnswerResponse.java
@@ -1,0 +1,16 @@
+package com.peekle.domain.cs.dto.response;
+
+import com.peekle.domain.cs.enums.CsQuestionType;
+
+public record CsWrongReviewAnswerResponse(
+        String reviewId,
+        Long questionId,
+        CsQuestionType questionType,
+        CsAttemptProgressResponse progress,
+        Boolean isCorrect,
+        String feedback,
+        Integer correctChoiceNo,
+        String correctAnswer,
+        Boolean isLast,
+        CsQuestionPayloadResponse nextQuestion) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongReviewCompleteResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongReviewCompleteResponse.java
@@ -1,0 +1,12 @@
+package com.peekle.domain.cs.dto.response;
+
+public record CsWrongReviewCompleteResponse(
+        String reviewId,
+        Integer totalQuestionCount,
+        Integer correctRate,
+        Integer correctCount,
+        Integer wrongCount,
+        String messageCode,
+        Integer clearedCount,
+        Integer remainedActiveCount) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongReviewStartResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsWrongReviewStartResponse.java
@@ -1,0 +1,7 @@
+package com.peekle.domain.cs.dto.response;
+
+public record CsWrongReviewStartResponse(
+        String reviewId,
+        Integer totalQuestionCount,
+        CsQuestionPayloadResponse firstQuestion) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsWrongProblem.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsWrongProblem.java
@@ -108,4 +108,9 @@ public class CsWrongProblem {
         }
         this.updatedAt = now;
     }
+
+    public void increaseWrongCount() {
+        this.wrongCount = (this.wrongCount == null ? 0 : this.wrongCount) + 1;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionRepository.java
@@ -10,4 +10,6 @@ public interface CsQuestionRepository extends JpaRepository<CsQuestion, Long> {
     List<CsQuestion> findByStage_IdAndIsActiveTrueOrderByIdAsc(Long stageId);
 
     Optional<CsQuestion> findByIdAndStage_Id(Long questionId, Long stageId);
+
+    Optional<CsQuestion> findByIdAndIsActiveTrue(Long questionId);
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsWrongProblemRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsWrongProblemRepository.java
@@ -2,10 +2,81 @@ package com.peekle.domain.cs.repository;
 
 import com.peekle.domain.cs.entity.CsWrongProblem;
 import com.peekle.domain.cs.entity.CsWrongProblemId;
+import com.peekle.domain.cs.enums.CsWrongProblemStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CsWrongProblemRepository extends JpaRepository<CsWrongProblem, CsWrongProblemId> {
     Optional<CsWrongProblem> findByUser_IdAndQuestion_Id(Long userId, Long questionId);
+
+    @Query(
+            value = """
+                    select wp
+                    from CsWrongProblem wp
+                    join fetch wp.question q
+                    join fetch q.stage s
+                    join fetch s.track t
+                    join fetch t.domain d
+                    where wp.user.id = :userId
+                      and q.isActive = true
+                      and (:status is null or wp.status = :status)
+                      and (:domainId is null or d.id = :domainId)
+                      and (:stageId is null or s.id = :stageId)
+                    order by wp.lastWrongAt desc, q.id asc
+                    """,
+            countQuery = """
+                    select count(wp)
+                    from CsWrongProblem wp
+                    join wp.question q
+                    join q.stage s
+                    join s.track t
+                    join t.domain d
+                    where wp.user.id = :userId
+                      and q.isActive = true
+                      and (:status is null or wp.status = :status)
+                      and (:domainId is null or d.id = :domainId)
+                      and (:stageId is null or s.id = :stageId)
+                    """)
+    org.springframework.data.domain.Page<CsWrongProblem> findPagedByUserAndFilters(
+            @Param("userId") Long userId,
+            @Param("status") CsWrongProblemStatus status,
+            @Param("domainId") Integer domainId,
+            @Param("stageId") Long stageId,
+            org.springframework.data.domain.Pageable pageable);
+
+    @Query("""
+            select wp
+            from CsWrongProblem wp
+            join fetch wp.question q
+            join fetch q.stage s
+            join fetch s.track t
+            join fetch t.domain d
+            where wp.user.id = :userId
+              and q.isActive = true
+              and wp.status = :status
+              and (:domainId is null or d.id = :domainId)
+              and (:stageId is null or s.id = :stageId)
+            order by wp.lastWrongAt desc, q.id asc
+            """)
+    List<CsWrongProblem> findCandidatesForReview(
+            @Param("userId") Long userId,
+            @Param("status") CsWrongProblemStatus status,
+            @Param("domainId") Integer domainId,
+            @Param("stageId") Long stageId);
+
+    @Query("""
+            select count(wp)
+            from CsWrongProblem wp
+            where wp.user.id = :userId
+              and wp.status = :status
+              and wp.question.id in :questionIds
+            """)
+    long countByUserAndStatusAndQuestionIds(
+            @Param("userId") Long userId,
+            @Param("status") CsWrongProblemStatus status,
+            @Param("questionIds") List<Long> questionIds);
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsWrongProblemService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsWrongProblemService.java
@@ -312,16 +312,41 @@ public class CsWrongProblemService {
                 question.getId(),
                 question.getQuestionType(),
                 question.getPrompt(),
+                resolveQuestionAnswerText(question),
                 domain.getId(),
                 domain.getName(),
                 (int) track.getTrackNo(),
                 stage.getId(),
                 (int) stage.getStageNo(),
                 wrongProblem.getStatus(),
-                safeInt(wrongProblem.getWrongCount()),
-                safeInt(wrongProblem.getReviewCorrectCount()),
                 wrongProblem.getLastWrongAt(),
                 wrongProblem.getClearedAt());
+    }
+
+    private String resolveQuestionAnswerText(CsQuestion question) {
+        if (question.getQuestionType() == CsQuestionType.MULTIPLE_CHOICE
+                || question.getQuestionType() == CsQuestionType.OX) {
+            return csQuestionChoiceRepository.findByQuestion_IdOrderByChoiceNoAsc(question.getId())
+                    .stream()
+                    .filter(choice -> Boolean.TRUE.equals(choice.getIsAnswer()))
+                    .findFirst()
+                    .map(choice -> choice.getChoiceNo() + ". " + choice.getContent())
+                    .orElse(null);
+        }
+
+        if (question.getQuestionType() == CsQuestionType.SHORT_ANSWER) {
+            return csQuestionShortAnswerRepository.findByQuestion_IdOrderByIsPrimaryDescIdAsc(question.getId())
+                    .stream()
+                    .sorted(Comparator
+                            .comparing((CsQuestionShortAnswer answer) -> !Boolean.TRUE.equals(answer.getIsPrimary()))
+                            .thenComparing(CsQuestionShortAnswer::getId))
+                    .map(this::resolveDisplayAnswerText)
+                    .filter(answer -> answer != null && !answer.isBlank())
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        return null;
     }
 
     private GradingResult gradeAnswer(CsQuestion question, Integer selectedChoiceNo, String answerText) {

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsWrongProblemService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsWrongProblemService.java
@@ -1,0 +1,518 @@
+package com.peekle.domain.cs.service;
+
+import com.peekle.domain.cs.dto.request.CsWrongReviewAnswerRequest;
+import com.peekle.domain.cs.dto.request.CsWrongReviewStartRequest;
+import com.peekle.domain.cs.dto.response.CsAttemptProgressResponse;
+import com.peekle.domain.cs.dto.response.CsQuestionChoiceResponse;
+import com.peekle.domain.cs.dto.response.CsQuestionPayloadResponse;
+import com.peekle.domain.cs.dto.response.CsWrongProblemItemResponse;
+import com.peekle.domain.cs.dto.response.CsWrongProblemPageResponse;
+import com.peekle.domain.cs.dto.response.CsWrongReviewAnswerResponse;
+import com.peekle.domain.cs.dto.response.CsWrongReviewCompleteResponse;
+import com.peekle.domain.cs.dto.response.CsWrongReviewStartResponse;
+import com.peekle.domain.cs.entity.CsQuestion;
+import com.peekle.domain.cs.entity.CsQuestionChoice;
+import com.peekle.domain.cs.entity.CsQuestionShortAnswer;
+import com.peekle.domain.cs.entity.CsWrongProblem;
+import com.peekle.domain.cs.enums.CsQuestionType;
+import com.peekle.domain.cs.enums.CsWrongProblemStatus;
+import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
+import com.peekle.domain.cs.repository.CsQuestionRepository;
+import com.peekle.domain.cs.repository.CsQuestionShortAnswerRepository;
+import com.peekle.domain.cs.repository.CsWrongProblemRepository;
+import com.peekle.domain.cs.service.store.CsWrongReviewSession;
+import com.peekle.domain.cs.service.store.CsWrongReviewStore;
+import com.peekle.domain.user.entity.User;
+import com.peekle.domain.user.repository.UserRepository;
+import com.peekle.global.exception.BusinessException;
+import com.peekle.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CsWrongProblemService {
+
+    private static final int MAX_REVIEW_QUESTION_COUNT = 10;
+    private static final int DEFAULT_REVIEW_QUESTION_COUNT = 10;
+    private static final int CLEAR_THRESHOLD = 1;
+    private static final int MESSAGE_SCORE_EXCELLENT = 90;
+    private static final int MESSAGE_SCORE_GOOD = 70;
+
+    private final CsWrongProblemRepository csWrongProblemRepository;
+    private final CsQuestionRepository csQuestionRepository;
+    private final CsQuestionChoiceRepository csQuestionChoiceRepository;
+    private final CsQuestionShortAnswerRepository csQuestionShortAnswerRepository;
+    private final CsWrongReviewStore csWrongReviewStore;
+    private final UserRepository userRepository;
+
+    public CsWrongProblemPageResponse getWrongProblems(
+            Long userId,
+            Integer domainId,
+            Long stageId,
+            CsWrongProblemStatus status,
+            int page,
+            int size) {
+        getUser(userId);
+
+        int normalizedPage = Math.max(page, 0);
+        int normalizedSize = Math.max(1, Math.min(size, 100));
+        CsWrongProblemStatus resolvedStatus = status == null ? CsWrongProblemStatus.ACTIVE : status;
+
+        Page<CsWrongProblem> resultPage = csWrongProblemRepository.findPagedByUserAndFilters(
+                userId,
+                resolvedStatus,
+                domainId,
+                stageId,
+                PageRequest.of(normalizedPage, normalizedSize));
+
+        List<CsWrongProblemItemResponse> content = resultPage.getContent().stream()
+                .map(this::toWrongProblemItemResponse)
+                .toList();
+
+        return new CsWrongProblemPageResponse(
+                content,
+                normalizedPage,
+                normalizedSize,
+                resultPage.getTotalElements());
+    }
+
+    @Transactional
+    public CsWrongReviewStartResponse startWrongReview(Long userId, CsWrongReviewStartRequest request) {
+        getUser(userId);
+
+        Integer domainId = request == null ? null : request.domainId();
+        Long stageId = request == null ? null : request.stageId();
+        int requestedCount = request != null && request.questionCount() != null
+                ? request.questionCount()
+                : DEFAULT_REVIEW_QUESTION_COUNT;
+        int reviewQuestionCount = Math.max(1, Math.min(requestedCount, MAX_REVIEW_QUESTION_COUNT));
+
+        List<CsWrongProblem> candidates = new ArrayList<>(csWrongProblemRepository.findCandidatesForReview(
+                userId,
+                CsWrongProblemStatus.ACTIVE,
+                domainId,
+                stageId));
+
+        if (candidates.isEmpty()) {
+            return new CsWrongReviewStartResponse(null, 0, null);
+        }
+
+        Collections.shuffle(candidates);
+        List<Long> selectedQuestionIds = candidates.stream()
+                .limit(reviewQuestionCount)
+                .map(wrongProblem -> wrongProblem.getQuestion().getId())
+                .toList();
+
+        String reviewId = UUID.randomUUID().toString();
+        LocalDateTime now = LocalDateTime.now();
+        CsWrongReviewSession session = CsWrongReviewSession.builder()
+                .reviewId(reviewId)
+                .userId(userId)
+                .domainId(domainId)
+                .stageId(stageId)
+                .questionOrder(selectedQuestionIds)
+                .currentIndex(0)
+                .correctCount(0)
+                .clearedCount(0)
+                .latestCorrectByQuestionId(new HashMap<>())
+                .completed(false)
+                .startedAt(now)
+                .updatedAt(now)
+                .build();
+        csWrongReviewStore.save(session);
+
+        Long firstQuestionId = selectedQuestionIds.get(0);
+        CsQuestion firstQuestion = csQuestionRepository.findByIdAndIsActiveTrue(firstQuestionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND));
+
+        return new CsWrongReviewStartResponse(
+                reviewId,
+                selectedQuestionIds.size(),
+                toQuestionPayload(firstQuestion));
+    }
+
+    @Transactional
+    public CsWrongReviewAnswerResponse submitWrongReviewAnswer(
+            Long userId,
+            String reviewId,
+            CsWrongReviewAnswerRequest request) {
+        User user = getUser(userId);
+        CsWrongReviewSession session = getReviewSession(userId, reviewId);
+
+        if (Boolean.TRUE.equals(session.getCompleted())) {
+            throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "이미 완료된 복습 세션입니다.");
+        }
+
+        List<Long> questionOrder = session.getQuestionOrder();
+        int currentIndex = safeInt(session.getCurrentIndex());
+        if (questionOrder == null || questionOrder.isEmpty() || currentIndex >= questionOrder.size()) {
+            throw new BusinessException(ErrorCode.CS_ATTEMPT_EXPIRED, "유효하지 않은 복습 세션 상태입니다.");
+        }
+
+        Long expectedQuestionId = questionOrder.get(currentIndex);
+        if (!expectedQuestionId.equals(request.questionId())) {
+            throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "현재 순서의 문제를 제출해야 합니다.");
+        }
+
+        CsQuestion question = csQuestionRepository.findByIdAndIsActiveTrue(request.questionId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND));
+
+        GradingResult gradingResult = gradeAnswer(question, request.selectedChoiceNo(), request.answerText());
+        boolean isCorrect = gradingResult.isCorrect();
+
+        applyWrongProblemState(user, question, session, isCorrect);
+
+        if (isCorrect) {
+            session.setCorrectCount(safeInt(session.getCorrectCount()) + 1);
+        }
+        session.getLatestCorrectByQuestionId().put(question.getId(), isCorrect);
+
+        int currentQuestionNo = currentIndex + 1;
+        int totalQuestionCount = questionOrder.size();
+
+        int nextIndex = currentIndex + 1;
+        if (nextIndex >= totalQuestionCount) {
+            session.setCurrentIndex(nextIndex);
+            session.setCompleted(true);
+        } else {
+            session.setCurrentIndex(nextIndex);
+        }
+
+        session.setUpdatedAt(LocalDateTime.now());
+        csWrongReviewStore.save(session);
+
+        boolean isLast = Boolean.TRUE.equals(session.getCompleted());
+        CsQuestionPayloadResponse nextQuestion = null;
+        if (!isLast) {
+            Long nextQuestionId = session.getQuestionOrder().get(session.getCurrentIndex());
+            CsQuestion next = csQuestionRepository.findByIdAndIsActiveTrue(nextQuestionId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND));
+            nextQuestion = toQuestionPayload(next);
+        }
+
+        return new CsWrongReviewAnswerResponse(
+                session.getReviewId(),
+                question.getId(),
+                question.getQuestionType(),
+                new CsAttemptProgressResponse(currentQuestionNo, totalQuestionCount),
+                isCorrect,
+                buildFeedback(gradingResult),
+                isCorrect ? null : gradingResult.correctChoiceNo(),
+                isCorrect ? null : gradingResult.correctAnswer(),
+                isLast,
+                nextQuestion);
+    }
+
+    @Transactional
+    public CsWrongReviewCompleteResponse completeWrongReview(Long userId, String reviewId) {
+        getUser(userId);
+        CsWrongReviewSession session = getReviewSession(userId, reviewId);
+
+        if (!Boolean.TRUE.equals(session.getCompleted())) {
+            throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "아직 복습이 완료되지 않았습니다.");
+        }
+
+        int totalQuestionCount = session.getQuestionOrder() == null ? 0 : session.getQuestionOrder().size();
+        int correctCount = safeInt(session.getCorrectCount());
+        int wrongCount = Math.max(totalQuestionCount - correctCount, 0);
+        int correctRate = totalQuestionCount == 0
+                ? 0
+                : (int) Math.round((correctCount * 100.0) / totalQuestionCount);
+
+        List<Long> questionIds = session.getQuestionOrder() == null ? List.of() : session.getQuestionOrder();
+        int remainedActiveCount = questionIds.isEmpty()
+                ? 0
+                : (int) csWrongProblemRepository.countByUserAndStatusAndQuestionIds(
+                        userId,
+                        CsWrongProblemStatus.ACTIVE,
+                        questionIds);
+
+        int clearedCount = safeInt(session.getClearedCount());
+        csWrongReviewStore.delete(userId, reviewId);
+
+        return new CsWrongReviewCompleteResponse(
+                reviewId,
+                totalQuestionCount,
+                correctRate,
+                correctCount,
+                wrongCount,
+                resolveMessageCode(correctRate),
+                clearedCount,
+                remainedActiveCount);
+    }
+
+    private void applyWrongProblemState(
+            User user,
+            CsQuestion question,
+            CsWrongReviewSession session,
+            boolean isCorrect) {
+        CsWrongProblem wrongProblem = csWrongProblemRepository
+                .findByUser_IdAndQuestion_Id(user.getId(), question.getId())
+                .orElseGet(() -> buildNewWrongProblem(user, question));
+
+        if (isCorrect) {
+            CsWrongProblemStatus beforeStatus = wrongProblem.getStatus();
+            wrongProblem.increaseWrongCount();
+            wrongProblem.markCorrectReview(CLEAR_THRESHOLD);
+            if (beforeStatus != CsWrongProblemStatus.CLEARED
+                    && wrongProblem.getStatus() == CsWrongProblemStatus.CLEARED) {
+                session.setClearedCount(safeInt(session.getClearedCount()) + 1);
+            }
+        } else {
+            wrongProblem.markWrong();
+        }
+
+        csWrongProblemRepository.save(wrongProblem);
+    }
+
+    private CsWrongProblem buildNewWrongProblem(User user, CsQuestion question) {
+        LocalDateTime now = LocalDateTime.now();
+        return CsWrongProblem.builder()
+                .user(user)
+                .question(question)
+                .domain(question.getStage().getTrack().getDomain())
+                .status(CsWrongProblemStatus.ACTIVE)
+                .wrongCount(0)
+                .reviewCorrectCount(0)
+                .lastWrongAt(now)
+                .updatedAt(now)
+                .build();
+    }
+
+    private CsWrongReviewSession getReviewSession(Long userId, String reviewId) {
+        return csWrongReviewStore.find(userId, reviewId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.CS_ATTEMPT_NOT_FOUND,
+                        "진행 중인 오답 복습 세션을 찾을 수 없습니다."));
+    }
+
+    private CsWrongProblemItemResponse toWrongProblemItemResponse(CsWrongProblem wrongProblem) {
+        CsQuestion question = wrongProblem.getQuestion();
+        var stage = question.getStage();
+        var track = stage.getTrack();
+        var domain = track.getDomain();
+
+        return new CsWrongProblemItemResponse(
+                question.getId(),
+                question.getQuestionType(),
+                question.getPrompt(),
+                domain.getId(),
+                domain.getName(),
+                (int) track.getTrackNo(),
+                stage.getId(),
+                (int) stage.getStageNo(),
+                wrongProblem.getStatus(),
+                safeInt(wrongProblem.getWrongCount()),
+                safeInt(wrongProblem.getReviewCorrectCount()),
+                wrongProblem.getLastWrongAt(),
+                wrongProblem.getClearedAt());
+    }
+
+    private GradingResult gradeAnswer(CsQuestion question, Integer selectedChoiceNo, String answerText) {
+        CsQuestionType questionType = question.getQuestionType();
+
+        return switch (questionType) {
+            case MULTIPLE_CHOICE, OX -> {
+                if (selectedChoiceNo == null || selectedChoiceNo <= 0) {
+                    throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "객관식/OX는 selectedChoiceNo가 필요합니다.");
+                }
+
+                List<CsQuestionChoice> choices = csQuestionChoiceRepository.findByQuestion_IdOrderByChoiceNoAsc(question.getId());
+                if (choices.isEmpty()) {
+                    throw new BusinessException(ErrorCode.CS_QUESTION_NOT_FOUND, "선택지가 존재하지 않는 문제입니다.");
+                }
+
+                CsQuestionChoice selectedChoice = choices.stream()
+                        .filter(choice -> choice.getChoiceNo() != null
+                                && choice.getChoiceNo().intValue() == selectedChoiceNo)
+                        .findFirst()
+                        .orElse(null);
+                if (selectedChoice == null) {
+                    throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "존재하지 않는 선택지입니다.");
+                }
+
+                List<CsQuestionChoice> answerChoices = choices.stream()
+                        .filter(choice -> Boolean.TRUE.equals(choice.getIsAnswer()))
+                        .toList();
+                if (answerChoices.size() != 1) {
+                    throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "문제 정답 구성이 올바르지 않습니다.");
+                }
+
+                CsQuestionChoice answerChoice = answerChoices.get(0);
+                boolean isCorrect = answerChoice.getChoiceNo().intValue() == selectedChoiceNo;
+                String correctAnswer = answerChoice.getChoiceNo() + ". " + answerChoice.getContent();
+
+                yield new GradingResult(
+                        isCorrect,
+                        (int) answerChoice.getChoiceNo(),
+                        correctAnswer,
+                        question.getExplanation());
+            }
+            case SHORT_ANSWER -> {
+                if (answerText == null || answerText.isBlank()) {
+                    throw new BusinessException(ErrorCode.CS_INVALID_ANSWER_PAYLOAD, "단답형은 answerText가 필요합니다.");
+                }
+
+                List<CsQuestionShortAnswer> acceptableAnswers = csQuestionShortAnswerRepository
+                        .findByQuestion_IdOrderByIsPrimaryDescIdAsc(question.getId());
+                if (acceptableAnswers.isEmpty()) {
+                    throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "단답형 정답 구성이 올바르지 않습니다.");
+                }
+
+                String submitted = answerText.strip();
+                String strictSubmitted = normalizeStrict(submitted);
+                String relaxedSubmitted = normalizeRelaxed(strictSubmitted);
+
+                Set<String> strictCandidates = new HashSet<>();
+                Set<String> relaxedCandidates = new HashSet<>();
+
+                for (CsQuestionShortAnswer acceptableAnswer : acceptableAnswers) {
+                    addCandidateNormalization(strictCandidates, relaxedCandidates, acceptableAnswer.getNormalizedAnswer());
+                    addCandidateNormalization(strictCandidates, relaxedCandidates, acceptableAnswer.getAnswerText());
+                }
+
+                boolean isCorrect = strictCandidates.contains(strictSubmitted)
+                        || (!relaxedSubmitted.isBlank() && relaxedCandidates.contains(relaxedSubmitted));
+
+                yield new GradingResult(
+                        isCorrect,
+                        null,
+                        isCorrect ? null : resolvePrimaryShortAnswer(acceptableAnswers),
+                        question.getExplanation());
+            }
+        };
+    }
+
+    private CsQuestionPayloadResponse toQuestionPayload(CsQuestion question) {
+        List<CsQuestionChoiceResponse> choices = switch (question.getQuestionType()) {
+            case MULTIPLE_CHOICE, OX -> csQuestionChoiceRepository
+                    .findByQuestion_IdOrderByChoiceNoAsc(question.getId())
+                    .stream()
+                    .map(choice -> new CsQuestionChoiceResponse(
+                            (int) choice.getChoiceNo(),
+                            choice.getContent()))
+                    .toList();
+            default -> List.of();
+        };
+
+        return new CsQuestionPayloadResponse(
+                question.getId(),
+                question.getQuestionType(),
+                question.getPrompt(),
+                choices.isEmpty() ? null : choices);
+    }
+
+    private String buildFeedback(GradingResult gradingResult) {
+        if (gradingResult.isCorrect()) {
+            return "정답입니다.";
+        }
+
+        StringBuilder feedback = new StringBuilder();
+        if (gradingResult.correctAnswer() != null && !gradingResult.correctAnswer().isBlank()) {
+            feedback.append("정답: ").append(gradingResult.correctAnswer().trim());
+        }
+        if (gradingResult.explanation() != null && !gradingResult.explanation().isBlank()) {
+            if (!feedback.isEmpty()) {
+                feedback.append("\n");
+            }
+            feedback.append("해설: ").append(gradingResult.explanation().trim());
+        }
+
+        return feedback.isEmpty() ? "오답입니다." : feedback.toString();
+    }
+
+    private String resolveMessageCode(int correctRate) {
+        if (correctRate >= MESSAGE_SCORE_EXCELLENT) {
+            return "CS_RESULT_EXCELLENT";
+        }
+        if (correctRate >= MESSAGE_SCORE_GOOD) {
+            return "CS_RESULT_GOOD";
+        }
+        return "CS_RESULT_KEEP_GOING";
+    }
+
+    private void addCandidateNormalization(Set<String> strictCandidates, Set<String> relaxedCandidates, String candidate) {
+        String strictCandidate = normalizeStrict(candidate);
+        if (strictCandidate.isBlank()) {
+            return;
+        }
+
+        strictCandidates.add(strictCandidate);
+
+        String relaxedCandidate = normalizeRelaxed(strictCandidate);
+        if (!relaxedCandidate.isBlank()) {
+            relaxedCandidates.add(relaxedCandidate);
+        }
+    }
+
+    private String resolvePrimaryShortAnswer(List<CsQuestionShortAnswer> answers) {
+        return answers.stream()
+                .sorted(Comparator
+                        .comparing((CsQuestionShortAnswer answer) -> !Boolean.TRUE.equals(answer.getIsPrimary()))
+                        .thenComparing(CsQuestionShortAnswer::getId))
+                .map(this::resolveDisplayAnswerText)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String resolveDisplayAnswerText(CsQuestionShortAnswer answer) {
+        if (answer.getAnswerText() != null && !answer.getAnswerText().isBlank()) {
+            return answer.getAnswerText().trim();
+        }
+        if (answer.getNormalizedAnswer() != null && !answer.getNormalizedAnswer().isBlank()) {
+            return answer.getNormalizedAnswer().trim();
+        }
+        return null;
+    }
+
+    private String normalizeStrict(String input) {
+        if (input == null) {
+            return "";
+        }
+        return input.strip()
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("\\s+", "");
+    }
+
+    private String normalizeRelaxed(String input) {
+        if (input == null || input.isBlank()) {
+            return "";
+        }
+        return input.replaceAll("[^\\p{L}\\p{N}]", "");
+    }
+
+    private int safeInt(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private User getUser(Long userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private record GradingResult(
+            boolean isCorrect,
+            Integer correctChoiceNo,
+            String correctAnswer,
+            String explanation) {
+    }
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/store/CsWrongReviewSession.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/store/CsWrongReviewSession.java
@@ -1,0 +1,31 @@
+package com.peekle.domain.cs.service.store;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CsWrongReviewSession {
+    private String reviewId;
+    private Long userId;
+    private Integer domainId;
+    private Long stageId;
+    private List<Long> questionOrder;
+    private Integer currentIndex;
+    private Integer correctCount;
+    private Integer clearedCount;
+    private Map<Long, Boolean> latestCorrectByQuestionId;
+    private Boolean completed;
+    private LocalDateTime startedAt;
+    private LocalDateTime updatedAt;
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/store/CsWrongReviewStore.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/store/CsWrongReviewStore.java
@@ -1,0 +1,11 @@
+package com.peekle.domain.cs.service.store;
+
+import java.util.Optional;
+
+public interface CsWrongReviewStore {
+    void save(CsWrongReviewSession session);
+
+    Optional<CsWrongReviewSession> find(Long userId, String reviewId);
+
+    void delete(Long userId, String reviewId);
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/store/InMemoryCsWrongReviewStore.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/store/InMemoryCsWrongReviewStore.java
@@ -1,0 +1,34 @@
+package com.peekle.domain.cs.service.store;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+@Profile("test")
+public class InMemoryCsWrongReviewStore implements CsWrongReviewStore {
+
+    private final ConcurrentMap<String, CsWrongReviewSession> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(CsWrongReviewSession session) {
+        storage.put(key(session.getUserId(), session.getReviewId()), session);
+    }
+
+    @Override
+    public Optional<CsWrongReviewSession> find(Long userId, String reviewId) {
+        return Optional.ofNullable(storage.get(key(userId, reviewId)));
+    }
+
+    @Override
+    public void delete(Long userId, String reviewId) {
+        storage.remove(key(userId, reviewId));
+    }
+
+    private String key(Long userId, String reviewId) {
+        return userId + ":" + reviewId;
+    }
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/store/RedisCsWrongReviewStore.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/store/RedisCsWrongReviewStore.java
@@ -1,0 +1,54 @@
+package com.peekle.domain.cs.service.store;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.peekle.global.redis.RedisKeyConst;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class RedisCsWrongReviewStore implements CsWrongReviewStore {
+
+    private static final Duration REVIEW_TTL = Duration.ofHours(6);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void save(CsWrongReviewSession session) {
+        redisTemplate.opsForValue().set(key(session.getUserId(), session.getReviewId()), session, REVIEW_TTL);
+    }
+
+    @Override
+    public Optional<CsWrongReviewSession> find(Long userId, String reviewId) {
+        Object value = redisTemplate.opsForValue().get(key(userId, reviewId));
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        if (value instanceof CsWrongReviewSession session) {
+            return Optional.of(session);
+        }
+
+        try {
+            return Optional.of(objectMapper.convertValue(value, CsWrongReviewSession.class));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void delete(Long userId, String reviewId) {
+        redisTemplate.delete(key(userId, reviewId));
+    }
+
+    private String key(Long userId, String reviewId) {
+        return String.format(RedisKeyConst.CS_WRONG_REVIEW, userId, reviewId);
+    }
+}

--- a/apps/backend/src/main/java/com/peekle/global/redis/RedisKeyConst.java
+++ b/apps/backend/src/main/java/com/peekle/global/redis/RedisKeyConst.java
@@ -185,4 +185,8 @@ public class RedisKeyConst {
     // CS learning temporary attempt state (Hash/JSON)
     // cs:attempt:{userId}:{stageId}
     public static final String CS_ATTEMPT = "cs:attempt:%d:%d";
+
+    // CS wrong-review temporary state (Hash/JSON)
+    // cs:wrong-review:{userId}:{reviewId}
+    public static final String CS_WRONG_REVIEW = "cs:wrong-review:%d:%s";
 }

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
@@ -307,6 +307,63 @@ class CsAttemptFlowIntegrationTest {
                 });
     }
 
+    @Test
+    @DisplayName("같은 문제를 다시 틀려도 오답 레코드는 중복 생성되지 않고 wrongCount만 누적된다")
+    void sameQuestionWrongAgain_updatesSingleWrongProblem() {
+        User user = createUser("wrong-duplicate-check");
+        CsDomain domain = createDomain(407, "중복 검증 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "중복 검증 트랙");
+        CsStage stage = createStage(track, 1);
+        CsQuestion question = createMultipleChoiceQuestion(stage, "중복 검증 문제");
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+
+        // 첫 번째 시도: 1회 오답 후 정답 완료
+        csAttemptService.startStageAttempt(user.getId(), stage.getId());
+        CsAttemptAnswerResponse firstWrong = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(question.getId(), 2, null));
+        assertThat(firstWrong.isCorrect()).isFalse();
+
+        CsAttemptAnswerResponse firstRetryCorrect = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(question.getId(), 1, null));
+        assertThat(firstRetryCorrect.isCorrect()).isTrue();
+        assertThat(firstRetryCorrect.isLast()).isTrue();
+        csAttemptService.completeAttempt(user.getId(), stage.getId());
+
+        // 두 번째 시도(예전 스테이지 재도전): 다시 1회 오답 후 정답 완료
+        csAttemptService.startStageAttempt(user.getId(), stage.getId());
+        CsAttemptAnswerResponse secondWrong = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(question.getId(), 2, null));
+        assertThat(secondWrong.isCorrect()).isFalse();
+
+        CsAttemptAnswerResponse secondRetryCorrect = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(question.getId(), 1, null));
+        assertThat(secondRetryCorrect.isCorrect()).isTrue();
+        assertThat(secondRetryCorrect.isLast()).isTrue();
+        csAttemptService.completeAttempt(user.getId(), stage.getId());
+
+        long wrongProblemRowCount = csWrongProblemRepository.findAll().stream()
+                .filter(wrongProblem -> wrongProblem.getUser().getId().equals(user.getId()))
+                .filter(wrongProblem -> wrongProblem.getQuestion().getId().equals(question.getId()))
+                .count();
+
+        CsWrongProblem wrongProblem = csWrongProblemRepository
+                .findByUser_IdAndQuestion_Id(user.getId(), question.getId())
+                .orElseThrow();
+
+        assertThat(wrongProblemRowCount).isEqualTo(1L);
+        assertThat(wrongProblem.getWrongCount()).isEqualTo(2);
+        assertThat(wrongProblem.getStatus()).isEqualTo(CsWrongProblemStatus.ACTIVE);
+    }
+
     private User createUser(String suffix) {
         return userRepository.save(User.builder()
                 .socialId("social-" + suffix)

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsWrongProblemServiceIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsWrongProblemServiceIntegrationTest.java
@@ -1,0 +1,315 @@
+package com.peekle.domain.cs.service;
+
+import com.peekle.domain.cs.dto.request.CsWrongReviewAnswerRequest;
+import com.peekle.domain.cs.dto.request.CsWrongReviewStartRequest;
+import com.peekle.domain.cs.dto.response.CsWrongProblemPageResponse;
+import com.peekle.domain.cs.dto.response.CsWrongReviewAnswerResponse;
+import com.peekle.domain.cs.dto.response.CsWrongReviewCompleteResponse;
+import com.peekle.domain.cs.dto.response.CsWrongReviewStartResponse;
+import com.peekle.domain.cs.entity.CsDomain;
+import com.peekle.domain.cs.entity.CsDomainTrack;
+import com.peekle.domain.cs.entity.CsQuestion;
+import com.peekle.domain.cs.entity.CsQuestionChoice;
+import com.peekle.domain.cs.entity.CsStage;
+import com.peekle.domain.cs.entity.CsWrongProblem;
+import com.peekle.domain.cs.enums.CsQuestionType;
+import com.peekle.domain.cs.enums.CsWrongProblemStatus;
+import com.peekle.domain.cs.repository.CsDomainRepository;
+import com.peekle.domain.cs.repository.CsDomainTrackRepository;
+import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
+import com.peekle.domain.cs.repository.CsQuestionRepository;
+import com.peekle.domain.cs.repository.CsStageRepository;
+import com.peekle.domain.cs.repository.CsWrongProblemRepository;
+import com.peekle.domain.user.entity.User;
+import com.peekle.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class CsWrongProblemServiceIntegrationTest {
+
+    @Autowired
+    private CsWrongProblemService csWrongProblemService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CsDomainRepository csDomainRepository;
+
+    @Autowired
+    private CsDomainTrackRepository csDomainTrackRepository;
+
+    @Autowired
+    private CsStageRepository csStageRepository;
+
+    @Autowired
+    private CsQuestionRepository csQuestionRepository;
+
+    @Autowired
+    private CsQuestionChoiceRepository csQuestionChoiceRepository;
+
+    @Autowired
+    private CsWrongProblemRepository csWrongProblemRepository;
+
+    @Test
+    @DisplayName("오답 목록은 사용자/도메인/스테이지/상태 필터로 조회된다")
+    void getWrongProblems_filtersByUserDomainStageAndStatus() {
+        User user = createUser("wrong-list");
+        User otherUser = createUser("wrong-list-other");
+
+        CsDomain domainA = createDomain(501, "도메인 A");
+        CsDomainTrack trackA = createTrack(domainA, 1, "트랙 A");
+        CsStage stageA1 = createStage(trackA, 1);
+        CsStage stageA2 = createStage(trackA, 2);
+
+        CsDomain domainB = createDomain(502, "도메인 B");
+        CsDomainTrack trackB = createTrack(domainB, 1, "트랙 B");
+        CsStage stageB1 = createStage(trackB, 1);
+
+        CsQuestion questionA1 = createMultipleChoiceQuestion(stageA1, "A1 문제");
+        CsQuestion questionA1Cleared = createMultipleChoiceQuestion(stageA1, "A1 클리어 문제");
+        CsQuestion questionA2 = createMultipleChoiceQuestion(stageA2, "A2 문제");
+        CsQuestion questionB1 = createMultipleChoiceQuestion(stageB1, "B1 문제");
+
+        saveWrongProblem(user, questionA1, CsWrongProblemStatus.ACTIVE, 2, 0);
+        saveWrongProblem(user, questionA2, CsWrongProblemStatus.ACTIVE, 1, 0);
+        saveWrongProblem(user, questionA1Cleared, CsWrongProblemStatus.CLEARED, 2, 1);
+        saveWrongProblem(user, questionB1, CsWrongProblemStatus.ACTIVE, 1, 0);
+        saveWrongProblem(otherUser, questionA1, CsWrongProblemStatus.ACTIVE, 3, 0);
+
+        CsWrongProblemPageResponse activeInStageA1 = csWrongProblemService.getWrongProblems(
+                user.getId(),
+                domainA.getId(),
+                stageA1.getId(),
+                CsWrongProblemStatus.ACTIVE,
+                0,
+                20);
+        assertThat(activeInStageA1.content()).hasSize(1);
+        assertThat(activeInStageA1.content().get(0).questionId()).isEqualTo(questionA1.getId());
+        assertThat(activeInStageA1.content().get(0).status()).isEqualTo(CsWrongProblemStatus.ACTIVE);
+
+        CsWrongProblemPageResponse clearedInDomainA = csWrongProblemService.getWrongProblems(
+                user.getId(),
+                domainA.getId(),
+                null,
+                CsWrongProblemStatus.CLEARED,
+                0,
+                20);
+        assertThat(clearedInDomainA.content()).hasSize(1);
+        assertThat(clearedInDomainA.content().get(0).questionId()).isEqualTo(questionA1Cleared.getId());
+        assertThat(clearedInDomainA.content().get(0).status()).isEqualTo(CsWrongProblemStatus.CLEARED);
+
+        CsWrongProblemPageResponse allActive = csWrongProblemService.getWrongProblems(
+                user.getId(),
+                null,
+                null,
+                CsWrongProblemStatus.ACTIVE,
+                0,
+                20);
+        assertThat(allActive.content()).hasSize(3);
+        assertThat(allActive.content())
+                .allSatisfy(item -> assertThat(item.status()).isEqualTo(CsWrongProblemStatus.ACTIVE));
+    }
+
+    @Test
+    @DisplayName("오답 복습 제출 시 정답은 CLEARED, 오답은 ACTIVE로 상태가 갱신되고 결과가 집계된다")
+    void wrongReview_flow_updatesStatusAndReturnsResult() {
+        User user = createUser("wrong-review-flow");
+        CsDomain domain = createDomain(503, "복습 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "복습 트랙");
+        CsStage stage = createStage(track, 1);
+
+        CsQuestion question1 = createMultipleChoiceQuestion(stage, "복습 문제 1");
+        CsQuestion question2 = createMultipleChoiceQuestion(stage, "복습 문제 2");
+
+        saveWrongProblem(user, question1, CsWrongProblemStatus.ACTIVE, 1, 0);
+        saveWrongProblem(user, question2, CsWrongProblemStatus.ACTIVE, 1, 0);
+
+        CsWrongReviewStartResponse startResponse = csWrongProblemService.startWrongReview(
+                user.getId(),
+                new CsWrongReviewStartRequest(domain.getId(), stage.getId(), 10));
+
+        assertThat(startResponse.reviewId()).isNotBlank();
+        assertThat(startResponse.totalQuestionCount()).isEqualTo(2);
+        assertThat(startResponse.firstQuestion()).isNotNull();
+
+        Long firstQuestionId = startResponse.firstQuestion().questionId();
+        boolean firstIsQuestion1 = firstQuestionId.equals(question1.getId());
+        int firstAnswer = firstIsQuestion1 ? 1 : 2;
+
+        CsWrongReviewAnswerResponse firstAnswerResponse = csWrongProblemService.submitWrongReviewAnswer(
+                user.getId(),
+                startResponse.reviewId(),
+                new CsWrongReviewAnswerRequest(firstQuestionId, firstAnswer, null));
+
+        assertThat(firstAnswerResponse.isCorrect()).isEqualTo(firstIsQuestion1);
+        assertThat(firstAnswerResponse.isLast()).isFalse();
+        assertThat(firstAnswerResponse.nextQuestion()).isNotNull();
+
+        Long secondQuestionId = firstAnswerResponse.nextQuestion().questionId();
+        boolean secondShouldBeCorrect = secondQuestionId.equals(question1.getId());
+        int secondAnswer = secondShouldBeCorrect ? 1 : 2;
+
+        CsWrongReviewAnswerResponse secondAnswerResponse = csWrongProblemService.submitWrongReviewAnswer(
+                user.getId(),
+                startResponse.reviewId(),
+                new CsWrongReviewAnswerRequest(secondQuestionId, secondAnswer, null));
+
+        assertThat(secondAnswerResponse.isLast()).isTrue();
+        assertThat(secondAnswerResponse.nextQuestion()).isNull();
+
+        CsWrongReviewCompleteResponse completeResponse = csWrongProblemService.completeWrongReview(
+                user.getId(),
+                startResponse.reviewId());
+
+        assertThat(completeResponse.totalQuestionCount()).isEqualTo(2);
+        assertThat(completeResponse.correctCount()).isEqualTo(1);
+        assertThat(completeResponse.wrongCount()).isEqualTo(1);
+        assertThat(completeResponse.clearedCount()).isEqualTo(1);
+        assertThat(completeResponse.remainedActiveCount()).isEqualTo(1);
+
+        Long correctQuestionId = firstAnswerResponse.isCorrect() ? firstQuestionId : secondQuestionId;
+        Long wrongQuestionId = firstAnswerResponse.isCorrect() ? secondQuestionId : firstQuestionId;
+
+        CsWrongProblem correctProblem = csWrongProblemRepository
+                .findByUser_IdAndQuestion_Id(user.getId(), correctQuestionId)
+                .orElseThrow();
+        CsWrongProblem wrongProblem = csWrongProblemRepository
+                .findByUser_IdAndQuestion_Id(user.getId(), wrongQuestionId)
+                .orElseThrow();
+
+        assertThat(correctProblem.getStatus()).isEqualTo(CsWrongProblemStatus.CLEARED);
+        assertThat(correctProblem.getWrongCount()).isEqualTo(2);
+        assertThat(wrongProblem.getStatus()).isEqualTo(CsWrongProblemStatus.ACTIVE);
+        assertThat(wrongProblem.getWrongCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("ACTIVE 오답이 없으면 복습 시작 응답은 빈 세션으로 반환된다")
+    void startWrongReview_returnsEmptySessionWhenNoActiveWrongProblem() {
+        User user = createUser("wrong-review-empty");
+        CsDomain domain = createDomain(504, "빈 복습 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "빈 복습 트랙");
+        CsStage stage = createStage(track, 1);
+        CsQuestion question = createMultipleChoiceQuestion(stage, "빈 복습 문제");
+
+        saveWrongProblem(user, question, CsWrongProblemStatus.CLEARED, 1, 1);
+
+        CsWrongReviewStartResponse response = csWrongProblemService.startWrongReview(
+                user.getId(),
+                new CsWrongReviewStartRequest(domain.getId(), stage.getId(), 10));
+
+        assertThat(response.reviewId()).isNull();
+        assertThat(response.totalQuestionCount()).isZero();
+        assertThat(response.firstQuestion()).isNull();
+    }
+
+    @Test
+    @DisplayName("복습 시작 문제 수는 최대 10개로 제한된다")
+    void startWrongReview_capsAtTenQuestions() {
+        User user = createUser("wrong-review-cap");
+        CsDomain domain = createDomain(505, "복습 제한 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "복습 제한 트랙");
+        CsStage stage = createStage(track, 1);
+
+        for (int i = 0; i < 12; i++) {
+            CsQuestion question = createMultipleChoiceQuestion(stage, "복습 제한 문제 " + i);
+            saveWrongProblem(user, question, CsWrongProblemStatus.ACTIVE, 1, 0);
+        }
+
+        CsWrongReviewStartResponse response = csWrongProblemService.startWrongReview(
+                user.getId(),
+                new CsWrongReviewStartRequest(domain.getId(), stage.getId(), 20));
+
+        assertThat(response.totalQuestionCount()).isEqualTo(10);
+    }
+
+    private User createUser(String suffix) {
+        return userRepository.save(User.builder()
+                .socialId("social-" + suffix)
+                .provider("TEST")
+                .nickname("nick-" + suffix)
+                .bojId("boj-" + suffix)
+                .profileImg("default.png")
+                .profileImgThumb("default-thumb.png")
+                .build());
+    }
+
+    private CsDomain createDomain(int domainId, String name) {
+        return csDomainRepository.save(CsDomain.builder()
+                .id(domainId)
+                .name(name)
+                .build());
+    }
+
+    private CsDomainTrack createTrack(CsDomain domain, int trackNo, String name) {
+        return csDomainTrackRepository.save(CsDomainTrack.builder()
+                .domain(domain)
+                .trackNo((short) trackNo)
+                .name(name)
+                .build());
+    }
+
+    private CsStage createStage(CsDomainTrack track, int stageNo) {
+        return csStageRepository.save(CsStage.builder()
+                .track(track)
+                .stageNo((short) stageNo)
+                .build());
+    }
+
+    private CsQuestion createMultipleChoiceQuestion(CsStage stage, String prompt) {
+        CsQuestion question = csQuestionRepository.save(CsQuestion.builder()
+                .stage(stage)
+                .questionType(CsQuestionType.MULTIPLE_CHOICE)
+                .prompt(prompt)
+                .explanation("테스트 해설")
+                .isActive(true)
+                .build());
+
+        csQuestionChoiceRepository.save(CsQuestionChoice.builder()
+                .question(question)
+                .choiceNo((short) 1)
+                .content("정답")
+                .isAnswer(true)
+                .build());
+        csQuestionChoiceRepository.save(CsQuestionChoice.builder()
+                .question(question)
+                .choiceNo((short) 2)
+                .content("오답")
+                .isAnswer(false)
+                .build());
+
+        return question;
+    }
+
+    private void saveWrongProblem(
+            User user,
+            CsQuestion question,
+            CsWrongProblemStatus status,
+            int wrongCount,
+            int reviewCorrectCount) {
+        LocalDateTime now = LocalDateTime.now();
+        csWrongProblemRepository.save(CsWrongProblem.builder()
+                .user(user)
+                .question(question)
+                .domain(question.getStage().getTrack().getDomain())
+                .status(status)
+                .wrongCount(wrongCount)
+                .reviewCorrectCount(reviewCorrectCount)
+                .lastWrongAt(now.minusMinutes(1))
+                .clearedAt(status == CsWrongProblemStatus.CLEARED ? now : null)
+                .updatedAt(now)
+                .build());
+    }
+}

--- a/apps/frontend/src/app/(main)/MainContentWrapper.tsx
+++ b/apps/frontend/src/app/(main)/MainContentWrapper.tsx
@@ -5,7 +5,9 @@ import { usePathname } from 'next/navigation';
 
 export default function MainContentWrapper({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const isHiddenRoute = pathname.startsWith('/cs/stage/');
+  const isHiddenRoute =
+    pathname.startsWith('/cs/stage/') ||
+    pathname.startsWith('/cs/wrong-notes/review');
 
   return (
     <div className={`flex min-w-0 flex-1 flex-col ${isHiddenRoute ? '' : 'lg:ml-[240px]'}`}>

--- a/apps/frontend/src/app/(main)/cs/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Loader2 } from 'lucide-react';
+import { Loader2, BookX } from 'lucide-react';
 import { fetchCSBootstrap, CSBootstrapResponse } from '@/domains/cs/api/csApi';
 import DomainSelection from '@/domains/cs/components/DomainSelection';
 import LearningMap from '@/domains/cs/components/LearningMap';
 import { toast } from 'sonner';
+import Link from 'next/link';
 
 export default function CSPage() {
   const [bootstrapData, setBootstrapData] = useState<CSBootstrapResponse | null>(null);
@@ -48,7 +49,19 @@ export default function CSPage() {
   return (
     <div className="flex flex-col animate-in fade-in duration-500">
       <div className="bg-card rounded-2xl p-8 shadow-sm">
-        <h1 className="text-2xl font-bold mb-2">CS 학습</h1>
+        {/* ── 헤더 영역 ── */}
+        <div className="flex items-start justify-between gap-3 mb-2">
+          <h1 className="text-2xl font-bold">CS 학습</h1>
+          <Link
+            href="/cs/wrong-notes"
+            id="cs-wrong-notes-btn"
+            className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-semibold text-muted-foreground hover:bg-muted hover:text-foreground transition-colors group shrink-0"
+          >
+            <BookX className="w-4 h-4 group-hover:text-primary transition-colors" />
+            오답노트
+          </Link>
+        </div>
+
         <p className="text-muted-foreground mb-6">
           선택한 도메인: <span className="font-semibold text-primary">{bootstrapData?.currentDomain?.name}</span>
         </p>

--- a/apps/frontend/src/app/(main)/cs/wrong-notes/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/wrong-notes/page.tsx
@@ -1,0 +1,34 @@
+import CSWrongNoteList from '@/domains/cs/components/CSWrongNoteList';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '오답노트 | CS 학습 - Peekle',
+  description: '틀린 CS 문제를 모아 복습하고 약점을 보완하세요.',
+};
+
+export default function CSWrongNotesPage() {
+  return (
+    <div className="flex flex-col min-h-[80vh] animate-in fade-in duration-300">
+      {/* ── 헤더 ──────────────────────────────────────────────────────────── */}
+      <header className="flex items-center gap-3 py-4 pb-6">
+        <Link
+          href="/cs"
+          id="wrong-notes-back-btn"
+          className="p-2 rounded-xl hover:bg-muted transition-colors group"
+          aria-label="CS 학습으로 돌아가기"
+        >
+          <ArrowLeft className="w-5 h-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+        </Link>
+        <div>
+          <h1 className="text-xl font-extrabold tracking-tight">오답노트</h1>
+          <p className="text-sm text-muted-foreground">틀린 문제를 모아 복습하세요</p>
+        </div>
+      </header>
+
+      {/* ── 목록 컴포넌트 ────────────────────────────────────────────────── */}
+      <CSWrongNoteList />
+    </div>
+  );
+}

--- a/apps/frontend/src/app/(main)/cs/wrong-notes/review/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/wrong-notes/review/page.tsx
@@ -1,0 +1,19 @@
+import CSWrongReviewSession from '@/domains/cs/components/session/CSWrongReviewSession';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '오답 복습 | CS 학습 - Peekle',
+  description: '오답 문제를 다시 풀며 복습합니다.',
+};
+
+interface CSWrongReviewPageProps {
+  searchParams: Promise<{ domainId?: string }>;
+}
+
+export default async function CSWrongReviewPage({ searchParams }: CSWrongReviewPageProps) {
+  const { domainId: rawDomainId } = await searchParams;
+  const parsedDomainId = rawDomainId ? Number(rawDomainId) : NaN;
+  const domainId = Number.isFinite(parsedDomainId) ? parsedDomainId : null;
+
+  return <CSWrongReviewSession domainId={domainId} />;
+}

--- a/apps/frontend/src/domains/cs/api/csApi.ts
+++ b/apps/frontend/src/domains/cs/api/csApi.ts
@@ -110,7 +110,17 @@ export type CSWrongProblemStatus = 'ACTIVE' | 'CLEARED';
 
 export interface CSWrongProblemItem {
   questionId: number;
+  questionType: CSQuestionType;
+  prompt: string;
+  correctAnswer?: string;
+  domainId: number;
+  domainName: string;
+  trackNo: number;
+  stageId: number;
+  stageNo: number;
+  status: CSWrongProblemStatus;
   lastWrongAt: string;
+  clearedAt?: string;
 }
 
 export interface CSWrongProblemsResponse {
@@ -118,6 +128,42 @@ export interface CSWrongProblemsResponse {
   page: number;
   size: number;
   totalElements: number;
+}
+
+export interface CSWrongReviewStartRequest {
+  domainId?: number;
+  stageId?: number;
+  questionCount?: number;
+}
+
+export interface CSWrongReviewStartResponse {
+  reviewId: string | null;
+  totalQuestionCount: number;
+  firstQuestion: CSQuestionPayload | null;
+}
+
+export interface CSWrongReviewAnswerResponse {
+  reviewId: string;
+  questionId: number;
+  questionType: CSQuestionType;
+  progress: CSAttemptProgress;
+  isCorrect: boolean;
+  feedback: string;
+  correctChoiceNo?: number;
+  correctAnswer?: string;
+  isLast: boolean;
+  nextQuestion?: CSQuestionPayload;
+}
+
+export interface CSWrongReviewCompleteResponse {
+  reviewId: string;
+  totalQuestionCount: number;
+  correctRate: number;
+  correctCount: number;
+  wrongCount: number;
+  messageCode: string;
+  clearedCount: number;
+  remainedActiveCount: number;
 }
 
 function assertApiData<T>(response: ApiResponse<T>, defaultMessage: string): T {
@@ -241,4 +287,49 @@ export const fetchCSWrongProblems = async (
 
   const response = await apiFetch<CSWrongProblemsResponse>(`/api/cs/wrong-problems?${query.toString()}`);
   return assertApiData(response, '오답노트를 불러오지 못했습니다.');
+};
+
+/**
+ * 오답 복습 세션 시작
+ */
+export const startCSWrongReview = async (
+  payload: CSWrongReviewStartRequest,
+): Promise<CSWrongReviewStartResponse> => {
+  const response = await apiFetch<CSWrongReviewStartResponse>('/api/cs/wrong-problems/review/start', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  return assertApiData(response, '오답 복습 세션을 시작하지 못했습니다.');
+};
+
+/**
+ * 오답 복습 문제 제출/채점
+ */
+export const answerCSWrongReviewQuestion = async (
+  reviewId: string,
+  payload: CSAttemptAnswerRequest,
+): Promise<CSWrongReviewAnswerResponse> => {
+  const response = await apiFetch<CSWrongReviewAnswerResponse>(
+    `/api/cs/wrong-problems/review/${reviewId}/answer`,
+    {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    },
+  );
+  return assertApiData(response, '오답 복습 문제 채점에 실패했습니다.');
+};
+
+/**
+ * 오답 복습 완료/결과 조회
+ */
+export const completeCSWrongReview = async (
+  reviewId: string,
+): Promise<CSWrongReviewCompleteResponse> => {
+  const response = await apiFetch<CSWrongReviewCompleteResponse>(
+    `/api/cs/wrong-problems/review/${reviewId}/complete`,
+    {
+      method: 'POST',
+    },
+  );
+  return assertApiData(response, '오답 복습 결과 조회에 실패했습니다.');
 };

--- a/apps/frontend/src/domains/cs/components/CSWrongNoteList.tsx
+++ b/apps/frontend/src/domains/cs/components/CSWrongNoteList.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  BookX,
+  CheckCircle2,
+  ChevronDown,
+  Clock3,
+  Inbox,
+  Loader2,
+  Play,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+import {
+  CSMyDomainItem,
+  CSWrongProblemItem,
+  CSWrongProblemStatus,
+  fetchCSWrongProblems,
+  fetchMyCSDomains,
+} from '@/domains/cs/api/csApi';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+function formatRelativeDate(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (minutes < 1) return '방금 전';
+  if (minutes < 60) return `${minutes}분 전`;
+  if (hours < 24) return `${hours}시간 전`;
+  if (days < 7) return `${days}일 전`;
+  return new Date(isoString).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+}
+
+interface TabButtonProps {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  count?: number;
+}
+
+function TabButton({ active, onClick, icon, label, count }: TabButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-all duration-200',
+        active
+          ? 'bg-primary text-primary-foreground shadow-sm'
+          : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+      )}
+    >
+      {icon}
+      {label}
+      {count !== undefined && (
+        <span
+          className={cn(
+            'inline-flex h-5 min-w-[20px] items-center justify-center rounded-full px-1.5 text-xs font-bold',
+            active ? 'bg-white/20 text-white' : 'bg-muted-foreground/20 text-muted-foreground',
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function WrongProblemCard({ item }: { item: CSWrongProblemItem }) {
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card p-4 shadow-sm transition-colors hover:border-primary/40">
+      <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="font-semibold">
+          #{item.questionId} · 스테이지 {item.stageNo}
+        </span>
+        <span>·</span>
+        <span className="inline-flex items-center gap-1">
+          <Clock3 className="h-3.5 w-3.5" />
+          {formatRelativeDate(item.lastWrongAt)}
+        </span>
+      </div>
+
+      <p className="mb-3 whitespace-pre-wrap text-sm font-semibold leading-relaxed text-foreground">
+        Q. {item.prompt}
+      </p>
+
+      <div className="rounded-xl bg-muted/50 px-3 py-2 text-sm">
+        <span className="mr-2 font-semibold text-muted-foreground">정답</span>
+        <span className="font-bold text-foreground">{item.correctAnswer || '-'}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function CSWrongNoteList() {
+  const router = useRouter();
+
+  const [myDomains, setMyDomains] = useState<CSMyDomainItem[]>([]);
+  const [selectedDomainId, setSelectedDomainId] = useState<number | null>(null);
+  const [activeTab, setActiveTab] = useState<CSWrongProblemStatus>('ACTIVE');
+  const [items, setItems] = useState<CSWrongProblemItem[]>([]);
+  const [totalElements, setTotalElements] = useState(0);
+  const [isLoadingDomains, setIsLoadingDomains] = useState(true);
+  const [isLoadingItems, setIsLoadingItems] = useState(false);
+  const [domainDropdownOpen, setDomainDropdownOpen] = useState(false);
+
+  useEffect(() => {
+    const loadDomains = async () => {
+      setIsLoadingDomains(true);
+      try {
+        const domains = await fetchMyCSDomains();
+        setMyDomains(domains);
+
+        const currentDomain = domains.find((domain) => domain.isCurrent) ?? domains[0];
+        if (currentDomain) {
+          setSelectedDomainId(currentDomain.domain.id);
+        }
+      } catch (error) {
+        console.error('Failed to load my CS domains:', error);
+        toast.error('도메인 목록을 불러오지 못했습니다.');
+      } finally {
+        setIsLoadingDomains(false);
+      }
+    };
+
+    loadDomains();
+  }, []);
+
+  const loadWrongProblems = useCallback(async () => {
+    if (selectedDomainId === null) return;
+
+    setIsLoadingItems(true);
+    try {
+      const response = await fetchCSWrongProblems(selectedDomainId, activeTab, 0, 20);
+      setItems(response.content);
+      setTotalElements(response.totalElements);
+    } catch (error) {
+      console.error('Failed to load CS wrong problems:', error);
+      toast.error('오답노트를 불러오지 못했습니다.');
+    } finally {
+      setIsLoadingItems(false);
+    }
+  }, [selectedDomainId, activeTab]);
+
+  useEffect(() => {
+    loadWrongProblems();
+  }, [loadWrongProblems]);
+
+  const selectedDomainName =
+    myDomains.find((domain) => domain.domain.id === selectedDomainId)?.domain.name ?? '도메인 선택';
+
+  const handleStartReview = () => {
+    if (!selectedDomainId) {
+      toast.error('먼저 도메인을 선택해주세요.');
+      return;
+    }
+    router.push(`/cs/wrong-notes/review?domainId=${selectedDomainId}`);
+  };
+
+  if (!isLoadingDomains && myDomains.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
+        <BookX className="h-14 w-14 text-muted-foreground/40" />
+        <p className="text-lg font-bold text-muted-foreground">학습 중인 도메인이 없습니다</p>
+        <p className="text-sm text-muted-foreground/70">CS 탭에서 도메인을 선택한 뒤 다시 시도해주세요.</p>
+        <Button className="mt-2" onClick={() => router.push('/cs')}>
+          CS 학습으로 이동
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5 animate-in fade-in duration-300">
+      <div className="relative">
+        <button
+          id="wrong-note-domain-filter"
+          onClick={() => setDomainDropdownOpen((prev) => !prev)}
+          disabled={isLoadingDomains}
+          className={cn(
+            'w-full rounded-2xl border border-border/60 bg-card px-4 py-3 text-left text-sm font-semibold shadow-sm transition-all duration-200',
+            'hover:border-primary/50 hover:shadow-md',
+            domainDropdownOpen && 'border-primary/60 ring-2 ring-primary/20',
+          )}
+        >
+          <span className="flex items-center justify-between gap-2">
+            <span className="truncate text-foreground">
+              {isLoadingDomains ? '도메인 로딩 중...' : selectedDomainName}
+            </span>
+            <ChevronDown
+              className={cn(
+                'h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200',
+                domainDropdownOpen && 'rotate-180',
+              )}
+            />
+          </span>
+        </button>
+
+        {domainDropdownOpen && (
+          <div className="absolute left-0 right-0 top-full z-50 mt-2 overflow-hidden rounded-2xl border border-border/60 bg-card shadow-xl">
+            {myDomains.map((domainItem) => (
+              <button
+                key={domainItem.domain.id}
+                onClick={() => {
+                  setSelectedDomainId(domainItem.domain.id);
+                  setDomainDropdownOpen(false);
+                }}
+                className={cn(
+                  'w-full px-4 py-3 text-left text-sm transition-colors hover:bg-muted',
+                  selectedDomainId === domainItem.domain.id && 'bg-primary/5 font-bold text-primary',
+                )}
+              >
+                <span className="flex items-center gap-2">
+                  <span className="truncate">{domainItem.domain.name}</span>
+                  {domainItem.isCurrent && (
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+                      학습 중
+                    </span>
+                  )}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex gap-2">
+          <TabButton
+            active={activeTab === 'ACTIVE'}
+            onClick={() => setActiveTab('ACTIVE')}
+            icon={<BookX className="h-4 w-4" />}
+            label="복습할 문제"
+            count={activeTab === 'ACTIVE' ? totalElements : undefined}
+          />
+          <TabButton
+            active={activeTab === 'CLEARED'}
+            onClick={() => setActiveTab('CLEARED')}
+            icon={<CheckCircle2 className="h-4 w-4" />}
+            label="복습 완료"
+            count={activeTab === 'CLEARED' ? totalElements : undefined}
+          />
+        </div>
+
+        {activeTab === 'ACTIVE' && (
+          <Button
+            onClick={handleStartReview}
+            disabled={isLoadingItems || totalElements === 0}
+            className="h-10 gap-1.5 rounded-xl font-semibold"
+          >
+            <Play className="h-4 w-4 fill-current" />
+            복습하기
+          </Button>
+        )}
+      </div>
+
+      {isLoadingItems ? (
+        <div className="flex flex-col items-center justify-center gap-3 py-20">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+          <p className="text-sm text-muted-foreground">오답 목록을 불러오는 중...</p>
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState status={activeTab} />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {items.map((item) => (
+            <WrongProblemCard key={item.questionId} item={item} />
+          ))}
+
+          {totalElements > items.length && (
+            <p className="pt-2 text-center text-sm text-muted-foreground">
+              {items.length} / {totalElements}개 표시 중
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ status }: { status: CSWrongProblemStatus }) {
+  if (status === 'ACTIVE') {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/20">
+          <CheckCircle2 className="h-10 w-10 text-emerald-500" />
+        </div>
+        <p className="text-lg font-bold text-foreground">복습할 오답이 없습니다.</p>
+        <p className="text-sm text-muted-foreground">새로운 문제를 풀고 오답이 생기면 이곳에서 복습할 수 있습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+      <div className="flex h-20 w-20 items-center justify-center rounded-full bg-muted">
+        <Inbox className="h-10 w-10 text-muted-foreground/50" />
+      </div>
+      <p className="text-lg font-bold text-muted-foreground">복습 완료 문제가 없습니다.</p>
+      <p className="text-sm text-muted-foreground/70">복습을 완료하면 이 탭에서 확인할 수 있습니다.</p>
+    </div>
+  );
+}

--- a/apps/frontend/src/domains/cs/components/session/CSWrongReviewSession.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSWrongReviewSession.tsx
@@ -1,0 +1,398 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Loader2, X, AlertCircle } from 'lucide-react';
+import { toast } from 'sonner';
+
+import {
+  CSAttemptAnswerRequest,
+  CSQuestionPayload,
+  CSWrongReviewAnswerResponse,
+  CSWrongReviewCompleteResponse,
+  answerCSWrongReviewQuestion,
+  completeCSWrongReview,
+  startCSWrongReview,
+} from '@/domains/cs/api/csApi';
+import CSQuestionPresenter from './CSQuestionPresenter';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+
+interface CSWrongReviewSessionProps {
+  domainId: number | null;
+}
+
+type SessionPhase = 'loading' | 'playing' | 'submitting_complete' | 'empty' | 'error' | 'done';
+
+interface WrongFeedbackContent {
+  answer: string | null;
+  explanation: string | null;
+}
+
+interface AnswerDisplay {
+  number: string | null;
+  text: string;
+}
+
+function parseWrongFeedback(answerResult: CSWrongReviewAnswerResponse): WrongFeedbackContent {
+  const lines = (answerResult.feedback || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const parsedAnswerLine = lines.find((line) => line.startsWith('정답:'));
+  const explanationStartIndex = lines.findIndex((line) => line.startsWith('해설:'));
+
+  const parsedAnswer = parsedAnswerLine?.replace(/^정답:\s*/, '').trim() || null;
+  let parsedExplanation: string | null = null;
+
+  if (explanationStartIndex >= 0) {
+    const firstLine = lines[explanationStartIndex].replace(/^해설:\s*/, '').trim();
+    const remainLines = lines.slice(explanationStartIndex + 1);
+    const merged = [firstLine, ...remainLines].filter(Boolean).join('\n').trim();
+    parsedExplanation = merged || null;
+  }
+
+  return {
+    answer: answerResult.correctAnswer?.trim() || parsedAnswer,
+    explanation: parsedExplanation,
+  };
+}
+
+function splitAnswerText(answer: string): AnswerDisplay {
+  const normalized = answer.trim();
+  const matched = normalized.match(/^(\d+)\.\s*(.+)$/);
+
+  if (!matched) {
+    return { number: null, text: normalized };
+  }
+
+  return {
+    number: matched[1],
+    text: matched[2].trim(),
+  };
+}
+
+export default function CSWrongReviewSession({ domainId }: CSWrongReviewSessionProps) {
+  const router = useRouter();
+
+  const [phase, setPhase] = useState<SessionPhase>('loading');
+  const [reviewId, setReviewId] = useState<string | null>(null);
+  const [currentQuestion, setCurrentQuestion] = useState<CSQuestionPayload | null>(null);
+  const [totalQuestionCount, setTotalQuestionCount] = useState(0);
+  const [progressedCount, setProgressedCount] = useState(0);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showExitAlert, setShowExitAlert] = useState(false);
+  const [answerResult, setAnswerResult] = useState<CSWrongReviewAnswerResponse | null>(null);
+  const [completeResult, setCompleteResult] = useState<CSWrongReviewCompleteResponse | null>(null);
+
+  const initSession = useCallback(async () => {
+    try {
+      setPhase('loading');
+      const started = await startCSWrongReview({
+        domainId: domainId ?? undefined,
+        questionCount: 10,
+      });
+
+      if (!started.reviewId || !started.firstQuestion || started.totalQuestionCount === 0) {
+        setPhase('empty');
+        return;
+      }
+
+      setReviewId(started.reviewId);
+      setCurrentQuestion(started.firstQuestion);
+      setTotalQuestionCount(started.totalQuestionCount);
+      setProgressedCount(0);
+      setPhase('playing');
+    } catch (error) {
+      console.error('Failed to start wrong review session:', error);
+      toast.error('오답 복습 세션을 시작하지 못했습니다.');
+      setPhase('error');
+    }
+  }, [domainId]);
+
+  useEffect(() => {
+    initSession();
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [initSession]);
+
+  const handleAnswerSubmit = async (payload: CSAttemptAnswerRequest) => {
+    if (!reviewId || !currentQuestion) return;
+
+    setIsSubmitting(true);
+    try {
+      const response = await answerCSWrongReviewQuestion(reviewId, payload);
+      setAnswerResult(response);
+    } catch (error) {
+      console.error('Failed to submit wrong review answer:', error);
+      toast.error('답안 제출에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleComplete = async () => {
+    if (!reviewId) return;
+    try {
+      setPhase('submitting_complete');
+      const result = await completeCSWrongReview(reviewId);
+      setCompleteResult(result);
+      setPhase('done');
+    } catch (error) {
+      console.error('Failed to complete wrong review:', error);
+      toast.error('오답 복습 결과 조회에 실패했습니다.');
+      setPhase('error');
+    }
+  };
+
+  const handleNextAfterFeedback = async () => {
+    if (!answerResult) return;
+
+    const { isLast, nextQuestion, progress } = answerResult;
+    setProgressedCount(progress.currentQuestionNo);
+    setAnswerResult(null);
+
+    if (isLast) {
+      await handleComplete();
+    } else if (nextQuestion) {
+      setCurrentQuestion(nextQuestion);
+    }
+  };
+
+  const handleExitConfirm = () => {
+    router.replace('/cs/wrong-notes');
+  };
+
+  if (phase === 'error') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <AlertCircle className="w-12 h-12 text-destructive" />
+        <h2 className="text-xl font-bold">오류가 발생했습니다</h2>
+        <Button onClick={() => router.replace('/cs/wrong-notes')} variant="outline">
+          돌아가기
+        </Button>
+      </div>
+    );
+  }
+
+  if (phase === 'loading') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 animate-pulse">
+        <Loader2 className="w-10 h-10 animate-spin text-primary" />
+        <p className="text-muted-foreground font-medium">복습 세션을 준비하고 있습니다...</p>
+      </div>
+    );
+  }
+
+  if (phase === 'empty') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <AlertCircle className="w-12 h-12 text-muted-foreground/50" />
+        <h2 className="text-xl font-bold">복습할 오답이 없습니다</h2>
+        <Button onClick={() => router.replace('/cs/wrong-notes')} variant="outline">
+          오답노트로 이동
+        </Button>
+      </div>
+    );
+  }
+
+  if (phase === 'submitting_complete') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <Loader2 className="w-10 h-10 animate-spin text-primary" />
+        <p className="text-muted-foreground font-medium animate-pulse">결과를 집계하고 있습니다...</p>
+      </div>
+    );
+  }
+
+  if (phase === 'done' && completeResult) {
+    return (
+      <div className="w-[calc(100%+2rem)] -mx-4 sm:w-full sm:mx-auto flex-1 flex flex-col items-center justify-center sm:max-w-lg py-0 sm:py-12 animate-in fade-in zoom-in px-0 sm:px-4 min-h-[100dvh] sm:min-h-[80vh]">
+        <div className="isolate w-full min-h-[100dvh] sm:min-h-0 border-none shadow-none sm:shadow-xl bg-background/90 sm:bg-background/50 sm:backdrop-blur-xl relative overflow-hidden flex flex-col items-center justify-start sm:justify-center px-6 pt-[max(5.5rem,calc(env(safe-area-inset-top)+3.5rem))] pb-[max(2rem,env(safe-area-inset-bottom))] sm:p-8 text-center rounded-none sm:rounded-3xl">
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-64 bg-gradient-to-b from-primary/25 to-transparent sm:inset-0 sm:h-auto sm:from-primary/10 z-0" />
+          <div className="relative z-10 w-full flex flex-col items-center">
+            <h1 className="text-3xl font-extrabold mb-2 text-foreground tracking-tight">복습 완료</h1>
+            <p className="text-muted-foreground mb-8">
+              정답률 <span className="font-bold text-primary">{completeResult.correctRate}%</span> (
+              {completeResult.correctCount}/{completeResult.totalQuestionCount})
+            </p>
+
+            <div className="w-full bg-muted/60 border border-border rounded-2xl p-4 text-left mb-8">
+              <p className="text-sm">
+                복습 완료 처리: <span className="font-bold">{completeResult.clearedCount}개</span>
+              </p>
+              <p className="text-sm mt-1">
+                아직 복습 필요: <span className="font-bold">{completeResult.remainedActiveCount}개</span>
+              </p>
+            </div>
+
+            <div className="flex flex-col w-full gap-3">
+              <Button className="w-full h-14 text-lg font-bold rounded-2xl" onClick={() => router.replace('/cs/wrong-notes')}>
+                오답노트로 돌아가기
+              </Button>
+              <Button
+                variant="outline"
+                className="w-full h-14 text-lg font-bold rounded-2xl"
+                onClick={() => router.replace(`/cs/wrong-notes/review?domainId=${domainId ?? ''}`)}
+              >
+                다시 복습하기
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col w-full animate-in fade-in relative min-h-[80vh] pb-28">
+      <header className="flex items-center justify-between py-4 px-6 bg-background/80 backdrop-blur-md sticky top-0 z-50 border-b border-border/50">
+        <div className="flex flex-col">
+          <span className="text-sm font-semibold text-muted-foreground">오답 복습</span>
+          {phase === 'playing' && totalQuestionCount > 0 && (
+            <div className="flex items-center gap-3">
+              <h1 className="text-lg font-bold">
+                진행도: {progressedCount} / {totalQuestionCount}
+              </h1>
+            </div>
+          )}
+        </div>
+        <button
+          onClick={() => setShowExitAlert(true)}
+          className="p-2 bg-muted hover:bg-muted/80 rounded-full transition-colors group"
+        >
+          <X className="w-6 h-6 text-muted-foreground group-hover:text-foreground transition-colors" />
+        </button>
+      </header>
+
+      <main className="flex-1 flex flex-col justify-center items-center p-4">
+        {phase === 'playing' && currentQuestion && (
+          <CSQuestionPresenter
+            key={currentQuestion.questionId}
+            question={currentQuestion}
+            onSubmit={handleAnswerSubmit}
+            isSubmitting={isSubmitting}
+          />
+        )}
+      </main>
+
+      <AlertDialog open={showExitAlert} onOpenChange={setShowExitAlert}>
+        <AlertDialogContent className="rounded-2xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertCircle className="w-5 h-5 text-destructive" />
+              복습을 중단하시겠습니까?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              지금 나가시면 현재까지의 복습 진행 상황이 사라집니다.
+              <br />
+              다음에 다시 들어오면 처음부터 시작해야 합니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="gap-2 sm:gap-0 mt-2">
+            <AlertDialogCancel className="rounded-xl">계속 풀기</AlertDialogCancel>
+            <AlertDialogAction
+              className="rounded-xl bg-destructive hover:bg-destructive/90 text-destructive-foreground"
+              onClick={handleExitConfirm}
+            >
+              나가기
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {answerResult && (
+        <div className="fixed inset-0 z-[100] flex animate-in fade-in bg-black/40 items-end sm:items-center justify-center p-0 sm:p-4 pointer-events-auto">
+          {(() => {
+            const wrongFeedback = !answerResult.isCorrect ? parseWrongFeedback(answerResult) : null;
+            const answerDisplay = wrongFeedback?.answer ? splitAnswerText(wrongFeedback.answer) : null;
+            return (
+              <div
+                className={`w-full sm:max-w-lg p-6 sm:p-8 flex flex-col gap-4 shadow-2xl rounded-t-3xl sm:rounded-2xl ${
+                  answerResult.isCorrect ? 'bg-emerald-50' : 'bg-gradient-to-b from-rose-50 to-red-50'
+                } animate-in slide-in-from-bottom sm:slide-in-from-bottom-8 duration-300 pointer-events-auto`}
+              >
+                <div className="flex flex-col gap-2">
+                  <h2
+                    className={`text-2xl font-black tracking-tight ${
+                      answerResult.isCorrect ? 'text-emerald-600' : 'text-red-500'
+                    }`}
+                  >
+                    {answerResult.isCorrect ? '정답입니다!' : '틀렸습니다.'}
+                  </h2>
+                  {!answerResult.isCorrect && (
+                    <div className="mt-2 flex flex-col gap-3">
+                      {wrongFeedback?.answer && (
+                        <div className="rounded-xl border-l-4 border-l-red-500 bg-white px-4 pt-2 pb-5 shadow-sm">
+                          <span className="inline-flex rounded-full bg-red-500 px-2.5 py-1 text-xs font-bold text-white">
+                            정답
+                          </span>
+                          {answerDisplay?.number ? (
+                            <div className="mt-3 flex items-end gap-2">
+                              <span className="text-4xl font-black leading-none text-red-600">
+                                {answerDisplay.number}.
+                              </span>
+                              <span className="pb-0.5 text-2xl font-extrabold leading-tight text-red-600">
+                                {answerDisplay.text}
+                              </span>
+                            </div>
+                          ) : (
+                            <p className="mt-3 text-2xl font-extrabold leading-tight text-red-600">
+                              {wrongFeedback.answer}
+                            </p>
+                          )}
+                        </div>
+                      )}
+
+                      {wrongFeedback?.explanation && (
+                        <div className="rounded-xl border-l-4 border-l-slate-300 bg-slate-50/90 px-4 pt-2 pb-4 shadow-sm">
+                          <span className="inline-flex rounded-full bg-slate-200 px-2.5 py-1 text-xs font-bold text-slate-700">
+                            해설
+                          </span>
+                          <p className="mt-3 whitespace-pre-wrap text-[15px] leading-8 text-slate-700">
+                            {wrongFeedback.explanation}
+                          </p>
+                        </div>
+                      )}
+
+                      {!wrongFeedback?.answer && !wrongFeedback?.explanation && answerResult.feedback && (
+                        <div className="rounded-xl border-l-4 border-l-slate-300 bg-slate-50/90 px-4 py-4 shadow-sm">
+                          <p className="whitespace-pre-wrap text-[15px] leading-8 text-slate-700">
+                            {answerResult.feedback}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+                <Button
+                  onClick={handleNextAfterFeedback}
+                  className={`w-full h-14 mt-4 font-bold text-lg rounded-xl shadow-sm hover:shadow-md transition-all ${
+                    answerResult.isCorrect ? 'bg-green-500 hover:bg-green-600' : 'bg-red-500 hover:bg-red-600'
+                  } text-white`}
+                >
+                  계속하기
+                </Button>
+              </div>
+            );
+          })()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
+++ b/apps/frontend/src/domains/lnb/components/MobileBottomNav.tsx
@@ -20,7 +20,9 @@ export default function MobileBottomNav() {
     return pathname.startsWith(href);
   };
 
-  const isHiddenRoute = pathname.startsWith('/cs/stage/');
+  const isHiddenRoute =
+    pathname.startsWith('/cs/stage/') ||
+    pathname.startsWith('/cs/wrong-notes/review');
 
   if (isHiddenRoute) {
     return null;
@@ -58,3 +60,4 @@ export default function MobileBottomNav() {
     </div>
   );
 }
+

--- a/apps/frontend/src/domains/lnb/components/Sidebar.tsx
+++ b/apps/frontend/src/domains/lnb/components/Sidebar.tsx
@@ -34,7 +34,9 @@ const Sidebar = ({ user }: SidebarProps) => {
 
   const { openModal, isOpen } = useSettingsStore();
 
-  const isHiddenRoute = pathname.startsWith('/cs/stage/');
+  const isHiddenRoute =
+    pathname.startsWith('/cs/stage/') ||
+    pathname.startsWith('/cs/wrong-notes/review');
 
   if (isHiddenRoute) {
     return null;
@@ -69,3 +71,4 @@ const Sidebar = ({ user }: SidebarProps) => {
 };
 
 export default Sidebar;
+


### PR DESCRIPTION
## 💡 의도 / 배경
- 기존 오답노트가 실제 복습 플로우로 이어지지 않아 학습 효율이 떨어지는 문제가 있었습니다.
- 오답 목록 확인 → 복습 시작 → 제출/결과 확인까지 한 흐름으로 동작하도록 개선했습니다.

## 🛠️ 작업 내용
- [x] 오답 목록/복습완료 목록 조회 API 연동 및 오답노트 UI 구성
- [x] 오답 목록 카드에 `문제 + 정답` 나열 형태로 표시
- [x] 개별 재도전 버튼 제거, 상단 `복습하기` 버튼으로 진입 방식 통일
- [x] 오답 복습 전용 세션 페이지 구현 (`start/answer/complete` API 연동)
- [x] 복습 화면 UI를 기존 문제풀이 화면과 동일한 톤(헤더/모달/피드백)으로 통일
- [x] `/cs/wrong-notes/review` 경로에서 사이드바/모바일 하단바 숨김 처리
- [x] 오답 목록 DTO에서 `wrongCount`, `reviewCorrectCount` 제거 (프론트 미사용 필드 정리)

## 🔗 관련 이슈
- Closes #149
- Related #139

## 🖼️ 스크린샷 (선택)
<img width="1202" height="1076" alt="image" src="https://github.com/user-attachments/assets/36a3fbdd-7ea0-4d44-80db-dccec1f30dd9" />


## 🧪 테스트 방법
- [x] 백엔드: `.\gradlew.bat test --tests com.peekle.domain.cs.service.CsWrongProblemServiceIntegrationTest`
- [x] 백엔드: `.\gradlew.bat test --tests com.peekle.domain.cs.service.CsAttemptFlowIntegrationTest.sameQuestionWrongAgain_updatesSingleWrongProblem`
- [x] 프론트: `pnpm --filter frontend type-check`
- [x] 수동 확인:
  - `/cs/wrong-notes`에서 목록 렌더링/탭 전환
  - `복습하기` 클릭 시 `/cs/wrong-notes/review` 진입
  - 복습 중 정오답 피드백 및 완료 결과 확인
  - 복습 경로에서 사이드바 비노출 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- 오답 복습 UX를 기존 스테이지 풀이 UX와 맞추는 데 집중했습니다.
- `wrongCount`는 내부 로직에는 남아있고, 목록 응답 DTO/프론트 노출에서는 제거했습니다.