### PR TITLE
feat: ide에 기본 언어 추가

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/auth/dto/SignupRequest.java
+++ b/apps/backend/src/main/java/com/peekle/domain/auth/dto/SignupRequest.java
@@ -7,6 +7,7 @@ public record SignupRequest(
         @NotBlank String token,
         @NotBlank String nickname,
         String bojId,
+        String preferredLanguage,
         PreferredRecTier preferredRecTier
 ) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/auth/service/AuthService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/auth/service/AuthService.java
@@ -27,6 +27,7 @@ public class AuthService {
     @Transactional
     public User signup(String socialId, String provider, SignupRequest request) {
         User user = new User(socialId, provider, request.nickname());
+        user.updatePreferredLanguage(normalizePreferredLanguage(request.preferredLanguage()));
         user.updateRecLevelX10(resolveInitialRecLevelX10(request.preferredRecTier()));
         if (request.bojId() != null && !request.bojId().isBlank()) {
             user.registerBojId(request.bojId());
@@ -47,5 +48,30 @@ public class AuthService {
             case PLATINUM -> 180;
             case BRONZE -> 30;
         };
+    }
+
+    private String normalizePreferredLanguage(String preferredLanguage) {
+        if (preferredLanguage == null || preferredLanguage.isBlank()) {
+            return "python";
+        }
+
+        String normalized = preferredLanguage.trim().toLowerCase();
+        if (normalized.contains("python") || normalized.contains("pypy")) {
+            return "python";
+        }
+        if (normalized.contains("java") && !normalized.contains("script")) {
+            return "java";
+        }
+        if (normalized.contains("c++") || normalized.contains("cpp")) {
+            return "cpp";
+        }
+        if (normalized.equals("c")
+                || normalized.startsWith("c ")
+                || normalized.contains("clang")
+                || normalized.contains("c11")
+                || normalized.contains("gnu11")) {
+            return "cpp";
+        }
+        return "python";
     }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/execution/service/ExecutionService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/execution/service/ExecutionService.java
@@ -59,14 +59,20 @@ public class ExecutionService {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         // Language
-        String lang = request.getLanguage();
+        String lang = request.getLanguage() == null ? "" : request.getLanguage().trim().toLowerCase();
         // Convert language names to match TIO standard identifiers
         if ("python".equals(lang) || "python3".equals(lang))
             lang = "python3";
-        else if ("java".equals(lang))
+        else if (lang.contains("java") && !lang.contains("script"))
             lang = "java-openjdk";
-        else if ("cpp".equals(lang))
+        else if ("c".equals(lang)
+                || lang.contains("clang")
+                || lang.contains("c11")
+                || lang.contains("cpp")
+                || lang.contains("c++"))
             lang = "cpp-gcc";
+        else
+            lang = "python3";
 
         baos.write(("Vlang\0" + "1\0" + lang + "\0").getBytes(StandardCharsets.UTF_8));
 

--- a/apps/backend/src/main/java/com/peekle/domain/study/service/RedisIdeService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/study/service/RedisIdeService.java
@@ -155,7 +155,12 @@ public class RedisIdeService {
         if (normalized.contains("java") && !normalized.contains("script")) {
             return "java";
         }
-        if (normalized.contains("cpp") || normalized.contains("c++")) {
+        if (normalized.equals("c")
+                || normalized.contains("clang")
+                || normalized.contains("c11")
+                || normalized.contains("gnu11")
+                || normalized.contains("cpp")
+                || normalized.contains("c++")) {
             return "cpp";
         }
         return "python";

--- a/apps/backend/src/main/java/com/peekle/domain/user/dto/UserProfileResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/dto/UserProfileResponse.java
@@ -15,6 +15,7 @@ public class UserProfileResponse {
     private Integer rank;
     private String profileImg;
     private String profileImgThumb;
+    private String preferredLanguage;
     private Integer streakCurrent;
     private Integer streakMax;
     private Long solvedCount;

--- a/apps/backend/src/main/java/com/peekle/domain/user/dto/UserUpdateRequest.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/dto/UserUpdateRequest.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 public class UserUpdateRequest {
     private String nickname;
     private String bojId;
+    private String preferredLanguage;
     private String profileImg;
     private String profileImgThumb;
     private Boolean isProfileImageDeleted;

--- a/apps/backend/src/main/java/com/peekle/domain/user/entity/User.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/entity/User.java
@@ -59,6 +59,7 @@ public class User extends BaseTimeEntity {
         this.profileImgType = ProfileImgType.DEFAULT;
         this.maxLeague = LeagueTier.STONE;
         this.manualRecRefreshCount = 0;
+        this.preferredLanguage = "python";
     }
 
     private String generateDefaultProfileImg(String nickname) {
@@ -125,6 +126,10 @@ public class User extends BaseTimeEntity {
     @Column(name = "manual_rec_refresh_date")
     private java.time.LocalDate manualRecRefreshDate;
 
+    @Builder.Default
+    @Column(name = "preferred_language", nullable = false, length = 20)
+    private String preferredLanguage = "python";
+
     public void updateStreak(boolean increment, java.time.LocalDate streakDate) {
         if (increment) {
             this.streakCurrent++;
@@ -165,6 +170,10 @@ public class User extends BaseTimeEntity {
     public void updateManualRecRefresh(java.time.LocalDate policyDate, int usedCount) {
         this.manualRecRefreshDate = policyDate;
         this.manualRecRefreshCount = Math.max(0, usedCount);
+    }
+
+    public void updatePreferredLanguage(String preferredLanguage) {
+        this.preferredLanguage = preferredLanguage;
     }
 
     public void updateProfile(String nickname, String bojId, String profileImg, String profileImgThumb) {
@@ -233,6 +242,9 @@ public class User extends BaseTimeEntity {
     protected void prePersist() {
         if (this.recLevelX10 == null) {
             this.recLevelX10 = 30;
+        }
+        if (this.preferredLanguage == null || this.preferredLanguage.isBlank()) {
+            this.preferredLanguage = "python";
         }
     }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/user/service/UserService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/user/service/UserService.java
@@ -140,6 +140,7 @@ public class UserService {
                 .rank((int) rank)
                 .profileImg(user.getProfileImg())
                 .profileImgThumb(user.getProfileImgThumb())
+                .preferredLanguage(user.getPreferredLanguage())
                 .streakCurrent(user.getStreakCurrent())
                 .streakMax(user.getStreakMax())
                 .solvedCount(solvedCount)
@@ -168,6 +169,7 @@ public class UserService {
         info.put("bojId", user.getBojId());
         info.put("league", user.getLeague().name());
         info.put("leaguePoint", user.getLeaguePoint());
+        info.put("preferredLanguage", user.getPreferredLanguage());
         return info;
     }
 
@@ -463,6 +465,37 @@ public class UserService {
                     null,
                     null);
         }
+
+        String normalizedPreferredLanguage = normalizePreferredLanguage(request.getPreferredLanguage());
+        if (normalizedPreferredLanguage != null) {
+            user.updatePreferredLanguage(normalizedPreferredLanguage);
+        }
+    }
+
+    private String normalizePreferredLanguage(String preferredLanguage) {
+        if (preferredLanguage == null || preferredLanguage.isBlank()) {
+            return null;
+        }
+
+        String normalized = preferredLanguage.trim().toLowerCase();
+        if (normalized.contains("python") || normalized.contains("pypy")) {
+            return "python";
+        }
+        if (normalized.contains("java") && !normalized.contains("script")) {
+            return "java";
+        }
+        if (normalized.contains("c++") || normalized.contains("cpp")) {
+            return "cpp";
+        }
+        if (normalized.equals("c")
+                || normalized.startsWith("c ")
+                || normalized.contains("clang")
+                || normalized.contains("c11")
+                || normalized.contains("gnu11")) {
+            return "cpp";
+        }
+
+        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
     }
 
     public Map<String, String> getProfileImagePresignedUrl(Long userId, String fileName, String contentType) {

--- a/apps/backend/src/main/resources/db/migration-postgres/V8__add_user_preferred_language.sql
+++ b/apps/backend/src/main/resources/db/migration-postgres/V8__add_user_preferred_language.sql
@@ -1,0 +1,17 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS preferred_language VARCHAR(20) NOT NULL DEFAULT 'python';
+
+UPDATE users
+SET preferred_language = 'python';
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_users_preferred_language'
+    ) THEN
+        ALTER TABLE users DROP CONSTRAINT chk_users_preferred_language;
+    END IF;
+    ALTER TABLE users
+        ADD CONSTRAINT chk_users_preferred_language
+            CHECK (preferred_language IN ('python', 'java', 'cpp'));
+END $$;

--- a/apps/extension/background.js
+++ b/apps/extension/background.js
@@ -467,8 +467,14 @@ async function handleSolvedSubmission(payload, sender) {
             normalizedLang = 'python';
         } else if (normalizedLang.includes('java')) {
             normalizedLang = 'java';
-        } else if (normalizedLang.includes('c++') || normalizedLang.includes('cpp')) {
-            normalizedLang = 'C++';
+        } else if (
+            normalizedLang === 'c' ||
+            normalizedLang.includes('c11') ||
+            normalizedLang.includes('clang') ||
+            normalizedLang.includes('c++') ||
+            normalizedLang.includes('cpp')
+        ) {
+            normalizedLang = 'cpp';
         }
         // Add more if needed (e.g. javascript, kotlin...)
 
@@ -497,7 +503,13 @@ async function handleSolvedSubmission(payload, sender) {
             // Normalize pending language same as handleSolvedSubmission logic
             if (pendingLang.includes('python') || pendingLang.includes('pypy')) pendingLang = 'python';
             else if (pendingLang.includes('java')) pendingLang = 'java';
-            else if (pendingLang.includes('c++') || pendingLang.includes('cpp')) pendingLang = 'C++';
+            else if (
+                pendingLang === 'c' ||
+                pendingLang.includes('c11') ||
+                pendingLang.includes('clang') ||
+                pendingLang.includes('c++') ||
+                pendingLang.includes('cpp')
+            ) pendingLang = 'cpp';
 
             if (normalizedLang !== pendingLang) {
                 console.error(`[Validation Failed] Language mismatch: Submission(${normalizedLang}) vs IDE(${pendingLang})`);

--- a/apps/extension/inject_script.js
+++ b/apps/extension/inject_script.js
@@ -21,7 +21,13 @@
         const l = lang.toLowerCase();
         if (l.includes('python')) return 'Python 3';
         if (l.includes('java')) return 'Java 11';
-        if (l.includes('cpp') || l.includes('c++')) return 'C++';
+        if (
+            l === 'c' ||
+            l.includes('c11') ||
+            l.includes('clang') ||
+            l.includes('cpp') ||
+            l.includes('c++')
+        ) return 'C++';
         return lang; // fallback
     }
 
@@ -55,6 +61,7 @@
                     langVal = opt.value;
                     if (optText === 'Python 3') break;
                     if (optText === 'Java 11') break;
+                    if (optText === 'C++') break;
                 }
             }
 

--- a/apps/frontend/src/api/authApi.ts
+++ b/apps/frontend/src/api/authApi.ts
@@ -10,11 +10,13 @@ export interface ApiResponse<T> {
 }
 
 export type PreferredRecTier = 'BRONZE' | 'SILVER' | 'GOLD' | 'PLATINUM';
+export type PreferredLanguage = 'python' | 'java' | 'cpp';
 
 export async function signup(
   token: string,
   nickname: string,
   bojId?: string | null,
+  preferredLanguage: PreferredLanguage = 'python',
   preferredRecTier: PreferredRecTier = 'BRONZE',
 ): Promise<ApiResponse<null>> {
   const res = await fetch(`/api/auth/signup`, {
@@ -24,6 +26,7 @@ export async function signup(
       token,
       nickname: nickname.trim(),
       bojId: bojId?.trim() || null,
+      preferredLanguage,
       preferredRecTier,
     }),
   });

--- a/apps/frontend/src/api/userApi.ts
+++ b/apps/frontend/src/api/userApi.ts
@@ -12,6 +12,7 @@ export interface UserInfo {
   id: number;
   nickname: string;
   bojId?: string;
+  preferredLanguage?: string;
 }
 
 export async function checkNickname(
@@ -75,6 +76,7 @@ export interface UserProfileClient {
   id: number;
   nickname: string;
   bojId: string | null;
+  preferredLanguage?: string;
   leagueName: string;
   score: number;
   streakCurrent: number;

--- a/apps/frontend/src/app/signup/page.tsx
+++ b/apps/frontend/src/app/signup/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useState, useEffect, useCallback } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
-import { signup as signupApi, type PreferredRecTier } from '@/api/authApi';
+import { signup as signupApi, type PreferredLanguage, type PreferredRecTier } from '@/api/authApi';
 import { checkNickname as checkNicknameApi, checkBojId as checkBojIdApi } from '@/api/userApi';
 
 interface NicknameValidation {
@@ -27,6 +27,7 @@ function SignupForm() {
 
   const [nickname, setNickname] = useState('');
   const [bojId, setBojId] = useState('');
+  const [preferredLanguage, setPreferredLanguage] = useState<PreferredLanguage>('python');
   const [preferredRecTier, setPreferredRecTier] = useState<PreferredRecTier>('BRONZE');
   const [validation, setValidation] = useState<NicknameValidation>({
     status: 'idle',
@@ -156,7 +157,7 @@ function SignupForm() {
     setIsSubmitting(true);
 
     try {
-      const data = await signupApi(token, nickname, bojId, preferredRecTier);
+      const data = await signupApi(token, nickname, bojId, preferredLanguage, preferredRecTier);
 
       if (data.success) {
         router.push('/home');
@@ -273,6 +274,38 @@ function SignupForm() {
                   {bojValidation.message}
                 </p>
               )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-foreground/80 mb-2">
+                주 언어를 골라주세요
+              </label>
+              <div className="grid grid-cols-3 gap-2">
+                {[
+                  { value: 'python', label: 'Python' },
+                  { value: 'java', label: 'Java' },
+                  { value: 'cpp', label: 'C++' },
+                ].map((option) => (
+                  <label
+                    key={option.value}
+                    className={`h-11 flex items-center justify-center rounded-xl border text-sm font-medium cursor-pointer transition-all ${
+                      preferredLanguage === option.value
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-border text-foreground/80 hover:border-primary/40'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="preferredLanguage"
+                      value={option.value}
+                      checked={preferredLanguage === option.value}
+                      onChange={(e) => setPreferredLanguage(e.target.value as PreferredLanguage)}
+                      className="sr-only"
+                    />
+                    {option.label}
+                  </label>
+                ))}
+              </div>
             </div>
 
             <div>

--- a/apps/frontend/src/domains/profile/actions/profile.ts
+++ b/apps/frontend/src/domains/profile/actions/profile.ts
@@ -50,6 +50,7 @@ export async function getMyProfile(): Promise<UserProfile> {
       league: data.leagueName,
       leaguePoint: Number(data.score),
       leagueGroupId: null, // 추후 구현
+      preferredLanguage: data.preferredLanguage || 'python',
       streakCurrent: data.streakCurrent,
       streakMax: data.streakMax,
       profileImg: data.profileImg || undefined,
@@ -64,6 +65,7 @@ export async function getMyProfile(): Promise<UserProfile> {
       id: '',
       nickname: '알 수 없음',
       bojId: null,
+      preferredLanguage: 'python',
       league: 'Unranked',
       leaguePoint: 0,
       leagueGroupId: null,
@@ -123,6 +125,7 @@ export async function getUserProfile(nickname: string): Promise<UserProfile | nu
       league: data.leagueName,
       leaguePoint: Number(data.score),
       leagueGroupId: null,
+      preferredLanguage: data.preferredLanguage || 'python',
       streakCurrent: data.streakCurrent,
       streakMax: data.streakMax,
       profileImg: data.profileImg || undefined,

--- a/apps/frontend/src/domains/profile/api/profileApi.ts
+++ b/apps/frontend/src/domains/profile/api/profileApi.ts
@@ -113,6 +113,7 @@ export async function fetchUserProfile(nickname: string): Promise<UserProfile> {
     id: String(data.id),
     nickname: data.nickname,
     bojId: data.bojId,
+    preferredLanguage: data.preferredLanguage || 'python',
     league: data.leagueName,
     leaguePoint: Number(data.score),
     streakCurrent: data.streakCurrent,

--- a/apps/frontend/src/domains/profile/components/CCProfileHeader.tsx
+++ b/apps/frontend/src/domains/profile/components/CCProfileHeader.tsx
@@ -21,6 +21,8 @@ interface Props {
   };
   editBojId?: string;
   setEditBojId?: (value: string) => void;
+  editPreferredLanguage?: string;
+  setEditPreferredLanguage?: (value: string) => void;
   bojIdValidation?: {
     status: 'idle' | 'checking' | 'valid' | 'invalid' | 'error';
     message: string;
@@ -41,6 +43,8 @@ export function CCProfileHeader({
   nicknameValidation,
   editBojId,
   setEditBojId,
+  editPreferredLanguage,
+  setEditPreferredLanguage,
   bojIdValidation,
 }: Props) {
   const isExtensionLinked = !!user.bojId;
@@ -108,6 +112,14 @@ export function CCProfileHeader({
       default:
         return 'text-slate-400';
     }
+  };
+
+  const getPreferredLanguageLabel = (value?: string) => {
+    const normalized = (value || '').toLowerCase();
+    if (normalized === 'java') return 'Java';
+    if (normalized === 'cpp' || normalized.includes('c++')) return 'C++';
+    if (normalized === 'c' || normalized.includes('c11') || normalized.includes('clang')) return 'C++';
+    return 'Python';
   };
 
   return (
@@ -210,31 +222,49 @@ export function CCProfileHeader({
           )}
 
           {isEditing && setEditBojId ? (
-            <div className="flex items-center gap-2 mt-6 relative">
-              <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-                BOJ ID:
-              </span>
-              <div className="relative">
-                <input
-                  type="text"
-                  value={editBojId}
-                  onChange={(e) => setEditBojId(e.target.value)}
-                  className={`text-sm bg-transparent border-b text-foreground focus:outline-none w-full max-w-[150px] transition-colors ${getBojInputBorderColor()}`}
-                  placeholder="Baekjoon"
-                />
-                {bojIdValidation && bojIdValidation.message && (
-                  <p
-                    className={`absolute top-full left-0 mt-1 text-xs whitespace-nowrap ${getBojValidationColor()}`}
-                  >
-                    {bojIdValidation.status === 'checking' && (
-                      <span className="inline-block w-2 pb-0.5 align-middle">
-                        <div className="w-2 h-2 border border-slate-300 border-t-slate-500 rounded-full animate-spin"></div>
-                      </span>
-                    )}
-                    {bojIdValidation.message}
-                  </p>
-                )}
+            <div className="mt-6 space-y-2">
+              <div className="flex items-center gap-2 relative">
+                <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+                  BOJ ID:
+                </span>
+                <div className="relative">
+                  <input
+                    type="text"
+                    value={editBojId}
+                    onChange={(e) => setEditBojId(e.target.value)}
+                    className={`text-sm bg-transparent border-b text-foreground focus:outline-none w-full max-w-[150px] transition-colors ${getBojInputBorderColor()}`}
+                    placeholder="Baekjoon"
+                  />
+                  {bojIdValidation && bojIdValidation.message && (
+                    <p
+                      className={`absolute top-full left-0 mt-1 text-xs whitespace-nowrap ${getBojValidationColor()}`}
+                    >
+                      {bojIdValidation.status === 'checking' && (
+                        <span className="inline-block w-2 pb-0.5 align-middle">
+                          <div className="w-2 h-2 border border-slate-300 border-t-slate-500 rounded-full animate-spin"></div>
+                        </span>
+                      )}
+                      {bojIdValidation.message}
+                    </p>
+                  )}
+                </div>
               </div>
+              {setEditPreferredLanguage && (
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+                    주 언어:
+                  </span>
+                  <select
+                    value={editPreferredLanguage || 'python'}
+                    onChange={(e) => setEditPreferredLanguage(e.target.value)}
+                    className="h-8 rounded-md border border-muted-foreground/40 bg-background px-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                  >
+                    <option value="python">Python</option>
+                    <option value="java">Java</option>
+                    <option value="cpp">C++</option>
+                  </select>
+                </div>
+              )}
             </div>
           ) : (
             <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
@@ -251,6 +281,11 @@ export function CCProfileHeader({
                   <span>BOJ 연동 안됨</span>
                 </div>
               )}
+              <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-primary/10 text-primary border border-primary/20">
+                <span className="font-medium">주 언어</span>
+                <span className="text-black/20 dark:text-white/20">|</span>
+                <span className="font-bold">{getPreferredLanguageLabel(user.preferredLanguage)}</span>
+              </div>
             </div>
           )}
         </div>

--- a/apps/frontend/src/domains/profile/components/CCProfileStatsRow.tsx
+++ b/apps/frontend/src/domains/profile/components/CCProfileStatsRow.tsx
@@ -79,7 +79,7 @@ export function CCProfileStatsRow({ user }: Props) {
         >
           <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"></path>
         </svg>
-        <p className="text-2xl font-bold text-foreground">{user.streakCurrent}일</p>
+        <p className="text-2xl font-bold text-foreground">{user.streakCurrent ?? 0}일</p>
         <p className="text-sm text-muted-foreground">연속 스트릭</p>
       </div>
 
@@ -100,7 +100,7 @@ export function CCProfileStatsRow({ user }: Props) {
           <polyline points="22 7 13.5 15.5 8.5 10.5 2 17"></polyline>
           <polyline points="16 7 22 7 22 13"></polyline>
         </svg>
-        <p className="text-2xl font-bold text-foreground">{user.streakMax}일</p>
+        <p className="text-2xl font-bold text-foreground">{user.streakMax ?? 0}일</p>
         <p className="text-sm text-muted-foreground">최대 스트릭</p>
       </div>
     </div>

--- a/apps/frontend/src/domains/profile/components/CCProfileView.tsx
+++ b/apps/frontend/src/domains/profile/components/CCProfileView.tsx
@@ -72,6 +72,7 @@ export function CCProfileView({ user, isMe, initialStreak, initialTimeline, init
   // Text State
   const [editNickname, setEditNickname] = useState(user.nickname);
   const [editBojId, setEditBojId] = useState(user.bojId || '');
+  const [editPreferredLanguage, setEditPreferredLanguage] = useState(user.preferredLanguage || 'python');
   const [isCheckingNickname, setIsCheckingNickname] = useState(false);
   const nickChangeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [nicknameValidation, setNicknameValidation] = useState<{
@@ -104,6 +105,7 @@ export function CCProfileView({ user, isMe, initialStreak, initialTimeline, init
     setThumbToUpload(null);
     setEditNickname(optimisticUser.nickname);
     setEditBojId(optimisticUser.bojId || '');
+    setEditPreferredLanguage(optimisticUser.preferredLanguage || 'python');
     setNicknameValidation({ status: 'idle', message: '' });
     setBojIdValidation({ status: 'idle', message: '' });
   };
@@ -116,6 +118,7 @@ export function CCProfileView({ user, isMe, initialStreak, initialTimeline, init
     setIsProfileImageDeleted(false);
     setEditNickname('');
     setEditBojId('');
+    setEditPreferredLanguage(user.preferredLanguage || 'python');
     setNicknameValidation({ status: 'idle', message: '' });
   };
 
@@ -333,6 +336,7 @@ export function CCProfileView({ user, isMe, initialStreak, initialTimeline, init
         ...optimisticUser,
         nickname: editNickname,
         bojId: editBojId || optimisticUser.bojId,
+        preferredLanguage: editPreferredLanguage,
         profileImg: nextProfileImg,
         // We might want to clear thumb or set it same as profile for preview purposes
         profileImgThumb: nextProfileImg, // for immediate preview, using same img is fine
@@ -401,6 +405,9 @@ export function CCProfileView({ user, isMe, initialStreak, initialTimeline, init
       }
       if (editBojId !== (user.bojId || '')) {
         updatePayload.bojId = editBojId;
+      }
+      if (editPreferredLanguage !== (user.preferredLanguage || 'python')) {
+        updatePayload.preferredLanguage = editPreferredLanguage;
       }
 
       // Image fields
@@ -516,6 +523,8 @@ export function CCProfileView({ user, isMe, initialStreak, initialTimeline, init
           nicknameValidation={nicknameValidation}
           editBojId={editBojId}
           setEditBojId={setEditBojId}
+          editPreferredLanguage={editPreferredLanguage}
+          setEditPreferredLanguage={setEditPreferredLanguage}
           bojIdValidation={bojIdValidation}
         />
 

--- a/apps/frontend/src/domains/profile/types.ts
+++ b/apps/frontend/src/domains/profile/types.ts
@@ -2,6 +2,7 @@ export interface UserProfile {
   id: string;
   nickname: string;
   bojId?: string | null;
+  preferredLanguage?: string;
   league?: string; // e.g. "Silver", "Gold"
   leaguePoint: number;
   leagueGroupId?: string | null;

--- a/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCCenterPanel.tsx
@@ -21,6 +21,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { ChevronUp, ChevronDown, Lock, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import { useIsTouchMobile } from '@/hooks/useIsMobile';
+import { useAuthStore } from '@/store/auth-store';
 
 interface CCCenterPanelProps {
   ideContent?: ReactNode;
@@ -82,7 +83,13 @@ public class Main {
 }`;
     }
 
-    if (normalized.includes('cpp') || normalized.includes('c++')) {
+    if (
+      normalized === 'c' ||
+      normalized.includes('c11') ||
+      normalized.includes('clang') ||
+      normalized.includes('cpp') ||
+      normalized.includes('c++')
+    ) {
       return `#include <iostream>
 #include <vector>
 #include <algorithm>
@@ -104,8 +111,14 @@ print("Hello World!")`;
 
   const normalizeLanguage = (languageValue: string): string => {
     const normalized = languageValue.toLowerCase();
+    if (
+      normalized === 'c' ||
+      normalized.includes('c11') ||
+      normalized.includes('clang') ||
+      normalized.includes('cpp') ||
+      normalized.includes('c++')
+    ) return 'cpp';
     if (normalized.includes('java') && !normalized.includes('script')) return 'java';
-    if (normalized.includes('cpp') || normalized.includes('c++')) return 'cpp';
     return 'python';
   };
 
@@ -152,6 +165,11 @@ print("Hello World!")`;
   const selectedProblemId = useRoomStore((state) => state.selectedProblemId);
   const selectedProblemTitle = useRoomStore((state) => state.selectedProblemTitle);
   const selectedProblemExternalId = useRoomStore((state) => state.selectedProblemExternalId);
+  const userPreferredLanguage = useAuthStore((state) => state.user?.preferredLanguage);
+  const normalizedPreferredLanguage = useMemo(
+    () => normalizeLanguage(userPreferredLanguage || 'python'),
+    [userPreferredLanguage],
+  );
   const isWhiteboardOverlayOpen = useRoomStore((state) => state.isWhiteboardOverlayOpen);
   const socket = useSocket(roomId, currentUserId);
   const setRightPanelActiveTab = useRoomStore((state) => state.setRightPanelActiveTab);
@@ -1462,10 +1480,10 @@ print("Hello World!")`;
   } | null>(null);
   const hydratedProblemKeyRef = useRef<string | null>(null);
   const restoreRequestSeqRef = useRef(0);
-  const lastRestoredLanguageRef = useRef<string>('python');
+  const lastRestoredLanguageRef = useRef<string>(normalizedPreferredLanguage);
   const previousSelectionRef = useRef<{ studyProblemId: number | null; language: string }>({
     studyProblemId: null,
-    language: 'python',
+    language: normalizedPreferredLanguage,
   });
   const ideEventTsRef = useRef(0);
 
@@ -1635,7 +1653,7 @@ print("Hello World!")`;
     };
 
     const seedTemplateCode = () => {
-      const defaultLanguage = 'python';
+      const defaultLanguage = normalizedPreferredLanguage;
       const templateCode = getTemplateCode(defaultLanguage);
       applyCode(templateCode, defaultLanguage);
     };
@@ -1659,7 +1677,7 @@ print("Hello World!")`;
         const draftCode = response.data?.code;
         const draftLanguage = response.data?.language
           ? normalizeLanguage(response.data.language)
-          : 'python';
+          : normalizedPreferredLanguage;
 
         if (response.success && typeof draftCode === 'string') {
           applyCode(draftCode, draftLanguage);
@@ -1675,7 +1693,7 @@ print("Hello World!")`;
     };
 
     void hydrateDraft();
-  }, [roomId, selectedStudyProblemId, setLanguage]);
+  }, [roomId, selectedStudyProblemId, setLanguage, normalizedPreferredLanguage]);
 
   useEffect(() => {
     if (!socket || !roomId || !selectedStudyProblemId) return;

--- a/apps/frontend/src/domains/study/hooks/useCenterPanel.ts
+++ b/apps/frontend/src/domains/study/hooks/useCenterPanel.ts
@@ -1,9 +1,24 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useRoomStore } from '@/domains/study/hooks/useRoomStore';
 import { type CCIDEPanelRef as IDEPanelRef } from '@/domains/study/components/CCIDEPanel';
+import { useAuthStore } from '@/store/auth-store';
+
+const normalizePreferredLanguage = (language?: string | null): string => {
+  const normalized = (language || '').toLowerCase();
+  if (normalized.includes('java') && !normalized.includes('script')) return 'java';
+  if (
+    normalized === 'c' ||
+    normalized.includes('c11') ||
+    normalized.includes('clang') ||
+    normalized.includes('cpp') ||
+    normalized.includes('c++')
+  ) return 'cpp';
+  return 'python';
+};
 
 export function useCenterPanel() {
   const [isVideoGridFolded, setIsVideoGridFolded] = useState(false);
+  const preferredLanguage = useAuthStore((state) => state.user?.preferredLanguage);
 
   const viewMode = useRoomStore((state) => state.viewMode);
   const viewingUser = useRoomStore((state) => state.viewingUser);
@@ -11,9 +26,17 @@ export function useCenterPanel() {
   const resetToOnlyMine = () => useRoomStore.getState().resetToOnlyMine();
 
   // IDE State
-  const [language, setLanguage] = useState('python');
+  const [language, setLanguage] = useState(() => normalizePreferredLanguage(preferredLanguage));
   const [theme, setTheme] = useState<'light' | 'vs-dark'>('light');
   const leftPanelRef = useRef<IDEPanelRef>(null);
+
+  useEffect(() => {
+    if (!preferredLanguage) return;
+    setLanguage((prev) => {
+      if (prev !== 'python') return prev;
+      return normalizePreferredLanguage(preferredLanguage);
+    });
+  }, [preferredLanguage]);
 
   const isViewingOther = viewMode !== 'ONLY_MINE';
 

--- a/apps/frontend/src/store/auth-store.ts
+++ b/apps/frontend/src/store/auth-store.ts
@@ -9,6 +9,7 @@ interface User {
   bojId: string | null;
   league: string;
   leaguePoint: number;
+  preferredLanguage?: string;
 }
 
 interface AuthState {


### PR DESCRIPTION
## 💡 의도 / 배경
유저별로 코딩 언어 선호가 달라 스터디방 입장 시 매번 수동으로 언어를 바꿔야 했습니다.  
프로필/회원가입에서 설정한 주 언어를 IDE에 자동 반영해 초기 진입 UX를 개선하고, 언어 값은 `cpp` 기준으로 일관되게 관리하도록 정리했습니다.

## 🛠️ 작업 내용
- [x] `users.preferred_language` 컬럼 및 제약 추가 (`python`, `java`, `cpp`)
- [x] 회원가입 시 주 언어 선택/저장 API 연동
- [x] 프로필 조회/수정에 주 언어 필드 연동
- [x] 스터디 IDE 최초 진입/문제 전환 시 사용자 주 언어 자동 적용
- [x] 확장프로그램 제출/주입 로직의 언어 처리 일관화
- [x] 프로필 스트릭 값이 없을 때 `0일`로 표시되도록 보정

## 🔗 관련 이슈
- Closes #122

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] `cmd /c pnpm --filter frontend run type-check`
- [x] `cmd /c gradlew.bat compileJava`
- [x] 회원가입에서 주 언어 선택 후 저장값이 프로필/IDE에 반영되는지 확인
- [x] 스터디 입장 시 IDE 언어가 사용자 주 언어로 자동 설정되는지 확인
- [x] 프로필 스트릭이 null/undefined일 때 `0일`로 노출되는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)