### PR TITLE
feat: cs 학습 맵에 트랙명 표시 추가

### DIFF
--- a/apps/frontend/src/app/(main)/cs/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/page.tsx
@@ -91,12 +91,14 @@ export default function CSPage() {
         />
       )}
 
-      <div className="bg-card rounded-2xl p-8 shadow-sm">
-        <h1 className="text-2xl font-bold mb-2">CS 학습</h1>
+      {bootstrapData?.progress?.currentTrackName && (
+        <div className="px-6 pt-5">
+          <p className="text-xs font-semibold text-muted-foreground">현재 트랙</p>
+          <h2 className="text-lg font-bold mt-1">{bootstrapData.progress.currentTrackName}</h2>
+        </div>
+      )}
 
-        <p className="text-muted-foreground mb-6">
-          선택한 도메인: <span className="font-semibold text-primary">{bootstrapData?.currentDomain?.name}</span>
-        </p>
+      <div className="bg-card rounded-2xl p-8 shadow-sm">
         {bootstrapData?.progress ? (
           <div className="w-full flex flex-col items-center">
             <LearningMap progress={bootstrapData.progress} stages={bootstrapData.stages ?? []} />

--- a/apps/frontend/src/domains/cs/components/LearningMap.tsx
+++ b/apps/frontend/src/domains/cs/components/LearningMap.tsx
@@ -80,7 +80,12 @@ export default function LearningMap({ progress, stages }: LearningMapProps) {
       return;
     }
 
-    router.push(`/cs/stage/${stage.stageId}`);
+    const query = new URLSearchParams({
+      trackName: progress.currentTrackName,
+      trackNo: String(currentTrackNo),
+      stageNo: String(stage.stageNo),
+    });
+    router.push(`/cs/stage/${stage.stageId}?${query.toString()}`);
   };
 
   return (


### PR DESCRIPTION
## 💡 의도 / 배경
기존 CS 학습 화면은 상단 헤더와 본문 정보 구조가 분리되어 있지 않아,  
사용자가 현재 학습 중인 트랙을 즉시 인지하기 어려웠습니다.

또한 스테이지 진입 시 내부 식별자 기반 표기(`stageId`)가 노출될 수 있어
사용자 관점에서 의미가 직관적이지 않았습니다.

이번 변경은
- CS 탭에서는 도메인 컨텍스트를 유지하면서
- 학습 맵 본문에 현재 트랙명을 명확히 노출하고
- 스테이지 내부에서는 `트랙명 (트랙-스테이지)` 형식으로 표기해
학습 맥락 이해도를 높이는 것을 목표로 합니다.

## 🛠️ 작업 내용
- [x] CS 탭 상단 헤더는 도메인명 유지
- [x] 헤더 하단(학습 맵 상단)에 현재 트랙명 표시 UI 추가
- [x] 스테이지 진입 시 트랙/스테이지 정보 전달 로직 추가
- [x] 스테이지 내부 상단 표기를 `트랙명 (2-1)` 형식으로 개선
- [x] `stageId` 직접 노출 fallback 문구 제거

## 🔗 관련 이슈
- Closes #186

## 🖼️ 스크린샷 (선택)
- CS 학습 맵: 헤더(도메인명) + 하단 트랙명 노출 화면
- 스테이지 내부: `트랙명 (2-1)` 표기 화면

## 🧪 테스트 방법
- [x] CS 탭 진입 시 상단 헤더에 도메인명이 유지되는지 확인
- [x] 헤더 아래에 현재 트랙명이 표시되는지 확인
- [x] 학습 맵에서 스테이지 클릭 시 스테이지 내부 상단이 `트랙명 (트랙-스테이지)`로 노출되는지 확인
- [x] `stageId`가 사용자에게 직접 노출되지 않는지 확인
- [x] `npm run type-check` 통과 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
도메인 컨텍스트(헤더)와 학습 컨텍스트(현재 트랙)를 분리해 정보 위계를 정리했습니다.  
특히 스테이지 내부 표기가 사용자 친화적으로 보이는지(`트랙명 (2-1)`) 중심으로 확인 부탁드립니다.
