### PR TITLE
feat: ai추천로직 변경

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/ai/controller/RecommendationController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/ai/controller/RecommendationController.java
@@ -1,7 +1,7 @@
 package com.peekle.domain.ai.controller;
 
 import com.peekle.domain.ai.dto.request.FeedbackRequest;
-import com.peekle.domain.ai.dto.response.RecommendationResponse.RecommendedProblem;
+import com.peekle.domain.ai.dto.response.DailyRecommendationResponse;
 import com.peekle.domain.ai.enums.RecommendationFeedbackType;
 import com.peekle.domain.ai.service.RecommendationService;
 import com.peekle.global.dto.ApiResponse;
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/recommendations")
@@ -24,17 +22,28 @@ public class RecommendationController {
     /**
      * 오늘의 추천 문제 조회
      * GET /api/recommendations/daily
-     * 
-     * 1. Redis에 있으면 그거 리턴
-     * 2. 없으면 AI 서버에 요청해서 생성 후 리턴
+     *
+     * 1. 기존 추천 3문제가 남아있고 미해결 상태면 재사용
+     * 2. 3문제 모두 해결했거나 추천이 비어있으면 새 추천 생성 시도
      */
     @GetMapping("/daily")
-    public ApiResponse<List<RecommendedProblem>> getDailyRecommendations(@AuthenticationPrincipal Long userId) {
+    public ApiResponse<DailyRecommendationResponse> getDailyRecommendations(@AuthenticationPrincipal Long userId) {
         log.info("추천 문제 요청 - userId: {}", userId);
-        
-        List<RecommendedProblem> recommendations = recommendationService.getOrGenerateRecommendations(userId);
-        
-        return ApiResponse.success(recommendations);
+
+        DailyRecommendationResponse response = recommendationService.getDailyRecommendations(userId);
+        return ApiResponse.success(response);
+    }
+
+    /**
+     * 수동 새로고침
+     * POST /api/recommendations/refresh
+     */
+    @PostMapping("/refresh")
+    public ApiResponse<DailyRecommendationResponse> refreshRecommendations(@AuthenticationPrincipal Long userId) {
+        log.info("추천 문제 수동 새로고침 요청 - userId: {}", userId);
+
+        DailyRecommendationResponse response = recommendationService.refreshRecommendationsManually(userId);
+        return ApiResponse.success(response);
     }
 
     /**

--- a/apps/backend/src/main/java/com/peekle/domain/ai/dto/response/DailyRecommendationResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/ai/dto/response/DailyRecommendationResponse.java
@@ -1,0 +1,14 @@
+package com.peekle.domain.ai.dto.response;
+
+import com.peekle.domain.ai.dto.response.RecommendationResponse.RecommendedProblem;
+import com.peekle.domain.ai.enums.RecommendationRefreshType;
+
+import java.util.List;
+
+public record DailyRecommendationResponse(
+        List<RecommendedProblem> recommendations,
+        RecommendationRefreshType refreshType,
+        String notice,
+        Integer manualRefreshRemaining
+) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/ai/enums/RecommendationRefreshType.java
+++ b/apps/backend/src/main/java/com/peekle/domain/ai/enums/RecommendationRefreshType.java
@@ -1,0 +1,12 @@
+package com.peekle.domain.ai.enums;
+
+public enum RecommendationRefreshType {
+    REUSED,
+    INITIAL_REFRESHED,
+    AUTO_REFRESHED,
+    MANUAL_REFRESHED,
+    INITIAL_REFRESH_FAILED,
+    AUTO_REFRESH_FAILED,
+    MANUAL_REFRESH_FAILED,
+    MANUAL_LIMIT_EXCEEDED
+}

--- a/apps/backend/src/main/java/com/peekle/domain/ai/service/RecommendationService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/ai/service/RecommendationService.java
@@ -4,11 +4,13 @@ import com.peekle.domain.ai.dto.request.TagStatDto;
 import com.peekle.domain.ai.dto.request.UserActivityRequest;
 import com.peekle.domain.ai.dto.request.CandidateProblemDto;
 import com.peekle.domain.ai.dto.response.AiApiResponse;
+import com.peekle.domain.ai.dto.response.DailyRecommendationResponse;
 import com.peekle.domain.ai.dto.response.RecommendationResponse;
 import com.peekle.domain.ai.dto.response.RecommendationResponse.RecommendedProblem;
 import com.peekle.domain.ai.entity.RecommendFeedback;
 import com.peekle.domain.ai.entity.RecommendProblem;
 import com.peekle.domain.ai.enums.RecommendationFeedbackType;
+import com.peekle.domain.ai.enums.RecommendationRefreshType;
 import com.peekle.domain.ai.repository.RecommendFeedbackRepository;
 import com.peekle.domain.ai.repository.RecommendProblemRepository;
 import com.peekle.domain.problem.entity.Problem;
@@ -30,6 +32,7 @@ import com.peekle.global.util.SolvedAcLevelUtil;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -64,7 +67,7 @@ public class RecommendationService {
     private static final int RELAXED_COOLDOWN_DAYS = 1;
     private static final int SOLVED_ALL_DELTA_X10 = 5;
     private static final int SOLVED_TWO_DELTA_X10 = 3;
-    private static final int SOLVED_ZERO_OR_ONE_DELTA_X10 = -2;
+    private static final int SOLVED_NONE_DELTA_X10 = -1;
     private static final int FEEDBACK_TOO_EASY_DELTA_X10 = 3;
     private static final int FEEDBACK_TOO_HARD_DELTA_X10 = -3;
     private static final double DIFFICULTY_WEIGHT = 35.0;
@@ -79,6 +82,8 @@ public class RecommendationService {
     private static final double POPULARITY_NORMALIZER = Math.log1p(1_000_000);
     private static final int MAX_LOW_FREQ_CENTERED_IN_SET = 1;
     private static final int MIN_POSITIVE_PRACTICALITY_COUNT = 2;
+    private static final int MANUAL_REFRESH_DAILY_LIMIT = 2;
+    private static final int DAILY_RESET_HOUR = 6;
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private enum PracticalTagCategory {
@@ -158,43 +163,234 @@ public class RecommendationService {
 
     @Transactional
     public List<RecommendedProblem> getOrGenerateRecommendations(Long userId) {
-        log.info("추천 로직 시작 - userId: {}", userId);
-        LocalDate today = LocalDate.now(KST);
+        return getDailyRecommendations(userId).recommendations();
+    }
+
+    @Transactional
+    public DailyRecommendationResponse getDailyRecommendations(Long userId) {
         User user = userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
-        applyPendingFeedbackIfNeeded(user, today);
+        List<RecommendProblem> currentRows = loadCurrentRecommendationRows(userId);
+        int manualRefreshRemaining = getManualRefreshRemaining(user);
+
+        if (hasCompleteRecommendationSet(currentRows) && !areAllRecommendationsSolved(currentRows)) {
+            log.info("추천 재사용 - userId={} refreshType=REUSED solvedCount={}", userId, countSolved(currentRows));
+            return buildResponseFromRows(
+                    currentRows,
+                    RecommendationRefreshType.REUSED,
+                    null,
+                    manualRefreshRemaining
+            );
+        }
+
+        RecommendationRefreshTrigger trigger = areAllRecommendationsSolved(currentRows)
+                ? RecommendationRefreshTrigger.AUTO
+                : RecommendationRefreshTrigger.INITIAL;
+        return refreshAndBuildResponse(user, currentRows, trigger, manualRefreshRemaining);
+    }
+
+    @Transactional
+    public DailyRecommendationResponse refreshRecommendationsManually(Long userId) {
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        List<RecommendProblem> currentRows = loadCurrentRecommendationRows(userId);
+
+        LocalDate policyDate = currentManualRefreshPolicyDate();
+        int usedCount = resolveManualRefreshUsedCount(user, policyDate);
+        if (usedCount >= MANUAL_REFRESH_DAILY_LIMIT) {
+            log.info("추천 수동 새로고침 한도 초과 - userId={} policyDate={} usedCount={}", userId, policyDate, usedCount);
+            return buildResponseFromRows(
+                    currentRows,
+                    RecommendationRefreshType.MANUAL_LIMIT_EXCEEDED,
+                    "수동 새로고침은 오전 6시 기준 하루 최대 2회까지 가능합니다.",
+                    0
+            );
+        }
+
+        int nextUsedCount = usedCount + 1;
+        user.updateManualRecRefresh(policyDate, nextUsedCount);
+        int manualRefreshRemaining = Math.max(0, MANUAL_REFRESH_DAILY_LIMIT - nextUsedCount);
+
+        log.info("추천 수동 새로고침 시작 - userId={} policyDate={} usedCount={} remaining={}", userId, policyDate, nextUsedCount, manualRefreshRemaining);
+        return refreshAndBuildResponse(user, currentRows, RecommendationRefreshTrigger.MANUAL, manualRefreshRemaining);
+    }
+
+    private DailyRecommendationResponse refreshAndBuildResponse(
+            User user,
+            List<RecommendProblem> currentRows,
+            RecommendationRefreshTrigger trigger,
+            int manualRefreshRemaining
+    ) {
+        Long userId = user.getId();
+        LocalDate today = LocalDate.now(KST);
 
         try {
-            List<RecommendedProblem> todayFromDb = loadTodayRecommendations(user, today);
-            if (!todayFromDb.isEmpty()) {
-                return todayFromDb;
-            }
-
             UserActivityRequest userActivity = fetchUserActivity(userId);
-            // DB에 오늘 추천이 부족하면 AI 서버 호출
-            RecommendationResponse response = callAiServer(user, today, userActivity);
-
-            if (response == null || response.recommendations().isEmpty()) {
-                log.warn("AI 서버에서 추천 결과를 받지 못했습니다. user: {}", userId);
-                return List.of();
+            RecommendationResponse response = callAiServer(userActivity);
+            if (response == null || response.recommendations() == null || response.recommendations().isEmpty()) {
+                log.warn("추천 갱신 실패(빈 응답) - userId={} trigger={}", userId, trigger);
+                return buildResponseFromRows(
+                        currentRows,
+                        failureTypeFor(trigger),
+                        failureNoticeFor(trigger, currentRows),
+                        manualRefreshRemaining
+                );
             }
 
-            if (response.recommendations().isEmpty()) {
-                log.warn("시도한 문제 제외 후 남은 추천이 없습니다. user: {}", userId);
-                return List.of();
+            boolean saved = saveCurrentRecommendations(user, response.recommendations(), today);
+            if (!saved) {
+                log.warn("추천 갱신 실패(저장 불가) - userId={} trigger={}", userId, trigger);
+                return buildResponseFromRows(
+                        currentRows,
+                        failureTypeFor(trigger),
+                        failureNoticeFor(trigger, currentRows),
+                        manualRefreshRemaining
+                );
+            }
+            if (trigger != RecommendationRefreshTrigger.MANUAL) {
+                applyPendingFeedbackIfNeeded(user, currentRows);
+            } else {
+                log.info("수동 새로고침은 추천 난이도 보정을 적용하지 않습니다. userId={}", userId);
+            }
+            List<RecommendProblem> refreshedRows = loadCurrentRecommendationRows(userId);
+            if (refreshedRows.isEmpty()) {
+                log.warn("추천 갱신 실패(저장 후 비어 있음) - userId={} trigger={}", userId, trigger);
+                return buildResponseFromRows(
+                        currentRows,
+                        failureTypeFor(trigger),
+                        failureNoticeFor(trigger, currentRows),
+                        manualRefreshRemaining
+                );
             }
 
-            saveTodayRecommendations(user, response.recommendations(), today);
-            return loadTodayRecommendations(user, today);
-
+            log.info(
+                    "추천 갱신 성공 - userId={} trigger={} recommendationCount={} solvedCount(before)={}",
+                    userId,
+                    trigger,
+                    refreshedRows.size(),
+                    countSolved(currentRows)
+            );
+            return buildResponseFromRows(
+                    refreshedRows,
+                    successTypeFor(trigger),
+                    successNoticeFor(trigger),
+                    manualRefreshRemaining
+            );
         } catch (Exception e) {
-            log.error("추천 로직 수행 중 오류 발생: {}", e.getMessage());
-            return List.of();
+            log.error("추천 갱신 실패(예외) - userId={} trigger={} reason={}", userId, trigger, e.getMessage(), e);
+            return buildResponseFromRows(
+                    currentRows,
+                    failureTypeFor(trigger),
+                    failureNoticeFor(trigger, currentRows),
+                    manualRefreshRemaining
+            );
         }
     }
 
-    private RecommendationResponse callAiServer(User user, LocalDate today, UserActivityRequest request) {
+    private DailyRecommendationResponse buildResponseFromRows(
+            List<RecommendProblem> rows,
+            RecommendationRefreshType refreshType,
+            String notice,
+            int manualRefreshRemaining
+    ) {
+        List<RecommendedProblem> recommendations = rows.stream()
+                .limit(TARGET_RECOMMENDATION_COUNT)
+                .map(this::mapFromRecommendProblem)
+                .toList();
+        return new DailyRecommendationResponse(
+                recommendations,
+                refreshType,
+                notice,
+                manualRefreshRemaining
+        );
+    }
+
+    private RecommendationRefreshType successTypeFor(RecommendationRefreshTrigger trigger) {
+        return switch (trigger) {
+            case INITIAL -> RecommendationRefreshType.INITIAL_REFRESHED;
+            case AUTO -> RecommendationRefreshType.AUTO_REFRESHED;
+            case MANUAL -> RecommendationRefreshType.MANUAL_REFRESHED;
+        };
+    }
+
+    private RecommendationRefreshType failureTypeFor(RecommendationRefreshTrigger trigger) {
+        return switch (trigger) {
+            case INITIAL -> RecommendationRefreshType.INITIAL_REFRESH_FAILED;
+            case AUTO -> RecommendationRefreshType.AUTO_REFRESH_FAILED;
+            case MANUAL -> RecommendationRefreshType.MANUAL_REFRESH_FAILED;
+        };
+    }
+
+    private String successNoticeFor(RecommendationRefreshTrigger trigger) {
+        if (trigger == RecommendationRefreshTrigger.MANUAL) {
+            return "추천 문제를 새로고침했어요.";
+        }
+        return null;
+    }
+
+    private String failureNoticeFor(RecommendationRefreshTrigger trigger, List<RecommendProblem> currentRows) {
+        if (trigger == RecommendationRefreshTrigger.MANUAL || trigger == RecommendationRefreshTrigger.AUTO) {
+            if (!currentRows.isEmpty()) {
+                return "AI 재추천에 실패해 기존 추천 목록을 유지했어요.";
+            }
+        }
+        if (currentRows.isEmpty()) {
+            return "AI 추천 생성에 실패했어요. 잠시 후 다시 시도해주세요.";
+        }
+        return "AI 재추천에 실패해 기존 추천 목록을 유지했어요.";
+    }
+
+    private List<RecommendProblem> loadCurrentRecommendationRows(Long userId) {
+        return recommendProblemRepository.findAllByUserIdOrderByOrderIndexAsc(userId).stream()
+                .limit(TARGET_RECOMMENDATION_COUNT)
+                .toList();
+    }
+
+    private boolean hasCompleteRecommendationSet(List<RecommendProblem> rows) {
+        return rows.size() >= TARGET_RECOMMENDATION_COUNT;
+    }
+
+    private boolean areAllRecommendationsSolved(List<RecommendProblem> rows) {
+        if (!hasCompleteRecommendationSet(rows)) {
+            return false;
+        }
+        return rows.stream()
+                .limit(TARGET_RECOMMENDATION_COUNT)
+                .allMatch(row -> Boolean.TRUE.equals(row.getSolved()));
+    }
+
+    private long countSolved(List<RecommendProblem> rows) {
+        return rows.stream()
+                .limit(TARGET_RECOMMENDATION_COUNT)
+                .filter(row -> Boolean.TRUE.equals(row.getSolved()))
+                .count();
+    }
+
+    private int getManualRefreshRemaining(User user) {
+        LocalDate policyDate = currentManualRefreshPolicyDate();
+        int usedCount = resolveManualRefreshUsedCount(user, policyDate);
+        return Math.max(0, MANUAL_REFRESH_DAILY_LIMIT - usedCount);
+    }
+
+    private int resolveManualRefreshUsedCount(User user, LocalDate policyDate) {
+        if (user.getManualRecRefreshDate() == null || !policyDate.equals(user.getManualRecRefreshDate())) {
+            return 0;
+        }
+        Integer count = user.getManualRecRefreshCount();
+        return count == null ? 0 : Math.max(0, count);
+    }
+
+    private LocalDate currentManualRefreshPolicyDate() {
+        ZonedDateTime now = ZonedDateTime.now(KST);
+        LocalDate policyDate = now.toLocalDate();
+        if (now.getHour() < DAILY_RESET_HOUR) {
+            return policyDate.minusDays(1);
+        }
+        return policyDate;
+    }
+
+    private RecommendationResponse callAiServer(UserActivityRequest request) {
         List<CandidateProblemDto> candidates = request.candidateProblems() == null
                 ? List.of()
                 : request.candidateProblems();
@@ -218,7 +414,8 @@ public class RecommendationService {
                 aiRecommendations = aiResponse.recommendations();
             }
         } catch (Exception e) {
-            log.warn("AI 서버 응답 실패. score 기반 폴백으로 전환합니다. reason={}", e.getMessage());
+            log.warn("AI 서버 응답 실패로 추천 갱신을 중단합니다. reason={}", e.getMessage());
+            return new RecommendationResponse(List.of());
         }
 
         List<CandidateProblemDto> rankedCandidates = candidates.stream()
@@ -324,21 +521,30 @@ public class RecommendationService {
         return new RecommendationResponse(mapped);
     }
 
-    private void applyPendingFeedbackIfNeeded(User user, LocalDate today) {
+    private enum RecommendationRefreshTrigger {
+        INITIAL,
+        AUTO,
+        MANUAL
+    }
+
+    private void applyPendingFeedbackIfNeeded(User user, List<RecommendProblem> currentRows) {
         Long userId = user.getId();
-        LocalDate latestRecommendationDate = user.getLastRecommendedDate();
-        if (latestRecommendationDate == null || !latestRecommendationDate.isBefore(today)) {
+        if (currentRows == null || currentRows.isEmpty()) {
             return;
         }
 
-        long solvedCount = recommendProblemRepository.countByUserIdAndSolvedTrue(userId);
+        long solvedCount = currentRows.stream()
+                .filter(row -> Boolean.TRUE.equals(row.getSolved()))
+                .count();
         int solveDeltaX10;
         if (solvedCount >= 3) {
             solveDeltaX10 = SOLVED_ALL_DELTA_X10;
         } else if (solvedCount == 2) {
             solveDeltaX10 = SOLVED_TWO_DELTA_X10;
+        } else if (solvedCount == 0) {
+            solveDeltaX10 = SOLVED_NONE_DELTA_X10;
         } else {
-            solveDeltaX10 = SOLVED_ZERO_OR_ONE_DELTA_X10;
+            solveDeltaX10 = 0;
         }
 
         List<RecommendFeedback> feedbacks = recommendFeedbackRepository.findAllByUserId(userId);
@@ -352,8 +558,8 @@ public class RecommendationService {
             int nextLevel = sanitizeRecLevelX10(user.getRecLevelX10() + totalDeltaX10);
             user.updateRecLevelX10(nextLevel);
             log.info(
-                    "추천 난이도 보정 적용 userId={} date={} solvedCount={} solveDeltaX10={} feedbackDeltaX10={} totalDeltaX10={} nextRecLevelX10={}",
-                    userId, latestRecommendationDate, solvedCount, solveDeltaX10, feedbackDeltaX10, totalDeltaX10, nextLevel
+                    "추천 난이도 보정 적용 userId={} solvedCount={} solveDeltaX10={} feedbackDeltaX10={} totalDeltaX10={} nextRecLevelX10={}",
+                    userId, solvedCount, solveDeltaX10, feedbackDeltaX10, totalDeltaX10, nextLevel
             );
         }
 
@@ -543,23 +749,7 @@ public class RecommendationService {
         };
     }
 
-    private List<RecommendedProblem> loadTodayRecommendations(User user, LocalDate today) {
-        if (!today.equals(user.getLastRecommendedDate())) {
-            return List.of();
-        }
-
-        List<RecommendProblem> todayRows = recommendProblemRepository.findAllByUserIdOrderByOrderIndexAsc(user.getId());
-        if (todayRows.isEmpty()) {
-            return List.of();
-        }
-
-        List<RecommendedProblem> mapped = todayRows.stream()
-                .map(this::mapFromRecommendProblem)
-                .toList();
-        return mapped;
-    }
-
-    private void saveTodayRecommendations(User user, List<RecommendedProblem> recommendations, LocalDate today) {
+    private boolean saveCurrentRecommendations(User user, List<RecommendedProblem> recommendations, LocalDate today) {
         Long userId = user.getId();
         List<RecommendedProblem> limitedRecommendations = recommendations.stream()
                 .limit(TARGET_RECOMMENDATION_COUNT)
@@ -601,6 +791,11 @@ public class RecommendationService {
             usedOrders.add(index);
         }
 
+        if (upsertRows.isEmpty()) {
+            log.warn("저장 가능한 추천 문제가 없어 기존 목록을 유지합니다. userId={} requestedCount={}", userId, limitedRecommendations.size());
+            return false;
+        }
+
         List<RecommendProblem> toDelete = existingRows.stream()
                 .filter(row -> row.getOrderIndex() == null || !usedOrders.contains(row.getOrderIndex()))
                 .toList();
@@ -612,6 +807,8 @@ public class RecommendationService {
             user.updateLastRecommendedDate(today);
             recommendProblemRepository.saveAll(upsertRows);
         }
+
+        return true;
     }
 
     private RecommendedProblem mapFromRecommendProblem(RecommendProblem recommendProblem) {

--- a/apps/backend/src/main/java/com/peekle/domain/user/entity/User.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/entity/User.java
@@ -58,6 +58,7 @@ public class User extends BaseTimeEntity {
         this.profileImgThumb = defaultImg;
         this.profileImgType = ProfileImgType.DEFAULT;
         this.maxLeague = LeagueTier.STONE;
+        this.manualRecRefreshCount = 0;
     }
 
     private String generateDefaultProfileImg(String nickname) {
@@ -117,6 +118,13 @@ public class User extends BaseTimeEntity {
     @Column(name = "last_recommended_date")
     private java.time.LocalDate lastRecommendedDate;
 
+    @Builder.Default
+    @Column(name = "manual_rec_refresh_count", nullable = false)
+    private Integer manualRecRefreshCount = 0;
+
+    @Column(name = "manual_rec_refresh_date")
+    private java.time.LocalDate manualRecRefreshDate;
+
     public void updateStreak(boolean increment, java.time.LocalDate streakDate) {
         if (increment) {
             this.streakCurrent++;
@@ -152,6 +160,11 @@ public class User extends BaseTimeEntity {
 
     public void updateLastRecommendedDate(java.time.LocalDate date) {
         this.lastRecommendedDate = date;
+    }
+
+    public void updateManualRecRefresh(java.time.LocalDate policyDate, int usedCount) {
+        this.manualRecRefreshDate = policyDate;
+        this.manualRecRefreshCount = Math.max(0, usedCount);
     }
 
     public void updateProfile(String nickname, String bojId, String profileImg, String profileImgThumb) {

--- a/apps/backend/src/main/resources/db/migration-postgres/V7__add_manual_refresh_limit_columns.sql
+++ b/apps/backend/src/main/resources/db/migration-postgres/V7__add_manual_refresh_limit_columns.sql
@@ -1,0 +1,14 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS manual_rec_refresh_count INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS manual_rec_refresh_date DATE;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_users_manual_rec_refresh_count'
+    ) THEN
+        ALTER TABLE users
+            ADD CONSTRAINT chk_users_manual_rec_refresh_count
+            CHECK (manual_rec_refresh_count >= 0);
+    END IF;
+END $$;

--- a/apps/frontend/src/api/userServerApi.ts
+++ b/apps/frontend/src/api/userServerApi.ts
@@ -43,10 +43,16 @@ export async function getTimelineServer(
 }
 
 export async function getAIRecommendationsServer(): Promise<AIRecommendationData[]> {
-  const data = await fetchServer<any[]>('/api/recommendations/daily');
+  const data = await fetchServer<any>('/api/recommendations/daily');
   if (!data) return [];
 
-  return data.map((item: any) => ({
+  const list = Array.isArray(data)
+    ? data
+    : Array.isArray(data.recommendations)
+      ? data.recommendations
+      : [];
+
+  return list.map((item: any) => ({
     problemId: `#${item.id}`,
     title: item.title,
     tier: item.tierType ? item.tierType.toLowerCase() : 'bronze',

--- a/apps/frontend/src/domains/home/components/AIRecommendation.tsx
+++ b/apps/frontend/src/domains/home/components/AIRecommendation.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { Sparkles, ExternalLink, Plus, Loader2, MessageCircle, ThumbsUp, ThumbsDown, Check } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Sparkles, ExternalLink, Plus, Loader2, MessageCircle, ThumbsUp, ThumbsDown, Check, RotateCcw } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useAIRecommendations } from '../hooks/useDashboardData';
 import { BOJ_TIER_NAMES, BOJ_TIER_COLORS } from '../mocks/dashboardMocks';
@@ -28,19 +28,114 @@ interface AIRecommendationProps {
   initialData?: AIRecommendationData[];
 }
 
+type RecommendationRefreshPayload = {
+  recommendations?: Array<{
+    id: string;
+    title: string;
+    tierType: string;
+    tierLevel: number;
+    tags: string[];
+    reason: string;
+    solved: boolean;
+  }>;
+  refreshType?: string;
+  notice?: string | null;
+  manualRefreshRemaining?: number | null;
+};
+
+const mapRecommendationItem = (item: any): AIRecommendationData => ({
+  problemId: `#${item.id}`,
+  title: item.title,
+  tier: item.tierType ? item.tierType.toLowerCase() : 'bronze',
+  tierLevel: item.tierLevel || 1,
+  tags: item.tags || [],
+  reason: item.reason || 'AI 추천 문제',
+  solved: !!item.solved,
+});
+
+const parseRefreshPayload = (raw: any) => {
+  if (Array.isArray(raw)) {
+    return {
+      recommendations: raw,
+      refreshType: null as string | null,
+      notice: null as string | null,
+      manualRefreshRemaining: null as number | null,
+    };
+  }
+
+  const payload: RecommendationRefreshPayload = raw || {};
+  return {
+    recommendations: Array.isArray(payload.recommendations) ? payload.recommendations : [],
+    refreshType: payload.refreshType ?? null,
+    notice: payload.notice ?? null,
+    manualRefreshRemaining:
+      typeof payload.manualRefreshRemaining === 'number' ? payload.manualRefreshRemaining : null,
+  };
+};
+
+const isFailureRefreshType = (refreshType: string | null) =>
+  refreshType === 'AUTO_REFRESH_FAILED' ||
+  refreshType === 'MANUAL_REFRESH_FAILED' ||
+  refreshType === 'INITIAL_REFRESH_FAILED' ||
+  refreshType === 'MANUAL_LIMIT_EXCEEDED';
+
 const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
   const router = useRouter();
   const isMobile = useIsMobile();
   const hasInitialData = Array.isArray(initialData) && initialData.length > 0;
   const [refreshKey, setRefreshKey] = useState(0);
-  const { data: fetchedData, isLoading } = useAIRecommendations({
+  const { data: fetchedData, isLoading, meta } = useAIRecommendations({
     skip: hasInitialData,
     refreshKey,
   });
-  const data = hasInitialData ? initialData : fetchedData || [];
+  const [data, setData] = useState<AIRecommendationData[]>(hasInitialData ? initialData || [] : []);
+  const [manualRefreshRemaining, setManualRefreshRemaining] = useState<number | null>(null);
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+  const latestNoticeKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!hasInitialData) {
+      return;
+    }
+    setData(initialData || []);
+  }, [hasInitialData, initialData]);
+
+  useEffect(() => {
+    if (hasInitialData) {
+      return;
+    }
+    setData(fetchedData || []);
+  }, [fetchedData, hasInitialData]);
+
+  useEffect(() => {
+    if (meta.manualRefreshRemaining === null) {
+      return;
+    }
+    setManualRefreshRemaining(meta.manualRefreshRemaining);
+  }, [meta.manualRefreshRemaining]);
+
+  useEffect(() => {
+    if (!meta.notice) {
+      return;
+    }
+
+    const noticeKey = `${meta.refreshType ?? 'UNKNOWN'}:${meta.notice}`;
+    if (latestNoticeKeyRef.current === noticeKey) {
+      return;
+    }
+    latestNoticeKeyRef.current = noticeKey;
+
+    if (isFailureRefreshType(meta.refreshType)) {
+      toast.error(meta.notice);
+      return;
+    }
+    if (meta.refreshType === 'MANUAL_REFRESHED') {
+      toast.success(meta.notice);
+    }
+  }, [meta.notice, meta.refreshType]);
 
   // 로딩 중이거나 초기 데이터가 없는 경우의 처리
-  const showLoading = !hasInitialData && isLoading;
+  const showLoading = !hasInitialData && isLoading && data.length === 0;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedProblem, setSelectedProblem] = useState<{ id: string; title: string } | null>(
@@ -98,6 +193,43 @@ const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
   const handleRetry = () => {
     setCanRetry(false);
     setRefreshKey(Date.now());
+  };
+
+  const handleManualRefresh = async () => {
+    setIsManualRefreshing(true);
+
+    try {
+      const response = await apiFetch<any>('/api/recommendations/refresh', {
+        method: 'POST',
+      });
+
+      if (!response.success || !response.data) {
+        toast.error(response.error?.message || '추천 새로고침에 실패했습니다.');
+        return;
+      }
+
+      const payload = parseRefreshPayload(response.data);
+      setData(payload.recommendations.map(mapRecommendationItem));
+      if (payload.manualRefreshRemaining !== null) {
+        setManualRefreshRemaining(payload.manualRefreshRemaining);
+      }
+      if (payload.notice) {
+        if (isFailureRefreshType(payload.refreshType)) {
+          toast.error(payload.notice);
+        } else if (payload.refreshType === 'MANUAL_REFRESHED') {
+          toast.success(payload.notice);
+        }
+      }
+      if (payload.refreshType === 'MANUAL_REFRESHED') {
+        setCurrentFeedback(null);
+        setShowFeedbackOptions(false);
+      }
+    } catch (e) {
+      console.error('Failed to refresh recommendations manually:', e);
+      toast.error('추천 새로고침 중 오류가 발생했습니다.');
+    } finally {
+      setIsManualRefreshing(false);
+    }
   };
 
   const handleOpenModal = (id: string, title: string) => {
@@ -253,16 +385,38 @@ const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
   return (
     <div className="bg-card border border-border rounded-2xl p-6 h-full transition-colors duration-300">
       {/* 헤더 */}
-      <div className="flex items-center gap-2">
-        <Sparkles className="w-5 h-5 text-primary" />
-        <div>
-          <h3 className="font-bold text-foreground">AI 추천 문제</h3>
-          <p className="text-xs text-muted-foreground">나에게 맞는 문제 추천</p>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-5 h-5 text-primary" />
+          <div>
+            <h3 className="font-bold text-foreground">AI 추천 문제</h3>
+            <p className="text-xs text-muted-foreground">나에게 맞는 문제 추천</p>
+          </div>
         </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 text-xs gap-1.5"
+          onClick={handleManualRefresh}
+          disabled={showLoading || isManualRefreshing}
+        >
+          {isManualRefreshing ? (
+            <Loader2 className="w-3 h-3 animate-spin" />
+          ) : (
+            <RotateCcw className="w-3 h-3" />
+          )}
+          새로고침
+          {manualRefreshRemaining !== null ? ` (${manualRefreshRemaining}/2)` : ''}
+        </Button>
       </div>
+      {manualRefreshRemaining !== null && (
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          수동 새로고침은 오전 6시 기준으로 하루 2회까지 가능해요.
+        </p>
+      )}
 
       {/* 추천 문제 목록 */}
-      <div className="space-y-4 h-full flex flex-col justify-center">
+      <div className="space-y-4 mt-4">
         {showLoading ? (
           <div className="flex flex-col items-center justify-center py-10 gap-3">
             <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -400,7 +554,7 @@ const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
             </div>
           ) : currentFeedback && !showFeedbackOptions ? (
-            <div className="flex items-center justify-between">
+            <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-2">
                 <Check className="w-4 h-4 text-green-500" />
                 <span className="text-sm text-muted-foreground">
@@ -431,7 +585,7 @@ const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
                 <MessageCircle className="w-4 h-4 text-muted-foreground" />
                 <span className="text-sm text-muted-foreground">오늘 추천 난이도는 어땠나요?</span>
               </div>
-              <div className="flex gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
                 {FEEDBACK_OPTIONS.map((option) => {
                   const Icon = option.icon;
                   const isSelected = currentFeedback === option.type;
@@ -441,7 +595,7 @@ const AIRecommendation = ({ initialData }: AIRecommendationProps) => {
                       variant="outline"
                       size="sm"
                       disabled={isFeedbackSubmitting}
-                      className={`flex-1 h-9 text-xs gap-1.5 transition-all ${
+                      className={`w-full h-9 text-xs gap-1.5 transition-all ${
                         isSelected ? `${option.bgColor} ${option.color} font-semibold` : 'border-border'
                       }`}
                       onClick={() => handleSubmitFeedback(option.type)}

--- a/apps/frontend/src/domains/home/hooks/useDashboardData.ts
+++ b/apps/frontend/src/domains/home/hooks/useDashboardData.ts
@@ -150,13 +150,77 @@ export const useTimeline = (
   return { data, isLoading };
 };
 
+type RecommendationProblemDto = {
+  id: string;
+  title: string;
+  tierType: string;
+  tierLevel: number;
+  tags: string[];
+  reason: string;
+  solved: boolean;
+};
+
+type RecommendationPayloadDto = {
+  recommendations?: RecommendationProblemDto[];
+  refreshType?: string;
+  notice?: string | null;
+  manualRefreshRemaining?: number | null;
+};
+
+export type AIRecommendationMeta = {
+  refreshType: string | null;
+  notice: string | null;
+  manualRefreshRemaining: number | null;
+};
+
+const mapRecommendationProblem = (item: any): AIRecommendationData => ({
+  problemId: `#${item.id}`,
+  title: item.title,
+  tier: item.tierType ? item.tierType.toLowerCase() : 'bronze',
+  tierLevel: item.tierLevel || 1,
+  tags: item.tags || [],
+  reason: item.reason || 'AI 추천 문제',
+  solved: !!item.solved,
+});
+
+const normalizeRecommendationPayload = (
+  raw: any,
+): { recommendations: RecommendationProblemDto[]; meta: AIRecommendationMeta } => {
+  if (Array.isArray(raw)) {
+    return {
+      recommendations: raw,
+      meta: {
+        refreshType: null,
+        notice: null,
+        manualRefreshRemaining: null,
+      },
+    };
+  }
+
+  const payload: RecommendationPayloadDto = raw || {};
+  return {
+    recommendations: Array.isArray(payload.recommendations) ? payload.recommendations : [],
+    meta: {
+      refreshType: payload.refreshType ?? null,
+      notice: payload.notice ?? null,
+      manualRefreshRemaining:
+        typeof payload.manualRefreshRemaining === 'number' ? payload.manualRefreshRemaining : null,
+    },
+  };
+};
+
 // AI 추천 문제 데이터 (토큰 인증 & 데이터 매핑 적용)
 export const useAIRecommendations = (options?: {
   skip?: boolean;
   refreshKey?: number;
-}): { data: AIRecommendationData[]; isLoading: boolean } => {
+}): { data: AIRecommendationData[]; isLoading: boolean; meta: AIRecommendationMeta } => {
   const [data, setData] = useState<AIRecommendationData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [meta, setMeta] = useState<AIRecommendationMeta>({
+    refreshType: null,
+    notice: null,
+    manualRefreshRemaining: null,
+  });
 
   useEffect(() => {
     if (options?.skip) {
@@ -169,29 +233,33 @@ export const useAIRecommendations = (options?: {
         setIsLoading(true);
 
         // apiFetch를 사용하면 Authorization 헤더가 자동으로 붙습니다.
-        const response = await apiFetch<any[]>('/api/recommendations/daily');
+        const response = await apiFetch<any>('/api/recommendations/daily');
 
         if (response.success && response.data) {
-          const list = response.data;
-
-          const mappedData: AIRecommendationData[] = list.map((item: any) => ({
-            problemId: `#${item.id}`,
-            title: item.title,
-            tier: item.tierType ? item.tierType.toLowerCase() : 'bronze',
-            tierLevel: item.tierLevel || 1,
-            tags: item.tags || [],
-            reason: item.reason || 'AI 추천 문제',
-            solved: !!item.solved,
-          }));
+          const normalized = normalizeRecommendationPayload(response.data);
+          const mappedData: AIRecommendationData[] = normalized.recommendations.map(
+            mapRecommendationProblem,
+          );
 
           setData(mappedData);
+          setMeta(normalized.meta);
         } else {
           console.warn('AI Recommendation API failed:', response.error);
           setData([]);
+          setMeta({
+            refreshType: null,
+            notice: response.error?.message || null,
+            manualRefreshRemaining: null,
+          });
         }
       } catch (e) {
         console.error('Failed to fetch AI recommendations:', e);
         setData([]);
+        setMeta({
+          refreshType: null,
+          notice: 'AI 추천을 불러오지 못했어요. 잠시 후 다시 시도해주세요.',
+          manualRefreshRemaining: null,
+        });
       } finally {
         setIsLoading(false);
       }
@@ -200,7 +268,7 @@ export const useAIRecommendations = (options?: {
     fetchData();
   }, [options?.skip, options?.refreshKey]);
 
-  return { data, isLoading };
+  return { data, isLoading, meta };
 };
 
 // 주간 점수 데이터


### PR DESCRIPTION
## 💡 의도 / 배경
기존 AI 추천이 페이지 재진입/새로고침 시 불필요하게 재생성되어 토큰 사용량이 증가하고, 추천 일관성이 떨어지는 문제가 있었습니다.  
추천 세트를 안정적으로 재사용하고, 필요한 경우에만 갱신되도록 정책을 명확히 적용했습니다.

## 🛠️ 작업 내용
- [x] 추천 갱신 정책 변경
- [x] 기존 추천 3문제 중 미해결이 있으면 재추천 없이 재사용
- [x] 추천 3문제 모두 해결 시에만 자동 재추천
- [x] 수동 새로고침 API 추가 (`POST /api/recommendations/refresh`)
- [x] 수동 새로고침 일 2회 제한 적용 (KST 오전 6시 기준)
- [x] 수동 한도 초과 시 AI 호출 없이 안내 메시지 반환
- [x] AI 재추천 실패 시 기존 추천 목록 유지 + 실패 안내 노출
- [x] 응답 메타 추가 (`refreshType`, `notice`, `manualRefreshRemaining`)
- [x] 자동/수동/실패/한도초과 로그 구분
- [x] 사용자 수동 새로고침 카운트 저장 컬럼 및 마이그레이션 추가
- [x] 프론트 AI 추천 카드에 수동 새로고침 버튼/남은 횟수 표시
- [x] 모바일에서 난이도 평가 버튼이 화면 밖으로 나가던 레이아웃 이슈 수정
- [x] 난이도 보정 규칙 조정
- [x] 수동 새로고침 시 난이도 보정 제외
- [x] 미해결 패널티 완화: 0문제 해결 시만 `-1`, 1문제 해결 시 `0`

## 🔗 관련 이슈
- Closes #151

## 🖼️ 스크린샷 (선택)
<img width="398" height="1053" alt="image" src="https://github.com/user-attachments/assets/1c77368d-8474-4a03-9713-aceeeb769938" />


## 🧪 테스트 방법
- [x] 백엔드 컴파일: `./gradlew.bat compileJava`
- [x] 프론트 빌드: `pnpm --filter frontend build`
- [x] 시나리오 확인
- [x] 미해결 추천 존재 시 `/api/recommendations/daily` 재조회해도 추천 세트 유지
- [x] 3문제 모두 solved 상태에서 `/api/recommendations/daily` 호출 시 자동 재추천
- [x] `/api/recommendations/refresh` 2회까지 성공, 3회째 `MANUAL_LIMIT_EXCEEDED` 확인
- [x] AI 실패 케이스에서 기존 추천 유지 및 실패 notice 확인
- [x] 수동 새로고침 후 `recLevelX10` 보정 미적용 확인
- [x] solvedCount=0일 때만 `-1` 보정, solvedCount=1일 때 0 보정 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
추천 정책이 서버 중심으로 고정되어 있어 클라이언트 재렌더/재진입 영향 없이 동일하게 동작합니다.  
특히 `MANUAL_LIMIT_EXCEEDED`, `*_REFRESH_FAILED` 분기에서 기존 추천 유지가 핵심이므로 해당 응답 메타/로그 위주로 확인 부탁드립니다.