### PR TITLE
fix: 문제집 상세가 열려있을 때 '새로 만들기' 버튼 클릭시 문제집 생성 모달이 가려지는 문제 수정

### DIFF
--- a/apps/frontend/src/app/(main)/workbooks/page.tsx
+++ b/apps/frontend/src/app/(main)/workbooks/page.tsx
@@ -47,6 +47,7 @@ function WorkbooksContent() {
   const [modalMode, setModalMode] = useState<'create' | 'edit'>('create');
 
   const handleCreateClick = () => {
+    setSelectedId(null); // 문제집 상세 패널 닫기
     setModalMode('create');
     setModalOpen(true);
   };


### PR DESCRIPTION
## 💡 의도 / 배경
<!-- 무엇을, 왜 변경했는지 설명해주세요. 배경 및 문제를 적어주세요. -->
- 문제집 상세 정보가 열려있는 상태에서 '새로 만들기' 버튼을 클릭할 경우, 기존의 상세 패널이 그대로 남아있어 생성 모달과 겹치거나 가려지는 현상을 해결하기 위함입니다.

## 🛠️ 작업 내용
<!-- 주요 구현 사항, 로직 변경, 추가된 기능 등을 리스트업 해주세요. -->
- [x] 문제집 생성 로직 수정: handleCreateClick 발생 시 현재 선택된 문제집 ID를 초기화(setSelectedId(null)) 하도록 변경하여 우측 상세 패널을 자동으로 닫게 함.
- [x] UI 사용성 개선: '새로 만들기' 클릭 시 생성 모달에만 집중할 수 있도록 레이아웃 정리.

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: Closes #xxx) -->
- Closes #192 

## 🖼️ 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요. -->

## 🧪 테스트 방법
<!-- 이 PR이 어떻게 테스트되었는지, 리뷰어가 어떻게 테스트해 볼 수 있는지 적어주세요. -->
- [x] 로컬에서 직접 프론트 확인했습니다

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
<!-- 같이 리뷰받고 싶은 부분이나 특별히 확인해야 할 사항이 있다면 적어주세요. -->
