### PR TITLE
feat: 랜딩페이지 개선

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { Users, Gamepad2, Trophy, Target, ArrowRight, Code2, Zap } from 'lucide-react';
+import { Users, Gamepad2, Trophy, Target, ArrowRight, Code2, Zap, BookOpen } from 'lucide-react';
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://peekle.today';
 
 export const metadata: Metadata = {
@@ -39,6 +39,14 @@ export const metadata: Metadata = {
     description: '실시간 스터디, 게임 모드, AI 추천으로 알고리즘 학습을 더 재미있게.',
   },
 };
+
+type LandingStat = {
+  num: string;
+  label: string;
+};
+
+// NOTE: 랜딩 통계는 검증된 데이터 소스가 연결된 경우에만 채워야 합니다.
+const VERIFIED_LANDING_STATS: LandingStat[] = [];
 
 export default function Home() {
   const websiteJsonLd = {
@@ -109,7 +117,7 @@ export default function Home() {
               <p className="text-[#6B7280] text-lg">알고리즘 학습의 새로운 방법을 제시합니다</p>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
               {[
                 {
                   icon: Users,
@@ -131,6 +139,11 @@ export default function Home() {
                   title: 'AI 문제 추천',
                   desc: '나에게 딱 맞는 문제를 AI가 추천해드려요',
                 },
+                {
+                  icon: BookOpen,
+                  title: 'CS 학습',
+                  desc: '자료구조, 네트워크, 운영체제 등 CS 핵심 개념을 학습하세요.',
+                },
               ].map((item, idx) => (
                 // 카드: bg-card (#FFFFFF), border-card-border (#F7E8F0) 사용
                 <div
@@ -150,22 +163,21 @@ export default function Home() {
         </section>
 
         {/* --- 통계 섹션 --- */}
-        <section className="py-24 border-t border-border bg-background">
-          <div className="max-w-5xl mx-auto flex flex-col md:flex-row justify-between items-center gap-12 text-center px-4">
-            {[
-              { num: '10,000+', label: '활성 사용자' },
-              { num: '500,000+', label: '문제 풀이 수' },
-              { num: '5,000+', label: '스터디 방' },
-            ].map((stat, idx) => (
-              <div key={idx} className="flex flex-col items-center w-full">
-                <span className="text-4xl md:text-5xl font-extrabold text-primary mb-2">
-                  {stat.num}
-                </span>
-                <span className="text-[#6B7280] font-medium tracking-wide">{stat.label}</span>
-              </div>
-            ))}
-          </div>
-        </section>
+        {VERIFIED_LANDING_STATS.length > 0 && (
+          <section className="py-24 border-t border-border bg-background">
+            <div className="max-w-5xl mx-auto flex flex-col md:flex-row justify-between items-center gap-12 text-center px-4">
+              {VERIFIED_LANDING_STATS.map((stat, idx) => (
+                <div key={idx} className="flex flex-col items-center w-full">
+                  <span className="text-4xl md:text-5xl font-extrabold text-primary mb-2">
+                    {stat.num}
+                  </span>
+                  <span className="text-[#6B7280] font-medium tracking-wide">{stat.label}</span>
+                </div>
+              ))
+              }
+            </div>
+          </section>
+        )}
 
         {/* --- 하단 CTA (핑크 배경) --- */}
         <section className="bg-primary py-32 text-center px-4 relative overflow-hidden">


### PR DESCRIPTION
## 💡 의도 / 배경
랜딩페이지에 검증되지 않은 통계 수치가 노출되어 신뢰도 이슈가 있어, 해당 정보를 제거하고 검증된 데이터만 노출 가능한 구조로 정리했습니다.  
추가로 랜딩 핵심 기능 소개에 `CS 학습` 영역을 포함해 현재 서비스 방향을 반영했습니다.

## 🛠️ 작업 내용
- [x] 랜딩 KPI 하드코딩 수치(`10,000+`, `500,000+`, `5,000+`) 제거
- [x] 검증된 통계가 없을 때 통계 섹션 자체 비노출 처리
- [x] 특징 카드에 `CS 학습` 추가 (`자료구조/네트워크/운영체제` 학습 문구)
- [x] 특징 카드 레이아웃을 `lg:grid-cols-5`로 조정

## 🔗 관련 이슈
- Closes #152

## 🖼️ 스크린샷 (선택)
<img width="1647" height="1078" alt="image" src="https://github.com/user-attachments/assets/de9c3b09-be8a-4c78-940d-1ee87e387637" />


## 🧪 테스트 방법
- [x] `pnpm -C apps/frontend exec tsc --noEmit` 실행
- [x] 랜딩페이지 수동 확인
- [x] 통계 섹션 비노출 확인 (검증 데이터 없음 기준)
- [x] `CS 학습` 카드 노출 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
랜딩 통계는 `VERIFIED_LANDING_STATS`가 채워졌을 때만 렌더링되도록 변경했습니다.  
실제 지표 연동 시 해당 값만 주입하면 바로 노출 가능합니다.