### PR TITLE
fix: 과거 날짜에서 문제 추가 시 오늘 날짜로 전환 후 추가되도록 수정

### DIFF
--- a/apps/frontend/src/domains/study/components/CCProblemListPanel.tsx
+++ b/apps/frontend/src/domains/study/components/CCProblemListPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { isSameDay } from 'date-fns';
+import { format, isSameDay } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { ChevronLeft, FileText, Plus, RotateCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -62,6 +62,7 @@ export function CCProblemListPanel({
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [submissionModalOpen, setSubmissionModalOpen] = useState(false);
   const [addProblemModalOpen, setAddProblemModalOpen] = useState(false);
+  const [addTargetDate, setAddTargetDate] = useState<string | null>(null);
   const [selectedSubmissionStudyProblemId, setSelectedSubmissionStudyProblemId] = useState<number | null>(
     null,
   );
@@ -176,8 +177,26 @@ export function CCProblemListPanel({
     customLink?: string,
   ) => {
     if (onAddProblem) {
-      await onAddProblem(title, number, tags, problemId, date, customLink);
+      const resolvedDate = date ?? addTargetDate ?? format(selectedDate, 'yyyy-MM-dd');
+      await onAddProblem(title, number, tags, problemId, resolvedDate, customLink);
     }
+  };
+
+  const handleOpenAddProblemModal = () => {
+    const today = new Date();
+    const todayKey = format(today, 'yyyy-MM-dd');
+
+    if (!isSameDay(selectedDate, today)) {
+      onDateChange(today);
+    }
+
+    setAddTargetDate(todayKey);
+    setAddProblemModalOpen(true);
+  };
+
+  const handleCloseAddProblemModal = () => {
+    setAddProblemModalOpen(false);
+    setAddTargetDate(null);
   };
 
   const handleRemoveProblem = async (problemId: number, studyProblemId?: number) => {
@@ -244,7 +263,7 @@ export function CCProblemListPanel({
 
           {allowProblemManage && (
             <Button
-              onClick={() => setAddProblemModalOpen(true)}
+              onClick={handleOpenAddProblemModal}
               className={cn(
                 'bg-primary hover:bg-primary/90 text-white h-8 text-xs shadow-sm',
                 isCompact ? 'px-2' : 'px-3',
@@ -330,7 +349,7 @@ export function CCProblemListPanel({
       {allowProblemManage && (
         <CCAddProblemModal
           isOpen={addProblemModalOpen}
-          onClose={() => setAddProblemModalOpen(false)}
+          onClose={handleCloseAddProblemModal}
           onAdd={handleAddProblem}
           onRemove={handleRemoveProblem}
           currentProblems={problems}


### PR DESCRIPTION
## 💡 의도 / 배경
과거 날짜를 보고 있는 상태에서 `문제 추가` 버튼을 누르면, 오늘 날짜로 이동한 뒤 오늘 커리큘럼에 추가되어야 합니다.  
기존에는 현재 보고 있던 날짜에 바로 추가되어 이슈 #175가 발생했습니다.

## 🛠️ 작업 내용
- [x] `CCProblemListPanel`에서 `문제 추가` 버튼 클릭 시 오늘 날짜가 아니면 `onDateChange(today)`를 먼저 호출하도록 수정
- [x] 추가 모달에서 사용할 `addTargetDate`를 오늘 날짜(`yyyy-MM-dd`)로 고정하고, 실제 `onAddProblem` 호출 시 해당 날짜를 우선 적용하도록 수정
- [x] 모달 닫힘 시 `addTargetDate`를 초기화하도록 처리

## 🔗 관련 이슈
- Closes #175

## 🖼️ 스크린샷 (선택)
- 없음 (동작 로직 수정)

## 🧪 테스트 방법
- [x] 자동 테스트 실행  
  `pnpm --filter frontend test -- --run src/domains/study/tests/CCProblemListPanel.test.tsx src/domains/study/tests/CCProblemListPanel.keys.test.tsx`
- [x] 수동 확인  
  1. 오늘이 아닌 날짜로 이동  
  2. `문제 추가` 클릭  
  3. 오늘 날짜로 전환된 뒤 문제가 오늘 날짜에 추가되는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
`문제 추가` 시 날짜 전환/추가 순서가 의도대로 보이는지(특히 과거 날짜에서 진입 시) 한 번만 확인 부탁드립니다.