### PR TITLE
feat: cs 학습 상단바에 프로그래스바 추가

### DIFF
--- a/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
@@ -9,6 +9,7 @@ import {
   startCSStageAttempt,
   answerCSStageQuestion,
   completeCSStageAttempt,
+  fetchCSBootstrap,
   CSQuestionPayload,
   CSAttemptAnswerRequest,
   CSAttemptAnswerResponse,
@@ -93,10 +94,28 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showExitAlert, setShowExitAlert] = useState(false);
   const [answerResult, setAnswerResult] = useState<CSAttemptAnswerResponse | null>(null);
+  const [trackInfo, setTrackInfo] = useState<{ name: string; trackNo: number; stageNo: number } | null>(null);
 
   const initSession = useCallback(async () => {
     try {
       setPhase('loading');
+
+      try {
+        const bootstrap = await fetchCSBootstrap();
+        if (bootstrap && bootstrap.progress && bootstrap.stages) {
+          const matchedStage = bootstrap.stages.find((s) => s.stageId === stageId);
+          if (matchedStage) {
+            setTrackInfo({
+              name: bootstrap.progress.currentTrackName,
+              trackNo: bootstrap.progress.currentTrackNo,
+              stageNo: matchedStage.stageNo
+            });
+          }
+        }
+      } catch (err) {
+        console.error('Failed to fetch track info:', err);
+      }
+
       const res = await startCSStageAttempt(stageId);
       setCurrentQuestion(res.firstQuestion);
       setTotalQuestionCount(res.totalQuestionCount);
@@ -209,23 +228,35 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
 
   return (
     <div className="flex flex-col w-full animate-in fade-in relative min-h-[80vh] pb-28">
-      <header className="flex items-center justify-between py-4 px-6 bg-background/80 backdrop-blur-md sticky top-0 z-50 border-b border-border/50">
-        <div className="flex flex-col">
-          <span className="text-sm font-semibold text-muted-foreground">스테이지 {stageId}</span>
-          {phase === 'playing' && totalQuestionCount > 0 && (
-            <div className="flex items-center gap-3">
-              <h1 className="text-lg font-bold">
+      <header className="flex flex-col py-4 px-6 bg-background/80 backdrop-blur-md sticky top-0 z-50 border-b border-border/50 gap-2">
+        <div className="flex items-center justify-between w-full">
+          <div className="flex flex-col">
+            <span className="text-sm font-semibold text-muted-foreground">
+              {trackInfo 
+                ? `${trackInfo.name} (${trackInfo.trackNo}-${trackInfo.stageNo})` 
+                : `(트랙 정보 없음) - 스테이지 ${stageId}`}
+            </span>
+            {phase === 'playing' && totalQuestionCount > 0 && (
+              <h1 className="text-lg font-bold mt-0.5">
                 진행도: {solvedQuestionIds.length} / {totalQuestionCount}
               </h1>
-            </div>
-          )}
+            )}
+          </div>
+          <button
+            onClick={() => setShowExitAlert(true)}
+            className="p-2 bg-muted hover:bg-muted/80 rounded-full transition-colors group"
+          >
+            <X className="w-6 h-6 text-muted-foreground group-hover:text-foreground transition-colors" />
+          </button>
         </div>
-        <button
-          onClick={() => setShowExitAlert(true)}
-          className="p-2 bg-muted hover:bg-muted/80 rounded-full transition-colors group"
-        >
-          <X className="w-6 h-6 text-muted-foreground group-hover:text-foreground transition-colors" />
-        </button>
+        {phase === 'playing' && totalQuestionCount > 0 && (
+          <div className="w-full bg-muted rounded-full h-2">
+            <div 
+              className="bg-primary h-2 rounded-full transition-all duration-300 ease-in-out" 
+              style={{ width: `${(solvedQuestionIds.length / totalQuestionCount) * 100}%` }}
+            />
+          </div>
+        )}
       </header>
 
       <main className="flex-1 flex flex-col justify-center items-center p-4">

--- a/apps/frontend/src/domains/cs/components/session/CSWrongReviewSession.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSWrongReviewSession.tsx
@@ -261,23 +261,31 @@ export default function CSWrongReviewSession({ domainId }: CSWrongReviewSessionP
 
   return (
     <div className="flex flex-col w-full animate-in fade-in relative min-h-[80vh] pb-28">
-      <header className="flex items-center justify-between py-4 px-6 bg-background/80 backdrop-blur-md sticky top-0 z-50 border-b border-border/50">
-        <div className="flex flex-col">
-          <span className="text-sm font-semibold text-muted-foreground">오답 복습</span>
-          {phase === 'playing' && totalQuestionCount > 0 && (
-            <div className="flex items-center gap-3">
-              <h1 className="text-lg font-bold">
+      <header className="flex flex-col py-4 px-6 bg-background/80 backdrop-blur-md sticky top-0 z-50 border-b border-border/50 gap-2">
+        <div className="flex items-center justify-between w-full">
+          <div className="flex flex-col">
+            <span className="text-sm font-semibold text-muted-foreground">오답 복습</span>
+            {phase === 'playing' && totalQuestionCount > 0 && (
+              <h1 className="text-lg font-bold mt-0.5">
                 진행도: {progressedCount} / {totalQuestionCount}
               </h1>
-            </div>
-          )}
+            )}
+          </div>
+          <button
+            onClick={() => setShowExitAlert(true)}
+            className="p-2 bg-muted hover:bg-muted/80 rounded-full transition-colors group"
+          >
+            <X className="w-6 h-6 text-muted-foreground group-hover:text-foreground transition-colors" />
+          </button>
         </div>
-        <button
-          onClick={() => setShowExitAlert(true)}
-          className="p-2 bg-muted hover:bg-muted/80 rounded-full transition-colors group"
-        >
-          <X className="w-6 h-6 text-muted-foreground group-hover:text-foreground transition-colors" />
-        </button>
+        {phase === 'playing' && totalQuestionCount > 0 && (
+          <div className="w-full bg-muted rounded-full h-2">
+            <div 
+              className="bg-primary h-2 rounded-full transition-all duration-300 ease-in-out" 
+              style={{ width: `${(progressedCount / totalQuestionCount) * 100}%` }}
+            />
+          </div>
+        )}
       </header>
 
       <main className="flex-1 flex flex-col justify-center items-center p-4">


### PR DESCRIPTION
## 💡 의도 / 배경
기존 상단바는 `진행도: x / y` 텍스트만 제공해 진행 상태를 직관적으로 파악하기 어려웠습니다.  
또한 내부 식별자(`stageId`) 중심 표기는 사용자 관점에서 의미 해석이 어려워, 학습 맥락을 빠르게 이해하기 힘든 문제가 있었습니다.

## 🛠️ 작업 내용
- [x] CS 학습 상단바에 진행률 기반 프로그래스바 UI 추가
- [x] 진행도 텍스트(`x / y`)와 프로그래스바 상태 동기화
- [x] `stageId` 노출 제거 및 사용자 친화 표기 적용(예: `요구사항 개요와 유형 (2-1)`)
- [x] 상단 정보 레이아웃 정리(중복 정보 최소화)

## 🔗 관련 이슈
- Closes #184

## 🖼️ 스크린샷 (선택)
UI 변경 전/후 스크린샷 첨부

## 🧪 테스트 방법
- [x] 학습 화면 진입 시 상단바에 프로그래스바가 정상 노출되는지 확인
- [x] 문제 풀이/진행 상태 변경 시 프로그래스바와 `x / y` 텍스트가 함께 갱신되는지 확인
- [x] 스테이지 표기가 `stageId` 대신 사용자용 명칭+번호로 노출되는지 확인
- [x] 모바일/데스크탑에서 레이아웃 깨짐 없이 표시되는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
상단바 정보 구조를 단순화하는 방향으로 정리했습니다.  
진행률 시각화(프로그래스바)와 스테이지 표기 방식(`명칭 + 번호`)이 사용자 인지에 자연스러운지 중점 리뷰 부탁드립니다.