### PR TITLE
fix: 대기방 입장 직후 발생하던 게임방 삭제(튕김) 문제 해결

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/game/service/RedisGameWaitService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/game/service/RedisGameWaitService.java
@@ -16,6 +16,8 @@ import com.peekle.global.exception.BusinessException;
 import com.peekle.global.exception.ErrorCode;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 게임 대기방(Waiting Room) 관련 Redis 작업을 담당하는 서비스
@@ -309,8 +311,32 @@ public class RedisGameWaitService {
         String status = (String) redisTemplate.opsForValue().get(statusKey);
 
         if ("WAITING".equals(status)) {
-            log.info("🚪 User {} disconnected from lobby (WAITING). Exiting immediately.", userId);
-            exitGameRoom(roomId, userId);
+            log.info("🚪 User {} disconnected from lobby (WAITING). Delaying exit for 5 seconds to handle page transitions.", userId);
+            
+            CompletableFuture.delayedExecutor(5, TimeUnit.SECONDS).execute(() -> {
+                try {
+                    // Check if the user is still assigned to this room in Redis
+                    String currentGameIdStr = (String) redisTemplate.opsForValue()
+                            .get(String.format(RedisKeyConst.USER_CURRENT_GAME, userId));
+                            
+                    if (currentGameIdStr == null || !roomId.equals(Long.parseLong(currentGameIdStr))) {
+                        return; // User has already joined a different room or properly exited
+                    }
+                    
+                    // Check if the user's socket is still offline
+                    String onlineKey = String.format(RedisKeyConst.GAME_ROOM_ONLINE, roomId);
+                    boolean isOnline = Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(onlineKey, userId));
+                    
+                    if (isOnline) {
+                        log.info("🔙 User {} successfully reconnected to Room {}. Ignoring exit.", userId, roomId);
+                    } else {
+                        log.info("🗑️ User {} did not reconnect to Room {} within 5 seconds. Exiting now.", userId, roomId);
+                        exitGameRoom(roomId, userId);
+                    }
+                } catch (Exception e) {
+                    log.error("Error during delayed exit process for user {} in room {}", userId, roomId, e);
+                }
+            });
             return;
         }
 

--- a/apps/frontend/src/domains/game/hooks/useGameWaitingRoom.ts
+++ b/apps/frontend/src/domains/game/hooks/useGameWaitingRoom.ts
@@ -175,6 +175,14 @@ export function useGameWaitingRoom(roomId: string): UseGameWaitingRoomReturn {
       }
     });
 
+    // 4. Send WebSocket ENTER message to register as online in Redis
+    // This is crucial for the backend's disconnect logic to recognize the user is active in the WAITING room
+    console.log('[GameWaitingRoom] Sending WebSocket ENTER to register online status');
+    client.publish({
+      destination: '/pub/games/enter',
+      body: JSON.stringify({ gameId: Number(roomId) })
+    });
+
     return () => {
       roomSub.unsubscribe();
       chatSub.unsubscribe();


### PR DESCRIPTION
## 💡 의도 / 배경
<!-- 무엇을, 왜 변경했는지 설명해주세요. 배경 및 문제를 적어주세요. -->
- 게임 방 생성 직후 호스트(방장)가 대기방으로 이동할 때 간헐적으로 방이 즉시 삭제되고 존재하지 않는 방입니다 에러가 발생하는 이슈 존재

## 🛠️ 작업 내용
<!-- 주요 구현 사항, 로직 변경, 추가된 기능 등을 리스트업 해주세요. -->
- [x] [Backend] 연결 유예(Grace Period) 로직 추가: RedisGameWaitService 내부 handleDisconnect 발생 시, 방을 즉시 삭제하지 않고 CompletableFuture를 이용해 5초간 대기 후 웹소켓 재접속 여부를 확인하여 처리
- [x] [Backend] Redis 직렬화 타입 오류 해결: GAME_ROOM_ONLINE 세트 존재 여부(isMember) 확인 시 String.valueOf(userId) 캐스팅을 제거하고 객체 타입 매칭 버그 수정
- [x] [Frontend] 대기실 생존 신고 메시지 발송: useGameWaitingRoom 최상단 마운트 시점에 명시적으로 /pub/games/enter STOMP 메시지를 발행하여 백엔드 온라인 유저 리스트에 정상 등재되도록 추가

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: Closes #xxx) -->
- Closes #179 

## 🖼️ 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요. -->


## 🧪 테스트 방법
<!-- 이 PR이 어떻게 테스트되었는지, 리뷰어가 어떻게 테스트해 볼 수 있는지 적어주세요. -->
- [ ] 안티의 헛짓거리로 테스트 못하고 발사했습니다...

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
<!-- 같이 리뷰받고 싶은 부분이나 특별히 확인해야 할 사항이 있다면 적어주세요. -->
