### PR TITLE
feat: cs 학습 스페이스/엔터로 넘어가기 추가

### DIFF
--- a/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { Loader2, X, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
@@ -86,6 +86,7 @@ function splitAnswerText(answer: string): AnswerDisplay {
 
 export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
   const router = useRouter();
+  const feedbackAdvanceLockRef = useRef(false);
 
   const [phase, setPhase] = useState<Phase>('loading');
   const [currentQuestion, setCurrentQuestion] = useState<CSQuestionPayload | null>(null);
@@ -173,7 +174,8 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
   };
 
   const handleNextAfterFeedback = async () => {
-    if (!answerResult) return;
+    if (!answerResult || feedbackAdvanceLockRef.current) return;
+    feedbackAdvanceLockRef.current = true;
     const { isLast, nextQuestion, isCorrect, questionId } = answerResult;
     
     // 계속하기 버튼을 누른 후 상태 업데이트
@@ -191,6 +193,26 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
       setCurrentQuestion(nextQuestion);
     }
   };
+
+  useEffect(() => {
+    if (!answerResult) {
+      feedbackAdvanceLockRef.current = false;
+      return;
+    }
+
+    const handleFeedbackAdvanceKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing || event.keyCode === 229) return;
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+
+      event.preventDefault();
+      void handleNextAfterFeedback();
+    };
+
+    window.addEventListener('keydown', handleFeedbackAdvanceKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleFeedbackAdvanceKeyDown);
+    };
+  }, [answerResult, handleNextAfterFeedback]);
 
   const handleExitConfirm = () => {
     router.replace('/cs');
@@ -266,6 +288,7 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
             question={currentQuestion}
             onSubmit={handleAnswerSubmit}
             isSubmitting={isSubmitting}
+            isInteractionLocked={Boolean(answerResult)}
           />
         )}
       </main>

--- a/apps/frontend/src/domains/cs/components/session/CSQuestionPresenter.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSQuestionPresenter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { CSQuestionPayload, CSAttemptAnswerRequest } from '@/domains/cs/api/csApi';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -17,25 +17,46 @@ interface CSQuestionPresenterProps {
   question: CSQuestionPayload;
   onSubmit: (payload: CSAttemptAnswerRequest) => void;
   isSubmitting: boolean;
+  isInteractionLocked?: boolean;
 }
 
