### PR TITLE
feat: 프로필에 cs 공부 단계 표기하기 추가

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/user/dto/UserCsProgressDto.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/dto/UserCsProgressDto.java
@@ -1,0 +1,6 @@
+package com.peekle.domain.user.dto;
+
+public record UserCsProgressDto(
+        String domainName,
+        Integer trackNo
+) {}

--- a/apps/backend/src/main/java/com/peekle/domain/user/dto/UserProfileResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/dto/UserProfileResponse.java
@@ -2,6 +2,7 @@ package com.peekle.domain.user.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import java.util.List;
 
 @Getter
 @Builder
@@ -18,6 +19,8 @@ public class UserProfileResponse {
     private Integer streakMax;
     private Long solvedCount;
     private boolean me;
+    // CS Learning Status
+    private List<UserCsProgressDto> csProgressList;
     // TODO: 활동 스트릭 넣기
 
     // TODO: 오늘의 학습 타임라인넣기

--- a/apps/backend/src/main/java/com/peekle/domain/user/service/UserService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/service/UserService.java
@@ -29,6 +29,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.Optional;
+
+import com.peekle.domain.cs.entity.CsUserDomainProgress;
+import com.peekle.domain.cs.entity.CsUserProfile;
+import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
+import com.peekle.domain.cs.repository.CsUserProfileRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +44,8 @@ public class UserService {
     private final SubmissionLogRepository submissionLogRepository;
     private final com.peekle.global.storage.R2StorageService r2StorageService;
     private final LeagueService leagueService;
+    private final CsUserProfileRepository csUserProfileRepository;
+    private final CsUserDomainProgressRepository csUserDomainProgressRepository;
     private final RestTemplate restTemplate = new RestTemplate();
 
     @Transactional
@@ -111,7 +119,18 @@ public class UserService {
 
         boolean isMe = currentUserId != null && currentUserId.equals(userId);
 
-        // 4. DTO 반환
+        // 4. CS 상태 조회
+        List<com.peekle.domain.cs.entity.CsUserDomainProgress> progressList = 
+            csUserDomainProgressRepository.findByUser_Id(userId);
+            
+        List<com.peekle.domain.user.dto.UserCsProgressDto> csProgressDtoList = progressList.stream()
+            .map(p -> new com.peekle.domain.user.dto.UserCsProgressDto(
+                p.getDomain().getName(),
+                (int) p.getCurrentTrackNo()
+            ))
+            .toList();
+
+        // 5. DTO 반환
         return UserProfileResponse.builder()
                 .id(user.getId())
                 .nickname(user.getNickname())
@@ -125,6 +144,7 @@ public class UserService {
                 .streakMax(user.getStreakMax())
                 .solvedCount(solvedCount)
                 .me(isMe)
+                .csProgressList(csProgressDtoList)
                 .build();
     }
 

--- a/apps/frontend/src/app/(main)/cs/wrong-problems/review/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/wrong-problems/review/page.tsx
@@ -1,0 +1,19 @@
+import CSWrongReviewSession from '@/domains/cs/components/session/CSWrongReviewSession';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '오답 복습 | CS 학습 - Peekle',
+  description: '오답 문제를 다시 풀며 복습합니다.',
+};
+
+interface CSWrongReviewPageProps {
+  searchParams: Promise<{ domainId?: string }>;
+}
+
+export default async function CSWrongReviewPage({ searchParams }: CSWrongReviewPageProps) {
+  const { domainId: rawDomainId } = await searchParams;
+  const parsedDomainId = rawDomainId ? Number(rawDomainId) : NaN;
+  const domainId = Number.isFinite(parsedDomainId) ? parsedDomainId : null;
+
+  return <CSWrongReviewSession domainId={domainId} />;
+}

--- a/apps/frontend/src/domains/profile/actions/profile.ts
+++ b/apps/frontend/src/domains/profile/actions/profile.ts
@@ -55,6 +55,7 @@ export async function getMyProfile(): Promise<UserProfile> {
       profileImg: data.profileImg || undefined,
       solvedCount: Number(data.solvedCount),
       isMe: data.me,
+      csProgressList: data.csProgressList,
     };
   } catch (e) {
     console.error('Failed to fetch profile:', e);
@@ -128,6 +129,7 @@ export async function getUserProfile(nickname: string): Promise<UserProfile | nu
       profileImgThumb: data.profileImgThumb || undefined,
       solvedCount: Number(data.solvedCount),
       isMe: data.me,
+      csProgressList: data.csProgressList,
     };
   } catch (e: any) {
     if (e.message && e.message.includes('404')) {

--- a/apps/frontend/src/domains/profile/components/CCProfileCSStatus.tsx
+++ b/apps/frontend/src/domains/profile/components/CCProfileCSStatus.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React from 'react';
+import { UserProfile } from '../types';
+import { BookX, GraduationCap, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  user: UserProfile;
+}
+
+export function CCProfileCSStatus({ user }: Props) {
+  const router = useRouter();
+  const hasLearningDomains = user.csProgressList && user.csProgressList.length > 0;
+
+  return (
+    <div className="mt-6 p-5 rounded-2xl bg-gradient-to-br from-primary/5 to-primary/10 border border-primary/20 transition-all duration-300 hover:shadow-md hover:shadow-primary/5 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+      <div>
+        <h3 className="text-sm font-bold text-primary flex items-center gap-2 mb-3">
+          <GraduationCap className="w-4 h-4" />
+          현재 CS 학습 상태
+        </h3>
+        
+        {hasLearningDomains ? (
+          <div className="flex flex-wrap gap-2">
+            {user.csProgressList!.map((progress, index) => (
+              <div 
+                key={index} 
+                className="flex items-center gap-2 bg-card border border-border px-3 py-2 rounded-xl shadow-sm"
+              >
+                <span className="text-sm font-bold text-foreground tracking-tight">
+                  {progress.domainName}
+                </span>
+                <span className="text-[11px] px-2 py-0.5 rounded-full bg-primary/15 text-primary font-bold whitespace-nowrap">
+                  레벨 {progress.trackNo}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div>
+            <div className="flex items-center gap-2 mt-1">
+              <BookX className="w-5 h-5 text-muted-foreground" />
+              <span className="text-sm font-semibold text-muted-foreground">
+                아직 시작한 CS 도메인이 없습니다
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground/70 mt-1">
+              {user.isMe ? 'CS 지식을 쌓고 약점을 보완해보세요!' : `${user.nickname}님은 아직 CS 학습 기록이 없습니다.`}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {!hasLearningDomains && user.isMe && (
+        <Button
+          onClick={() => router.push('/cs')}
+          className="w-full sm:w-auto rounded-xl h-10 px-5 font-bold shadow-sm shrink-0"
+        >
+          CS 학습 시작하기
+          <ChevronRight className="w-4 h-4 ml-1 opacity-70" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/domains/profile/components/CCProfileView.tsx
+++ b/apps/frontend/src/domains/profile/components/CCProfileView.tsx
@@ -6,6 +6,7 @@ import { useExtensionCheck } from '@/hooks/useExtensionCheck';
 import { UserProfile, ExtensionStatus } from '../types';
 import { CCProfileHeader } from './CCProfileHeader';
 import { CCProfileStatsRow } from './CCProfileStatsRow';
+import { CCProfileCSStatus } from './CCProfileCSStatus';
 import {
   checkNickname as checkNicknameApi,
   checkBojId as checkBojIdApi,
@@ -525,6 +526,9 @@ export function CCProfileView({ user, isMe, initialStreak, initialTimeline, init
           accept=".jpg,.jpeg,.png,.webp"
           onChange={handleFileChange}
         />
+
+        {/* 2. CS Learning Status */}
+        <CCProfileCSStatus user={optimisticUser} />
 
         {/* 3. Stats Row */}
         <CCProfileStatsRow user={optimisticUser} />

--- a/apps/frontend/src/domains/profile/types.ts
+++ b/apps/frontend/src/domains/profile/types.ts
@@ -11,6 +11,7 @@ export interface UserProfile {
   profileImgThumb?: string;
   solvedCount: number;
   isMe?: boolean;
+  csProgressList?: { domainName: string; trackNo: number }[];
 }
 
 export interface SubmissionHistory {


### PR DESCRIPTION
## 💡 의도 / 배경
- 현재 프로필에서 사용자의 CS 학습 진행 상태(어떤 도메인을 공부 중인지, 어느 레벨인지)를 확인할 수 없어 학습 맥락 인지 및 학습 동기 부여가 떨어지는 문제가 있었습니다.
- 본인뿐만 아니라 타인의 프로필 방문 시에도 해당 유저가 어떤 CS 지식을 어느 정도 학습하고 있는지 종합적으로 파악할 수 있도록 프로필 화면에 CS 학습 상태 영역을 추가했습니다.

## 🛠️ 작업 내용
- [x] **백엔드**: `UserProfileResponse` 에 사용자가 학습 중인 전체 CS 도메인 진행 상태를 반환하도록 `csProgressList` (List<UserCsProgressDto>) 필드 추가
- [x] **백엔드**: `UserService` 프로필 조회 로직에서 `CsUserDomainProgressRepository`를 통해 해당 유저의 모든 학습 중인 도메인 데이터를 매핑하여 응답에 포함
- [x] **프론트엔드**: 프로필 조회 응답 객체 변경 리플렉션 적용 (`types.ts`, `actions/profile.ts`)
- [x] **프론트엔드**: 프로필 컴포넌트 내 CS 학습 상태 영역 UI 구현 (`CCProfileCSStatus.tsx`)
  - 학습 중인 경우: 학습 중인 모든 도메인과 각 레벨을 칩(배지) 형태로 나열
  - 학습 내역이 없는 경우: 빈 상태 UI 렌더링
  - 본인 프로필 && 학습 내역이 없는 경우에 한정하여 "CS 학습 시작하기" CTA 버튼 제공

## 🔗 관련 이슈
- Closes #153
- Relates #139

## 🖼️ 스크린샷 (선택)
<img width="1001" height="465" alt="image" src="https://github.com/user-attachments/assets/bc6a00aa-b8fc-4461-a4da-05574be5fa61" />

## 🧪 테스트 방법
- [x] 로컬 서버 실행 후, 본인의 프로필(`/profile/me`)로 진입하여 CS 학습 탭 진행 상황(도메인 목록 및 레벨 배지)이 잘 뜨는지 확인합니다.
- [x] 만약 CS 학습을 시작하지 않았다면, 빈 화면 문구와 "CS 학습 시작하기" 버튼이 정상적으로 노출되는지 확인합니다.
- [x] 다른 사용자(타인)의 프로필로 이동했을 때, 타인의 학습 상태가 올바르게 렌더링되며, 빈 경우 "CS 학습 시작하기" 버튼이 숨김 처리(안 보임) 상태인지 확인합니다.

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)