### PR TITLE
feat: cs 관리 페이지 개선

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsAdminController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsAdminController.java
@@ -84,11 +84,27 @@ public class CsAdminController {
         return ApiResponse.success(csAdminContentService.renameTrack(userId, trackId, request));
     }
 
+    @DeleteMapping("/tracks/{trackId}")
+    public ApiResponse<Void> deleteTrack(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long trackId) {
+        csAdminContentService.deleteTrack(userId, trackId);
+        return ApiResponse.success();
+    }
+
     @GetMapping("/stages/{stageId}/questions")
     public ApiResponse<List<CsAdminQuestionResponse>> getStageQuestions(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long stageId) {
         return ApiResponse.success(csAdminContentService.getStageQuestions(userId, stageId));
+    }
+
+    @DeleteMapping("/stages/{stageId}")
+    public ApiResponse<Void> deleteStage(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long stageId) {
+        csAdminContentService.deleteStage(userId, stageId);
+        return ApiResponse.success();
     }
 
     @PostMapping("/stages/{stageId}/questions/import")

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsAdminTrackCreateRequest.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsAdminTrackCreateRequest.java
@@ -1,10 +1,13 @@
 package com.peekle.domain.cs.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 public record CsAdminTrackCreateRequest(
         @NotBlank(message = "name은 필수입니다.")
         @Size(max = 150, message = "name은 150자 이하여야 합니다.")
-        String name) {
+        String name,
+        @Positive(message = "stageCount는 1 이상의 값이어야 합니다.")
+        Integer stageCount) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminStageSummaryResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminStageSummaryResponse.java
@@ -1,0 +1,6 @@
+package com.peekle.domain.cs.dto.response;
+
+public record CsAdminStageSummaryResponse(
+        Long stageId,
+        Integer stageNo) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminTrackResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminTrackResponse.java
@@ -5,7 +5,8 @@ import java.util.List;
 public record CsAdminTrackResponse(
         Long trackId,
         Integer domainId,
+        String domainName,
         Integer trackNo,
         String name,
-        List<Long> stageIds) {
+        List<CsAdminStageSummaryResponse> stages) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsDomainTrack.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsDomainTrack.java
@@ -46,4 +46,8 @@ public class CsDomainTrack {
     public void rename(String name) {
         this.name = name;
     }
+
+    public void updateTrackNo(short trackNo) {
+        this.trackNo = trackNo;
+    }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsStage.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsStage.java
@@ -39,4 +39,8 @@ public class CsStage {
 
     @Column(name = "stage_no", nullable = false)
     private Short stageNo;
+
+    public void updateStageNo(short stageNo) {
+        this.stageNo = stageNo;
+    }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsStageRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsStageRepository.java
@@ -21,4 +21,6 @@ public interface CsStageRepository extends JpaRepository<CsStage, Long> {
     List<CsStage> findByTrack_IdOrderByStageNoAsc(Long trackId);
 
     Optional<CsStage> findByTrack_IdAndStageNo(Long trackId, Short stageNo);
+
+    Optional<CsStage> findTopByTrack_IdOrderByStageNoDesc(Long trackId);
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsUserDomainProgressRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsUserDomainProgressRepository.java
@@ -16,4 +16,10 @@ public interface CsUserDomainProgressRepository extends JpaRepository<CsUserDoma
 
     @EntityGraph(attributePaths = "domain")
     Optional<CsUserDomainProgress> findByUser_IdAndDomain_Id(Long userId, Integer domainId);
+
+    @EntityGraph(attributePaths = "domain")
+    List<CsUserDomainProgress> findByDomain_Id(Integer domainId);
+
+    @EntityGraph(attributePaths = "domain")
+    List<CsUserDomainProgress> findByDomain_IdAndCurrentTrackNo(Integer domainId, Short currentTrackNo);
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAdminContentService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAdminContentService.java
@@ -14,6 +14,7 @@ import com.peekle.domain.cs.dto.response.CsAdminQuestionChoiceResponse;
 import com.peekle.domain.cs.dto.response.CsAdminQuestionImportResponse;
 import com.peekle.domain.cs.dto.response.CsAdminQuestionResponse;
 import com.peekle.domain.cs.dto.response.CsAdminQuestionShortAnswerResponse;
+import com.peekle.domain.cs.dto.response.CsAdminStageSummaryResponse;
 import com.peekle.domain.cs.dto.response.CsAdminTrackResponse;
 import com.peekle.domain.cs.dto.response.CsDomainResponse;
 import com.peekle.domain.cs.entity.CsDomain;
@@ -22,6 +23,7 @@ import com.peekle.domain.cs.entity.CsQuestion;
 import com.peekle.domain.cs.entity.CsQuestionChoice;
 import com.peekle.domain.cs.entity.CsQuestionShortAnswer;
 import com.peekle.domain.cs.entity.CsStage;
+import com.peekle.domain.cs.entity.CsUserDomainProgress;
 import com.peekle.domain.cs.enums.CsQuestionType;
 import com.peekle.domain.cs.repository.CsDomainRepository;
 import com.peekle.domain.cs.repository.CsDomainTrackRepository;
@@ -29,6 +31,7 @@ import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
 import com.peekle.domain.cs.repository.CsQuestionRepository;
 import com.peekle.domain.cs.repository.CsQuestionShortAnswerRepository;
 import com.peekle.domain.cs.repository.CsStageRepository;
+import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
 import com.peekle.domain.user.entity.User;
 import com.peekle.domain.user.enums.UserRole;
 import com.peekle.domain.user.repository.UserRepository;
@@ -52,7 +55,8 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class CsAdminContentService {
 
-    private static final int DEFAULT_STAGE_COUNT_PER_TRACK = 10;
+    private static final int DEFAULT_STAGE_COUNT_PER_TRACK = 5;
+    private static final int MAX_STAGE_COUNT_PER_TRACK = 20;
     private static final int REQUIRED_STAGE_QUESTION_COUNT = 10;
 
     private final CsDomainRepository csDomainRepository;
@@ -61,6 +65,7 @@ public class CsAdminContentService {
     private final CsQuestionRepository csQuestionRepository;
     private final CsQuestionChoiceRepository csQuestionChoiceRepository;
     private final CsQuestionShortAnswerRepository csQuestionShortAnswerRepository;
+    private final CsUserDomainProgressRepository csUserDomainProgressRepository;
     private final UserRepository userRepository;
 
     public List<CsDomainResponse> getDomains(Long userId) {
@@ -115,6 +120,7 @@ public class CsAdminContentService {
     public CsAdminTrackResponse createTrack(Long userId, Integer domainId, CsAdminTrackCreateRequest request) {
         assertAdmin(userId);
         CsDomain domain = getDomain(domainId);
+        int stageCount = resolveRequestedStageCount(request.stageCount());
 
         short nextTrackNo = (short) (csDomainTrackRepository.findTopByDomain_IdOrderByTrackNoDesc(domainId)
                 .map(track -> (int) track.getTrackNo())
@@ -126,21 +132,22 @@ public class CsAdminContentService {
                 .name(request.name().trim())
                 .build());
 
-        List<Long> stageIds = new ArrayList<>(DEFAULT_STAGE_COUNT_PER_TRACK);
-        for (short stageNo = 1; stageNo <= DEFAULT_STAGE_COUNT_PER_TRACK; stageNo++) {
-            CsStage stage = csStageRepository.save(CsStage.builder()
+        List<CsAdminStageSummaryResponse> stages = new ArrayList<>(stageCount);
+        for (short stageNo = 1; stageNo <= stageCount; stageNo++) {
+            CsStage savedStage = csStageRepository.save(CsStage.builder()
                     .track(track)
                     .stageNo(stageNo)
                     .build());
-            stageIds.add(stage.getId());
+            stages.add(new CsAdminStageSummaryResponse(savedStage.getId(), (int) savedStage.getStageNo()));
         }
 
         return new CsAdminTrackResponse(
                 track.getId(),
                 domainId,
+                domain.getName(),
                 (int) track.getTrackNo(),
                 track.getName(),
-                stageIds);
+                stages);
     }
 
     @Transactional
@@ -149,6 +156,67 @@ public class CsAdminContentService {
         CsDomainTrack track = getTrack(trackId);
         track.rename(request.name().trim());
         return toTrackResponse(track);
+    }
+
+    @Transactional
+    public void deleteTrack(Long userId, Long trackId) {
+        assertAdmin(userId);
+        CsDomainTrack track = getTrack(trackId);
+        Integer domainId = track.getDomain().getId();
+        short deletedTrackNo = track.getTrackNo();
+
+        List<CsDomainTrack> tracks = csDomainTrackRepository.findByDomain_IdOrderByTrackNoAsc(domainId);
+        if (tracks.size() <= 1) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "도메인에는 최소 1개의 트랙이 필요합니다.");
+        }
+
+        csDomainTrackRepository.delete(track);
+
+        List<CsDomainTrack> remainingTracks = csDomainTrackRepository.findByDomain_IdOrderByTrackNoAsc(domainId);
+        resequenceTracks(remainingTracks);
+
+        short maxTrackNo = (short) remainingTracks.size();
+        Map<Short, Short> maxStageNoByTrackNo = resolveMaxStageNoByTrackNo(remainingTracks);
+        List<CsUserDomainProgress> progresses = csUserDomainProgressRepository.findByDomain_Id(domainId);
+        for (CsUserDomainProgress progress : progresses) {
+            short nextTrackNo = resolveTrackNoAfterDeletion(progress.getCurrentTrackNo(), deletedTrackNo, maxTrackNo);
+            short nextStageNo = clampStageNo(
+                    progress.getCurrentStageNo(),
+                    maxStageNoByTrackNo.getOrDefault(nextTrackNo, (short) 1));
+
+            if (progress.getCurrentTrackNo() != nextTrackNo || progress.getCurrentStageNo() != nextStageNo) {
+                progress.advanceTo(nextTrackNo, nextStageNo);
+            }
+        }
+    }
+
+    @Transactional
+    public void deleteStage(Long userId, Long stageId) {
+        assertAdmin(userId);
+        CsStage stage = getStage(stageId);
+        Long trackId = stage.getTrack().getId();
+        Integer domainId = stage.getTrack().getDomain().getId();
+        short trackNo = stage.getTrack().getTrackNo();
+        short deletedStageNo = stage.getStageNo();
+
+        List<CsStage> stages = csStageRepository.findByTrack_IdOrderByStageNoAsc(trackId);
+        if (stages.size() <= 1) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "트랙에는 최소 1개의 스테이지가 필요합니다.");
+        }
+
+        csStageRepository.delete(stage);
+
+        List<CsStage> remainingStages = csStageRepository.findByTrack_IdOrderByStageNoAsc(trackId);
+        resequenceStages(remainingStages);
+
+        short maxStageNo = (short) remainingStages.size();
+        List<CsUserDomainProgress> progresses = csUserDomainProgressRepository.findByDomain_IdAndCurrentTrackNo(domainId, trackNo);
+        for (CsUserDomainProgress progress : progresses) {
+            short nextStageNo = resolveStageNoAfterDeletion(progress.getCurrentStageNo(), deletedStageNo, maxStageNo);
+            if (progress.getCurrentStageNo() != nextStageNo) {
+                progress.advanceTo(progress.getCurrentTrackNo(), nextStageNo);
+            }
+        }
     }
 
     public List<CsAdminQuestionResponse> getStageQuestions(Long userId, Long stageId) {
@@ -581,15 +649,101 @@ public class CsAdminContentService {
     }
 
     private CsAdminTrackResponse toTrackResponse(CsDomainTrack track) {
+        List<CsAdminStageSummaryResponse> stages = csStageRepository.findByTrack_IdOrderByStageNoAsc(track.getId())
+                .stream()
+                .map(stage -> new CsAdminStageSummaryResponse(stage.getId(), (int) stage.getStageNo()))
+                .toList();
+
         return new CsAdminTrackResponse(
                 track.getId(),
                 track.getDomain().getId(),
+                track.getDomain().getName(),
                 (int) track.getTrackNo(),
                 track.getName(),
-                csStageRepository.findByTrack_IdOrderByStageNoAsc(track.getId())
-                        .stream()
-                        .map(CsStage::getId)
-                        .toList());
+                stages);
+    }
+
+    private int resolveRequestedStageCount(Integer requestedStageCount) {
+        if (requestedStageCount == null) {
+            return DEFAULT_STAGE_COUNT_PER_TRACK;
+        }
+        if (requestedStageCount < 1 || requestedStageCount > MAX_STAGE_COUNT_PER_TRACK) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_INPUT_VALUE,
+                    "stageCount는 1 이상 " + MAX_STAGE_COUNT_PER_TRACK + " 이하여야 합니다.");
+        }
+        return requestedStageCount;
+    }
+
+    private void resequenceTracks(List<CsDomainTrack> tracks) {
+        for (int i = 0; i < tracks.size(); i++) {
+            short expectedTrackNo = (short) (i + 1);
+            CsDomainTrack current = tracks.get(i);
+            if (current.getTrackNo() != expectedTrackNo) {
+                current.updateTrackNo(expectedTrackNo);
+            }
+        }
+    }
+
+    private void resequenceStages(List<CsStage> stages) {
+        for (int i = 0; i < stages.size(); i++) {
+            short expectedStageNo = (short) (i + 1);
+            CsStage current = stages.get(i);
+            if (current.getStageNo() != expectedStageNo) {
+                current.updateStageNo(expectedStageNo);
+            }
+        }
+    }
+
+    private Map<Short, Short> resolveMaxStageNoByTrackNo(List<CsDomainTrack> tracks) {
+        Map<Short, Short> maxStageNoByTrackNo = new HashMap<>();
+        for (CsDomainTrack current : tracks) {
+            short maxStageNo = csStageRepository.findTopByTrack_IdOrderByStageNoDesc(current.getId())
+                    .map(CsStage::getStageNo)
+                    .orElse((short) 1);
+            maxStageNoByTrackNo.put(current.getTrackNo(), maxStageNo);
+        }
+        return maxStageNoByTrackNo;
+    }
+
+    private short resolveTrackNoAfterDeletion(short currentTrackNo, short deletedTrackNo, short maxTrackNo) {
+        if (currentTrackNo > deletedTrackNo) {
+            return clampTrackNo((short) (currentTrackNo - 1), maxTrackNo);
+        }
+        if (currentTrackNo == deletedTrackNo) {
+            return clampTrackNo((short) Math.min(deletedTrackNo, maxTrackNo), maxTrackNo);
+        }
+        return clampTrackNo(currentTrackNo, maxTrackNo);
+    }
+
+    private short resolveStageNoAfterDeletion(short currentStageNo, short deletedStageNo, short maxStageNo) {
+        if (currentStageNo > deletedStageNo) {
+            return clampStageNo((short) (currentStageNo - 1), maxStageNo);
+        }
+        if (currentStageNo == deletedStageNo) {
+            return clampStageNo(currentStageNo, maxStageNo);
+        }
+        return clampStageNo(currentStageNo, maxStageNo);
+    }
+
+    private short clampTrackNo(short trackNo, short maxTrackNo) {
+        if (trackNo < 1) {
+            return 1;
+        }
+        if (trackNo > maxTrackNo) {
+            return maxTrackNo;
+        }
+        return trackNo;
+    }
+
+    private short clampStageNo(short stageNo, short maxStageNo) {
+        if (stageNo < 1) {
+            return 1;
+        }
+        if (stageNo > maxStageNo) {
+            return maxStageNo;
+        }
+        return stageNo;
     }
 
     private void assertAdmin(Long userId) {

--- a/apps/frontend/src/app/admin/cs-content/page.tsx
+++ b/apps/frontend/src/app/admin/cs-content/page.tsx
@@ -12,6 +12,7 @@ export default function CsContentAdminPage() {
   const [selectedDomainId, setSelectedDomainId] = useState<number | null>(null);
   const [selectedTrack, setSelectedTrack] = useState<CSAdminTrack | null>(null);
   const [selectedStageId, setSelectedStageId] = useState<number | null>(null);
+  const selectedStage = selectedTrack?.stages.find((stage) => stage.stageId === selectedStageId) ?? null;
 
   return (
     <div className="container mx-auto py-5">
@@ -38,8 +39,8 @@ export default function CsContentAdminPage() {
               <CardHeader className="px-5 pt-5 pb-3">
                 <CardTitle className="text-xl">스테이지 편집</CardTitle>
                 <CardDescription>
-                  스테이지 {selectedStageId} 문제 편집
-                  (트랙: {selectedTrack?.name})
+                  {selectedTrack?.domainName} / {selectedTrack?.domainId}-{selectedTrack?.trackNo}) {selectedTrack?.name}
+                  {selectedStage ? ` · 스테이지 ${selectedStage.stageNo} 문제 편집` : ''}
                 </CardDescription>
               </CardHeader>
               <CardContent className="px-5 pb-5 pt-0">

--- a/apps/frontend/src/domains/admin/components/CsDomainManager.tsx
+++ b/apps/frontend/src/domains/admin/components/CsDomainManager.tsx
@@ -11,6 +11,8 @@ import {
   fetchAdminTracks,
   createAdminTrack,
   renameAdminTrack,
+  deleteAdminTrack,
+  deleteAdminStage,
   CSAdminTrack
 } from '@/domains/cs/api/csAdminApi';
 import { CSDomain } from '@/domains/cs/api/csApi';
@@ -54,8 +56,10 @@ export default function CsDomainManager({
     try {
       const data = await fetchAdminTracks(domainId);
       setTracks(data);
+      return data;
     } catch (err: any) {
       toast({ variant: 'destructive', title: '오류', description: err.message });
+      return [];
     } finally {
       setLoadingTracks(false);
     }
@@ -121,12 +125,22 @@ export default function CsDomainManager({
 
   const handleCreateTrack = async () => {
     if (!selectedDomainId) return;
-    const name = prompt('새 트랙 이름을 입력하세요 (생성 시 10개 스테이지 자동생성)');
+    const name = prompt('새 트랙 이름을 입력하세요');
     if (!name?.trim()) return;
+
+    const stageCountInput = prompt('초기 스테이지 수를 입력하세요 (기본 5, 1~20)', '5');
+    if (stageCountInput === null) return;
+
+    const stageCount = parseInt(stageCountInput, 10);
+    if (Number.isNaN(stageCount) || stageCount < 1 || stageCount > 20) {
+      toast({ variant: 'destructive', title: '오류', description: '스테이지 수는 1~20 사이 숫자여야 합니다.' });
+      return;
+    }
+
     try {
-      const newTrack = await createAdminTrack(selectedDomainId, name.trim());
-      setTracks([...tracks, newTrack]);
-      toast({ title: '트랙 생성 성공 (스테이지 10개 포함)' });
+      const newTrack = await createAdminTrack(selectedDomainId, name.trim(), stageCount);
+      setTracks([...tracks, newTrack].sort((a, b) => a.trackNo - b.trackNo));
+      toast({ title: `트랙 생성 성공 (스테이지 ${stageCount}개)` });
     } catch (err: any) {
       toast({ variant: 'destructive', title: '오류', description: err.message });
     }
@@ -147,6 +161,70 @@ export default function CsDomainManager({
         onSelectTrack(updated);
       }
       toast({ title: '트랙 이름 변경 성공' });
+    } catch (err: any) {
+      toast({ variant: 'destructive', title: '오류', description: err.message });
+    }
+  };
+
+  const handleDeleteTrack = async (trackId: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!selectedDomainId) return;
+    if (!confirm('정말 트랙을 삭제하시겠습니까? 포함된 스테이지/문제가 함께 삭제됩니다.')) return;
+
+    try {
+      await deleteAdminTrack(trackId);
+      const reloadedTracks = await loadTracks(selectedDomainId);
+
+      if (selectedTrack?.trackId === trackId) {
+        onSelectTrack(null);
+        onSelectStage(null);
+      } else if (selectedTrack) {
+        const refreshedSelectedTrack = reloadedTracks.find((track) => track.trackId === selectedTrack.trackId) ?? null;
+        onSelectTrack(refreshedSelectedTrack);
+        if (!refreshedSelectedTrack || !refreshedSelectedTrack.stages.some((stage) => stage.stageId === selectedStageId)) {
+          onSelectStage(null);
+        }
+      }
+
+      toast({ title: '트랙 삭제 성공' });
+    } catch (err: any) {
+      toast({ variant: 'destructive', title: '오류', description: err.message });
+    }
+  };
+
+  const handleDeleteStage = async (
+    trackId: number,
+    stageId: number,
+    stageNo: number,
+    e: React.MouseEvent
+  ) => {
+    e.stopPropagation();
+    if (!selectedDomainId) return;
+    if (!confirm(`스테이지 ${stageNo}를 삭제하시겠습니까? 포함된 문제가 함께 삭제됩니다.`)) return;
+
+    try {
+      await deleteAdminStage(stageId);
+      const reloadedTracks = await loadTracks(selectedDomainId);
+      const refreshedTrack = reloadedTracks.find((track) => track.trackId === trackId) ?? null;
+
+      if (!refreshedTrack) {
+        onSelectTrack(null);
+        onSelectStage(null);
+        toast({ title: '스테이지 삭제 성공' });
+        return;
+      }
+
+      onSelectTrack(refreshedTrack);
+      if (selectedStageId === stageId) {
+        const preferredStage = refreshedTrack.stages.find((stage) => stage.stageNo === stageNo)
+          ?? refreshedTrack.stages[refreshedTrack.stages.length - 1]
+          ?? null;
+        onSelectStage(preferredStage?.stageId ?? null);
+      } else if (!refreshedTrack.stages.some((stage) => stage.stageId === selectedStageId)) {
+        onSelectStage(null);
+      }
+
+      toast({ title: '스테이지 삭제 성공' });
     } catch (err: any) {
       toast({ variant: 'destructive', title: '오류', description: err.message });
     }
@@ -198,7 +276,7 @@ export default function CsDomainManager({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-md">트랙</CardTitle>
-            <Button variant="ghost" size="icon" onClick={handleCreateTrack}>
+            <Button variant="ghost" size="icon" onClick={handleCreateTrack} disabled={loadingTracks}>
               <Plus className="h-4 w-4" />
             </Button>
           </CardHeader>
@@ -218,18 +296,34 @@ export default function CsDomainManager({
                       <Button variant="ghost" size="icon" className="h-6 w-6" onClick={(e) => handleRenameTrack(t.trackId, e)}>
                         <Pencil className="h-4 w-4" />
                       </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 text-destructive"
+                        onClick={(e) => handleDeleteTrack(t.trackId, e)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                       <ChevronRight className={`h-4 w-4 transition-transform ${selectedTrack?.trackId === t.trackId ? 'rotate-90' : ''}`} />
                     </div>
                   </div>
                   {selectedTrack?.trackId === t.trackId && (
                     <ul className="bg-muted/30 pl-6 pb-2">
-                      {t.stageIds?.map((stageId, i) => (
+                      {t.stages?.map((stage) => (
                         <li 
-                          key={stageId}
-                          className={`p-2 text-sm cursor-pointer hover:text-primary ${selectedStageId === stageId ? 'text-primary font-bold' : 'text-muted-foreground'}`}
-                          onClick={() => onSelectStage(stageId)}
+                          key={stage.stageId}
+                          className={`p-2 text-sm cursor-pointer hover:text-primary ${selectedStageId === stage.stageId ? 'text-primary font-bold' : 'text-muted-foreground'} flex items-center justify-between`}
+                          onClick={() => onSelectStage(stage.stageId)}
                         >
-                          스테이지 {i + 1}
+                          <span>스테이지 {stage.stageNo}</span>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 text-destructive"
+                            onClick={(e) => handleDeleteStage(t.trackId, stage.stageId, stage.stageNo, e)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
                         </li>
                       ))}
                     </ul>

--- a/apps/frontend/src/domains/cs/api/csAdminApi.ts
+++ b/apps/frontend/src/domains/cs/api/csAdminApi.ts
@@ -5,9 +5,15 @@ import { CSDomain, CSQuestionType } from './csApi';
 export interface CSAdminTrack {
   trackId: number;
   domainId: number;
+  domainName: string;
   trackNo: number;
   name: string;
-  stageIds: number[];
+  stages: CSAdminStageSummary[];
+}
+
+export interface CSAdminStageSummary {
+  stageId: number;
+  stageNo: number;
 }
 
 export interface CSAdminQuestionChoice {
@@ -94,10 +100,14 @@ export const fetchAdminTracks = async (domainId: number): Promise<CSAdminTrack[]
   return assertApiData(response, '트랙 목록을 불러오지 못했습니다.');
 };
 
-export const createAdminTrack = async (domainId: number, name: string): Promise<CSAdminTrack> => {
+export const createAdminTrack = async (
+  domainId: number,
+  name: string,
+  stageCount?: number
+): Promise<CSAdminTrack> => {
   const response = await apiFetch<CSAdminTrack>(`/api/cs/admin/domains/${domainId}/tracks`, {
     method: 'POST',
-    body: JSON.stringify({ name }),
+    body: JSON.stringify({ name, stageCount }),
   });
   return assertApiData(response, '트랙 생성에 실패했습니다.');
 };
@@ -108,6 +118,24 @@ export const renameAdminTrack = async (trackId: number, name: string): Promise<C
     body: JSON.stringify({ name }),
   });
   return assertApiData(response, '트랙 이름 변경에 실패했습니다.');
+};
+
+export const deleteAdminTrack = async (trackId: number): Promise<void> => {
+  const response = await apiFetch<void>(`/api/cs/admin/tracks/${trackId}`, {
+    method: 'DELETE',
+  });
+  if (!response.success) {
+    throw new Error(response.error?.message || '트랙 삭제에 실패했습니다.');
+  }
+};
+
+export const deleteAdminStage = async (stageId: number): Promise<void> => {
+  const response = await apiFetch<void>(`/api/cs/admin/stages/${stageId}`, {
+    method: 'DELETE',
+  });
+  if (!response.success) {
+    throw new Error(response.error?.message || '스테이지 삭제에 실패했습니다.');
+  }
 };
 
 /** Stage/Question Management */


### PR DESCRIPTION
## 💡 의도 / 배경
CS 관리자 페이지에서 트랙 생성 시 스테이지 수가 10개로 고정되어 운영 유연성이 낮았고, 트랙/스테이지 삭제 기능이 없어 관리가 불편했습니다.  
또한 스테이지 편집 화면이 `stageId` 중심 표기라 운영자가 컨텍스트(도메인/트랙)를 빠르게 파악하기 어려운 문제가 있었습니다.

## 🛠️ 작업 내용
- [x] 트랙 생성 시 `stageCount` 입력 지원(기본 5, 범위 1~20)
- [x] 트랙 삭제 API/관리자 UI 삭제 버튼 추가
- [x] 스테이지 삭제 API/관리자 UI 삭제 버튼 추가
- [x] 삭제 시 번호 재정렬(트랙번호/스테이지번호) 및 진행도 보정 로직 추가
- [x] 삭제 불가 조건(최소 1개 유지) 검증 및 에러 메시지 처리
- [x] 스테이지 편집 헤더를 `도메인명 / 도메인번호-트랙번호) 트랙명` 형식으로 개선
- [x] `stageId` 단독 메인 표기 제거(보조 정보 중심으로 변경)

## 🔗 관련 이슈
- Closes #194 

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] 백엔드 컴파일 확인: `cmd /c gradlew.bat compileJava` (workdir: `apps/backend`)
- [x] 프론트 타입체크 확인: `cmd /c pnpm --filter frontend exec tsc --noEmit`
- [x] 관리자 화면에서 트랙/스테이지 삭제 동작 및 확인 모달 노출 수동 확인
- [x] 삭제 불가 케이스(최소 1개 남을 때) 에러 메시지 노출 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- 현재 삭제 확인은 브라우저 기본 `confirm`을 사용합니다.  
- 디자인 시스템 모달로 교체가 필요하면 후속 PR에서 통일하겠습니다.