-export default function CSQuestionPresenter({ question, onSubmit, isSubmitting }: CSQuestionPresenterProps) {
+export default function CSQuestionPresenter({
+  question,
+  onSubmit,
+  isSubmitting,
+  isInteractionLocked = false,
+}: CSQuestionPresenterProps) {
   const [answerText, setAnswerText] = useState('');
   const [selectedChoiceNo, setSelectedChoiceNo] = useState<number | null>(null);
+  const submitLockRef = useRef(false);
 
   // 문제가 바뀔 때마다 입력 상태 초기화
   useEffect(() => {
     console.log('[DEBUG] Question changed → resetting input state. New questionId:', question.questionId, 'type:', question.questionType);
     setSelectedChoiceNo(null);
     setAnswerText('');
+    submitLockRef.current = false;
   }, [question.questionId, question.questionType]);
 
-  const handleSubmit = () => {
+  useEffect(() => {
+    if (!isSubmitting && !isInteractionLocked) {
+      submitLockRef.current = false;
+    }
+  }, [isSubmitting, isInteractionLocked]);
+
+  const isChoiceQuestion = question.questionType === 'MULTIPLE_CHOICE' || question.questionType === 'OX';
+  const isSubjectiveQuestion = question.questionType === 'SHORT_ANSWER' || question.questionType === 'ESSAY';
+
+  const handleSubmit = useCallback(() => {
+    if (isSubmitting || isInteractionLocked || submitLockRef.current) {
+      return;
+    }
+
     const payload: CSAttemptAnswerRequest = {
       questionId: question.questionId,
     };
 
-    if (question.questionType === 'MULTIPLE_CHOICE' || question.questionType === 'OX') {
+    if (isChoiceQuestion) {
       if (selectedChoiceNo === null) {
         console.log('[DEBUG] Validation failed: no choice selected');
         toast.error('선택지를 선택해주세요.');
@@ -52,15 +73,49 @@ export default function CSQuestionPresenter({ question, onSubmit, isSubmitting }
       payload.answerText = normalized;
     }
 
+    submitLockRef.current = true;
     console.log('[DEBUG] Submitting payload:', JSON.stringify(payload));
     onSubmit(payload);
-  };
+  }, [
+    answerText,
+    isChoiceQuestion,
+    isSubmitting,
+    isInteractionLocked,
+    onSubmit,
+    question.questionId,
+    selectedChoiceNo,
+  ]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing || event.keyCode === 229) return;
+      if (isSubmitting || isInteractionLocked) return;
+
+      if (isChoiceQuestion) {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        handleSubmit();
+        return;
+      }
+
+      if (isSubjectiveQuestion && event.key === 'Enter') {
+        const target = event.target as HTMLElement | null;
+        if (!target || target.tagName !== 'TEXTAREA') return;
+        event.preventDefault();
+        handleSubmit();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleSubmit, isChoiceQuestion, isInteractionLocked, isSubjectiveQuestion, isSubmitting]);
 
   const typeLabel = QUESTION_TYPE_LABEL[question.questionType] || question.questionType;
-  const isChoiceQuestion = question.questionType === 'MULTIPLE_CHOICE' || question.questionType === 'OX';
   const hasTextAnswer = answerText.trim().length > 0;
   const isAnswerReady = isChoiceQuestion ? selectedChoiceNo !== null : hasTextAnswer;
-  const isSubmitDisabled = isSubmitting || !isAnswerReady;
+  const isSubmitDisabled = isSubmitting || isInteractionLocked || !isAnswerReady;
 
   return (
     <Card className="w-full max-w-2xl mx-auto p-6 md:p-8 flex flex-col gap-6 animate-in fade-in zoom-in-95 duration-300">


### PR DESCRIPTION
## 💡 의도 / 배경
CS 학습 화면에서 매번 버튼 클릭으로 제출/진행해야 해서 키보드 중심 풀이 흐름이 끊기는 문제가 있었습니다.  
클릭 의존도를 줄이기 위해 문제 유형별 제출 키와 정답 피드백 모달의 진행 키를 추가했습니다.

## 🛠️ 작업 내용
- [x] 객관식/OX 문제에서 `Space` 또는 `Enter`로 정답 제출 가능하도록 키 입력 처리 추가
- [x] 주관식(`SHORT_ANSWER`/`ESSAY`) 문제에서 `Enter`로만 정답 제출되도록 처리 (`Space` 제출 미동작)
- [x] 정답 피드백 모달의 `계속하기`를 `Space`/`Enter`로도 진행 가능하게 처리
- [x] IME 조합 중(`event.isComposing`, `keyCode === 229`) Enter 입력은 제출/진행에서 제외
- [x] 제출/진행 연타 시 중복 요청 방지를 위한 lock 처리 추가
- [x] 피드백 모달 표시 중 문제 입력 인터랙션 잠금 처리

## 🔗 관련 이슈
- Closes #188

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] `pnpm --filter frontend exec tsc --noEmit` 실행 시 타입 오류 없음 확인
- [x] 객관식/OX에서 선택 후 `Space`/`Enter` 입력 시 제출되는지 확인
- [x] 주관식에서 `Enter`로 제출되고 `Space`로는 제출되지 않는지 확인
- [x] 정답 피드백 모달에서 `Space`/`Enter`로 다음 문제로 넘어가는지 확인
- [x] 키 연타 시 중복 제출/중복 진행이 발생하지 않는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [ ] 관련된 이슈를 Closes 항목에 포함시켰는가? (이슈 번호 입력 필요)
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
키 입력 처리를 전역 `keydown`으로 붙여두어 모달/문제 전환 시점의 키 연타에 대한 안정성을 함께 보완했습니다.  
주관식 Enter 제출은 `textarea` 대상일 때만 동작하도록 제한해 의도치 않은 전역 Enter 제출을 방지했습니다.