### PR TITLE
feat: 단답형 멀티빈칸 채점 확장 (순서무관 + 빈칸별 1:N 정답)

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsAdminQuestionShortAnswerDraft.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsAdminQuestionShortAnswerDraft.java
@@ -5,5 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 public record CsAdminQuestionShortAnswerDraft(
         @NotBlank(message = "answerText는 필수입니다.")
         String answerText,
+        Integer blankIndex,
         Boolean isPrimary) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminQuestionShortAnswerResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminQuestionShortAnswerResponse.java
@@ -4,5 +4,6 @@ public record CsAdminQuestionShortAnswerResponse(
         Long shortAnswerId,
         String answerText,
         String normalizedAnswer,
+        Integer blankIndex,
         Boolean isPrimary) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsQuestionShortAnswer.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsQuestionShortAnswer.java
@@ -24,8 +24,8 @@ import lombok.NoArgsConstructor;
         name = "cs_question_short_answers",
         uniqueConstraints = {
                 @UniqueConstraint(
-                        name = "uk_cs_question_short_answers_question_normalized",
-                        columnNames = { "question_id", "normalized_answer" })
+                        name = "uk_cs_question_short_answers_question_blank_normalized",
+                        columnNames = { "question_id", "blank_index", "normalized_answer" })
         })
 public class CsQuestionShortAnswer {
 
@@ -44,12 +44,17 @@ public class CsQuestionShortAnswer {
     private String normalizedAnswer;
 
     @Builder.Default
+    @Column(name = "blank_index", nullable = false)
+    private Short blankIndex = 1;
+
+    @Builder.Default
     @Column(name = "is_primary", nullable = false)
     private Boolean isPrimary = false;
 
-    public void update(String answerText, String normalizedAnswer, Boolean isPrimary) {
+    public void update(String answerText, String normalizedAnswer, Short blankIndex, Boolean isPrimary) {
         this.answerText = answerText;
         this.normalizedAnswer = normalizedAnswer;
+        this.blankIndex = blankIndex;
         this.isPrimary = isPrimary;
     }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/enums/CsQuestionGradingMode.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/enums/CsQuestionGradingMode.java
@@ -5,5 +5,6 @@ public enum CsQuestionGradingMode {
     SINGLE_CHOICE,
     SHORT_TEXT_EXACT,
     MULTI_BLANK_ORDERED,
+    MULTI_BLANK_UNORDERED,
     ORDERING
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionShortAnswerRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionShortAnswerRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface CsQuestionShortAnswerRepository extends JpaRepository<CsQuestionShortAnswer, Long> {
-    List<CsQuestionShortAnswer> findByQuestion_IdOrderByIsPrimaryDescIdAsc(Long questionId);
+    List<CsQuestionShortAnswer> findByQuestion_IdOrderByBlankIndexAscIsPrimaryDescIdAsc(Long questionId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from CsQuestionShortAnswer s where s.question.id = :questionId")

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAdminContentService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAdminContentService.java
@@ -66,6 +66,7 @@ public class CsAdminContentService {
     private static final int PAST_EXAM_MAX_STAGE_QUESTION_COUNT = 20;
     private static final int PAST_EXAM_MIN_YEAR = 2020;
     private static final int PAST_EXAM_MAX_YEAR = 2025;
+    private static final short DEFAULT_SHORT_ANSWER_BLANK_INDEX = 1;
     private static final Set<String> ALLOWED_IMAGE_CONTENT_TYPES = Set.of(
             "image/jpeg",
             "image/jpg",
@@ -347,7 +348,9 @@ public class CsAdminContentService {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "단답형 문제만 정답을 수정할 수 있습니다.");
         }
 
-        List<CsAdminQuestionShortAnswerDraft> normalized = validateShortAnswers(request.shortAnswers());
+        List<CsAdminQuestionShortAnswerDraft> normalized = validateShortAnswers(
+                request.shortAnswers(),
+                resolveEffectiveGradingMode(question));
         syncShortAnswers(question, normalized);
 
         return toAdminQuestionResponse(question);
@@ -447,7 +450,7 @@ public class CsAdminContentService {
         }
 
         if (draft.questionType() == CsQuestionType.SHORT_ANSWER) {
-            syncShortAnswers(question, validateShortAnswers(draft.shortAnswers()));
+            syncShortAnswers(question, validateShortAnswers(draft.shortAnswers(), gradingMode));
             return;
         }
 
@@ -459,7 +462,7 @@ public class CsAdminContentService {
             saveChoices(question, draft.choices());
             return;
         }
-        saveShortAnswers(question, validateShortAnswers(draft.shortAnswers()));
+        saveShortAnswers(question, validateShortAnswers(draft.shortAnswers(), resolveGradingMode(draft)));
     }
 
     private void saveChoices(CsQuestion question, List<CsAdminQuestionChoiceDraft> choices) {
@@ -510,10 +513,12 @@ public class CsAdminContentService {
     private void saveShortAnswers(CsQuestion question, List<CsAdminQuestionShortAnswerDraft> shortAnswers) {
         List<CsAdminQuestionShortAnswerDraft> normalizedDrafts = normalizePrimaryShortAnswers(shortAnswers);
         for (CsAdminQuestionShortAnswerDraft answer : normalizedDrafts) {
+            short blankIndex = normalizeBlankIndex(answer.blankIndex());
             csQuestionShortAnswerRepository.save(CsQuestionShortAnswer.builder()
                     .question(question)
                     .answerText(answer.answerText().trim())
                     .normalizedAnswer(normalizeStrict(answer.answerText()))
+                    .blankIndex(blankIndex)
                     .isPrimary(Boolean.TRUE.equals(answer.isPrimary()))
                     .build());
         }
@@ -522,21 +527,26 @@ public class CsAdminContentService {
     private void syncShortAnswers(CsQuestion question, List<CsAdminQuestionShortAnswerDraft> shortAnswers) {
         List<CsAdminQuestionShortAnswerDraft> normalizedDrafts = normalizePrimaryShortAnswers(shortAnswers);
         List<CsQuestionShortAnswer> existingAnswers = csQuestionShortAnswerRepository
-                .findByQuestion_IdOrderByIsPrimaryDescIdAsc(question.getId());
+                .findByQuestion_IdOrderByBlankIndexAscIsPrimaryDescIdAsc(question.getId());
 
-        Map<String, CsQuestionShortAnswer> existingByNormalized = new HashMap<>();
+        Map<String, CsQuestionShortAnswer> existingByBlankAndNormalized = new HashMap<>();
         for (CsQuestionShortAnswer existingAnswer : existingAnswers) {
-            existingByNormalized.put(existingAnswer.getNormalizedAnswer(), existingAnswer);
+            existingByBlankAndNormalized.put(
+                    toShortAnswerKey(existingAnswer.getBlankIndex(), existingAnswer.getNormalizedAnswer()),
+                    existingAnswer);
         }
 
         for (CsAdminQuestionShortAnswerDraft answer : normalizedDrafts) {
             String normalized = normalizeStrict(answer.answerText());
-            CsQuestionShortAnswer existing = existingByNormalized.remove(normalized);
+            short blankIndex = normalizeBlankIndex(answer.blankIndex());
+            String key = toShortAnswerKey(blankIndex, normalized);
+            CsQuestionShortAnswer existing = existingByBlankAndNormalized.remove(key);
             if (existing == null) {
                 csQuestionShortAnswerRepository.save(CsQuestionShortAnswer.builder()
                         .question(question)
                         .answerText(answer.answerText().trim())
                         .normalizedAnswer(normalized)
+                        .blankIndex(blankIndex)
                         .isPrimary(Boolean.TRUE.equals(answer.isPrimary()))
                         .build());
                 continue;
@@ -545,11 +555,12 @@ public class CsAdminContentService {
             existing.update(
                     answer.answerText().trim(),
                     normalized,
+                    blankIndex,
                     Boolean.TRUE.equals(answer.isPrimary()));
         }
 
-        if (!existingByNormalized.isEmpty()) {
-            csQuestionShortAnswerRepository.deleteAllInBatch(existingByNormalized.values());
+        if (!existingByBlankAndNormalized.isEmpty()) {
+            csQuestionShortAnswerRepository.deleteAllInBatch(existingByBlankAndNormalized.values());
         }
     }
 
@@ -581,7 +592,7 @@ public class CsAdminContentService {
             validateChoices(draft.choices(), true);
             return;
         }
-        validateShortAnswers(draft.shortAnswers());
+        validateShortAnswers(draft.shortAnswers(), resolveGradingMode(draft));
     }
 
     private void validateChoices(List<CsAdminQuestionChoiceDraft> choices, boolean ox) {
@@ -623,12 +634,16 @@ public class CsAdminContentService {
         }
     }
 
-    private List<CsAdminQuestionShortAnswerDraft> validateShortAnswers(List<CsAdminQuestionShortAnswerDraft> shortAnswers) {
+    private List<CsAdminQuestionShortAnswerDraft> validateShortAnswers(
+            List<CsAdminQuestionShortAnswerDraft> shortAnswers,
+            CsQuestionGradingMode gradingMode) {
         if (shortAnswers == null || shortAnswers.isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "단답형 문제는 shortAnswers가 1개 이상 필요합니다.");
         }
 
         Set<String> normalizedSet = new HashSet<>();
+        Map<Short, Integer> answerCountByBlank = new HashMap<>();
+        Map<Short, Integer> primaryCountByBlank = new HashMap<>();
         List<CsAdminQuestionShortAnswerDraft> normalized = new ArrayList<>(shortAnswers.size());
         for (CsAdminQuestionShortAnswerDraft answer : shortAnswers) {
             String trimmed = answer.answerText() == null ? "" : answer.answerText().trim();
@@ -636,13 +651,46 @@ public class CsAdminContentService {
                 throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "shortAnswers.answerText는 비어 있을 수 없습니다.");
             }
 
+            short blankIndex = normalizeBlankIndex(answer.blankIndex());
             String normalizedAnswer = normalizeStrict(trimmed);
-            if (!normalizedSet.add(normalizedAnswer)) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "단답형 정답은 중복될 수 없습니다.");
+            if (!normalizedSet.add(toShortAnswerKey(blankIndex, normalizedAnswer))) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "같은 빈칸의 단답형 정답은 중복될 수 없습니다.");
             }
 
-            normalized.add(new CsAdminQuestionShortAnswerDraft(trimmed, answer.isPrimary()));
+            answerCountByBlank.merge(blankIndex, 1, Integer::sum);
+            if (Boolean.TRUE.equals(answer.isPrimary())) {
+                primaryCountByBlank.merge(blankIndex, 1, Integer::sum);
+            }
+
+            normalized.add(new CsAdminQuestionShortAnswerDraft(trimmed, (int) blankIndex, answer.isPrimary()));
         }
+
+        for (Map.Entry<Short, Integer> primaryEntry : primaryCountByBlank.entrySet()) {
+            if (primaryEntry.getValue() != null && primaryEntry.getValue() > 1) {
+                throw new BusinessException(
+                        ErrorCode.INVALID_INPUT_VALUE,
+                        primaryEntry.getKey() + "번 빈칸에는 대표 정답을 1개만 설정할 수 있습니다.");
+            }
+        }
+
+        if (isMultiBlankGradingMode(gradingMode)) {
+            if (answerCountByBlank.size() < 2) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "멀티 빈칸 문제는 빈칸별 정답이 최소 2개 이상 필요합니다.");
+            }
+            short maxBlankIndex = answerCountByBlank.keySet().stream()
+                    .max(Short::compareTo)
+                    .orElse(DEFAULT_SHORT_ANSWER_BLANK_INDEX);
+            for (short i = 1; i <= maxBlankIndex; i++) {
+                if (!answerCountByBlank.containsKey(i)) {
+                    throw new BusinessException(
+                            ErrorCode.INVALID_INPUT_VALUE,
+                            "빈칸 번호는 1부터 순서대로 입력해야 합니다. 누락된 번호: " + i);
+                }
+            }
+        } else if (answerCountByBlank.keySet().stream().anyMatch(index -> index != DEFAULT_SHORT_ANSWER_BLANK_INDEX)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "단일 단답 모드에서는 blankIndex를 1로만 설정할 수 있습니다.");
+        }
+
         return normalized;
     }
 
@@ -712,18 +760,34 @@ public class CsAdminContentService {
     private List<CsAdminQuestionShortAnswerDraft> normalizePrimaryShortAnswers(
             List<CsAdminQuestionShortAnswerDraft> shortAnswers) {
         List<CsAdminQuestionShortAnswerDraft> normalizedDrafts = new ArrayList<>(shortAnswers.size());
-        boolean hasPrimary = shortAnswers.stream()
-                .anyMatch(answer -> Boolean.TRUE.equals(answer.isPrimary()));
+        Map<Short, Integer> firstIndexByBlank = new HashMap<>();
+        Set<Short> hasPrimaryByBlank = new HashSet<>();
 
         for (int i = 0; i < shortAnswers.size(); i++) {
             CsAdminQuestionShortAnswerDraft answer = shortAnswers.get(i);
-            boolean isPrimary = hasPrimary
-                    ? Boolean.TRUE.equals(answer.isPrimary())
-                    : i == 0;
+            short blankIndex = normalizeBlankIndex(answer.blankIndex());
+            boolean isPrimary = Boolean.TRUE.equals(answer.isPrimary());
+            if (isPrimary) {
+                hasPrimaryByBlank.add(blankIndex);
+            }
+            firstIndexByBlank.putIfAbsent(blankIndex, i);
 
             normalizedDrafts.add(new CsAdminQuestionShortAnswerDraft(
                     answer.answerText().trim(),
+                    (int) blankIndex,
                     isPrimary));
+        }
+
+        for (Map.Entry<Short, Integer> entry : firstIndexByBlank.entrySet()) {
+            if (hasPrimaryByBlank.contains(entry.getKey())) {
+                continue;
+            }
+            int index = entry.getValue();
+            CsAdminQuestionShortAnswerDraft answer = normalizedDrafts.get(index);
+            normalizedDrafts.set(index, new CsAdminQuestionShortAnswerDraft(
+                    answer.answerText(),
+                    answer.blankIndex(),
+                    true));
         }
         return normalizedDrafts;
     }
@@ -739,12 +803,13 @@ public class CsAdminContentService {
                 .toList();
 
         List<CsAdminQuestionShortAnswerResponse> shortAnswers = csQuestionShortAnswerRepository
-                .findByQuestion_IdOrderByIsPrimaryDescIdAsc(question.getId())
+                .findByQuestion_IdOrderByBlankIndexAscIsPrimaryDescIdAsc(question.getId())
                 .stream()
                 .map(answer -> new CsAdminQuestionShortAnswerResponse(
                         answer.getId(),
                         answer.getAnswerText(),
                         answer.getNormalizedAnswer(),
+                        answer.getBlankIndex() == null ? (int) DEFAULT_SHORT_ANSWER_BLANK_INDEX : (int) answer.getBlankIndex(),
                         answer.getIsPrimary()))
                 .toList();
 
@@ -778,6 +843,37 @@ public class CsAdminContentService {
             case MULTIPLE_CHOICE, OX -> CsQuestionGradingMode.SINGLE_CHOICE;
             case SHORT_ANSWER -> CsQuestionGradingMode.SHORT_TEXT_EXACT;
         };
+    }
+
+    private CsQuestionGradingMode resolveEffectiveGradingMode(CsQuestion question) {
+        CsQuestionGradingMode gradingMode = question.getGradingMode();
+        if (gradingMode == null || gradingMode == CsQuestionGradingMode.DEFAULT_BY_TYPE) {
+            return question.getQuestionType() == CsQuestionType.SHORT_ANSWER
+                    ? CsQuestionGradingMode.SHORT_TEXT_EXACT
+                    : CsQuestionGradingMode.SINGLE_CHOICE;
+        }
+        return gradingMode;
+    }
+
+    private boolean isMultiBlankGradingMode(CsQuestionGradingMode gradingMode) {
+        return gradingMode == CsQuestionGradingMode.MULTI_BLANK_ORDERED
+                || gradingMode == CsQuestionGradingMode.MULTI_BLANK_UNORDERED
+                || gradingMode == CsQuestionGradingMode.ORDERING;
+    }
+
+    private short normalizeBlankIndex(Integer blankIndex) {
+        if (blankIndex == null || blankIndex < 1) {
+            return DEFAULT_SHORT_ANSWER_BLANK_INDEX;
+        }
+        if (blankIndex > Short.MAX_VALUE) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "blankIndex 값이 너무 큽니다.");
+        }
+        return blankIndex.shortValue();
+    }
+
+    private String toShortAnswerKey(Short blankIndex, String normalizedAnswer) {
+        short safeBlankIndex = blankIndex == null ? DEFAULT_SHORT_ANSWER_BLANK_INDEX : blankIndex;
+        return safeBlankIndex + ":" + normalizedAnswer;
     }
 
     private String normalizeContentBlocks(CsQuestionContentMode contentMode, String contentBlocks) {

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
@@ -387,7 +387,7 @@ public class CsAttemptService {
                 }
 
                 List<CsQuestionShortAnswer> acceptableAnswers = csQuestionShortAnswerRepository
-                        .findByQuestion_IdOrderByIsPrimaryDescIdAsc(question.getId());
+                        .findByQuestion_IdOrderByBlankIndexAscIsPrimaryDescIdAsc(question.getId());
                 if (acceptableAnswers.isEmpty()) {
                     throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "단답형 정답 구성이 올바르지 않습니다.");
                 }
@@ -395,8 +395,7 @@ public class CsAttemptService {
                 String submitted = answerText.strip();
                 CsQuestionGradingMode gradingMode = resolveEffectiveGradingMode(question);
 
-                if (gradingMode == CsQuestionGradingMode.MULTI_BLANK_ORDERED
-                        || gradingMode == CsQuestionGradingMode.ORDERING) {
+                if (isOrderedMultiBlankMode(gradingMode)) {
                     List<String> submittedParts = parseOrderedSubmittedAnswers(submitted);
                     List<String> expectedParts = resolveOrderedExpectedAnswers(question, acceptableAnswers);
                     boolean isCorrect = isOrderedAnswerCorrect(submittedParts, expectedParts);
@@ -405,6 +404,18 @@ public class CsAttemptService {
                             isCorrect,
                             null,
                             isCorrect ? null : formatOrderedAnswerForFeedback(expectedParts),
+                            question.getExplanation());
+                }
+
+                if (gradingMode == CsQuestionGradingMode.MULTI_BLANK_UNORDERED) {
+                    List<String> submittedParts = parseOrderedSubmittedAnswers(submitted);
+                    List<String> expectedParts = resolveOrderedExpectedAnswers(question, acceptableAnswers);
+                    boolean isCorrect = isUnorderedAnswerCorrect(submittedParts, expectedParts);
+
+                    yield new GradingResult(
+                            isCorrect,
+                            null,
+                            isCorrect ? null : formatUnorderedAnswerForFeedback(expectedParts),
                             question.getExplanation());
                 }
 
@@ -664,10 +675,23 @@ public class CsAttemptService {
     }
 
     private List<String> resolveOrderedExpectedAnswers(CsQuestion question, List<CsQuestionShortAnswer> acceptableAnswers) {
-        List<String> answerTexts = acceptableAnswers.stream()
+        List<CsQuestionShortAnswer> sortedAnswers = acceptableAnswers.stream()
                 .sorted(Comparator
-                        .comparing((CsQuestionShortAnswer answer) -> !Boolean.TRUE.equals(answer.getIsPrimary()))
+                        .comparing((CsQuestionShortAnswer answer) -> answer.getBlankIndex() == null
+                                ? (short) 1
+                                : answer.getBlankIndex())
+                        .thenComparing((CsQuestionShortAnswer answer) -> !Boolean.TRUE.equals(answer.getIsPrimary()))
                         .thenComparing(CsQuestionShortAnswer::getId))
+                .toList();
+
+        List<String> groupedByBlank = resolveExpectedAnswersByBlankGroup(sortedAnswers);
+        int expectedCount = extractExpectedBlankCount(question.getMetadata());
+        if (groupedByBlank.size() > 1
+                && (expectedCount <= 1 || groupedByBlank.size() == expectedCount)) {
+            return groupedByBlank;
+        }
+
+        List<String> answerTexts = sortedAnswers.stream()
                 .map(this::resolveDisplayAnswerText)
                 .filter(text -> text != null && !text.isBlank())
                 .map(String::trim)
@@ -677,7 +701,6 @@ public class CsAttemptService {
             return List.of();
         }
 
-        int expectedCount = extractExpectedBlankCount(question.getMetadata());
         if (expectedCount > 1) {
             if (answerTexts.size() >= expectedCount) {
                 return new ArrayList<>(answerTexts.subList(0, expectedCount));
@@ -695,6 +718,36 @@ public class CsAttemptService {
 
         List<String> splitSingle = splitOrderedTokens(answerTexts.get(0));
         return splitSingle.isEmpty() ? answerTexts : splitSingle;
+    }
+
+    private List<String> resolveExpectedAnswersByBlankGroup(List<CsQuestionShortAnswer> sortedAnswers) {
+        Map<Short, List<String>> answersByBlank = new java.util.LinkedHashMap<>();
+        for (CsQuestionShortAnswer answer : sortedAnswers) {
+            String displayText = resolveDisplayAnswerText(answer);
+            if (displayText == null || displayText.isBlank()) {
+                continue;
+            }
+            short blankIndex = answer.getBlankIndex() == null ? 1 : answer.getBlankIndex();
+            answersByBlank.computeIfAbsent(blankIndex, key -> new ArrayList<>())
+                    .add(displayText.trim());
+        }
+
+        List<String> grouped = new ArrayList<>();
+        for (List<String> candidates : answersByBlank.values()) {
+            Set<String> seen = new HashSet<>();
+            List<String> deduplicated = new ArrayList<>();
+            for (String candidate : candidates) {
+                String normalized = normalizeStrict(candidate);
+                if (normalized.isBlank() || !seen.add(normalized)) {
+                    continue;
+                }
+                deduplicated.add(candidate);
+            }
+            if (!deduplicated.isEmpty()) {
+                grouped.add(String.join(" / ", deduplicated));
+            }
+        }
+        return grouped;
     }
 
     private List<String> splitOrderedTokens(String text) {
@@ -728,19 +781,77 @@ public class CsAttemptService {
         return true;
     }
 
+    private boolean isUnorderedAnswerCorrect(List<String> submittedParts, List<String> expectedParts) {
+        if (submittedParts.isEmpty() || expectedParts.isEmpty()) {
+            return false;
+        }
+        if (submittedParts.size() != expectedParts.size()) {
+            return false;
+        }
+
+        boolean[] used = new boolean[submittedParts.size()];
+        return matchExpectedPart(expectedParts, submittedParts, used, 0);
+    }
+
+    private boolean matchExpectedPart(
+            List<String> expectedParts,
+            List<String> submittedParts,
+            boolean[] used,
+            int expectedIndex) {
+        if (expectedIndex >= expectedParts.size()) {
+            return true;
+        }
+
+        String expectedPart = expectedParts.get(expectedIndex);
+        for (int submittedIndex = 0; submittedIndex < submittedParts.size(); submittedIndex++) {
+            if (used[submittedIndex]) {
+                continue;
+            }
+            if (!isOrderedPartCorrect(submittedParts.get(submittedIndex), expectedPart)) {
+                continue;
+            }
+
+            used[submittedIndex] = true;
+            if (matchExpectedPart(expectedParts, submittedParts, used, expectedIndex + 1)) {
+                return true;
+            }
+            used[submittedIndex] = false;
+        }
+        return false;
+    }
+
+    private boolean isOrderedMultiBlankMode(CsQuestionGradingMode gradingMode) {
+        return gradingMode == CsQuestionGradingMode.MULTI_BLANK_ORDERED
+                || gradingMode == CsQuestionGradingMode.ORDERING;
+    }
+
     private boolean isOrderedPartCorrect(String submittedPart, String expectedPart) {
         String strictSubmitted = normalizeStrict(submittedPart);
         String relaxedSubmitted = normalizeRelaxed(strictSubmitted);
 
-        String[] expectedOptions = expectedPart.split("[|/]+");
         Set<String> strictCandidates = new HashSet<>();
         Set<String> relaxedCandidates = new HashSet<>();
-        for (String option : expectedOptions) {
+        for (String option : parseExpectedPartOptions(expectedPart)) {
             addCandidateNormalization(strictCandidates, relaxedCandidates, option);
         }
 
         return strictCandidates.contains(strictSubmitted)
                 || (!relaxedSubmitted.isBlank() && relaxedCandidates.contains(relaxedSubmitted));
+    }
+
+    private List<String> parseExpectedPartOptions(String expectedPart) {
+        if (expectedPart == null || expectedPart.isBlank()) {
+            return List.of();
+        }
+        String[] rawTokens = expectedPart.split("[|/]+");
+        List<String> tokens = new ArrayList<>();
+        for (String rawToken : rawTokens) {
+            String normalized = rawToken == null ? "" : rawToken.trim();
+            if (!normalized.isBlank()) {
+                tokens.add(normalized);
+            }
+        }
+        return tokens;
     }
 
     private int extractExpectedBlankCount(String metadata) {
@@ -782,6 +893,13 @@ public class CsAttemptService {
             builder.append("(").append(i + 1).append(") ").append(expectedParts.get(i));
         }
         return builder.toString();
+    }
+
+    private String formatUnorderedAnswerForFeedback(List<String> expectedParts) {
+        if (expectedParts == null || expectedParts.isEmpty()) {
+            return null;
+        }
+        return String.join(", ", expectedParts);
     }
 
     private String resolveDisplayAnswerText(CsQuestionShortAnswer answer) {

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsWrongProblemService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsWrongProblemService.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -342,7 +343,7 @@ public class CsWrongProblemService {
 
         if (question.getQuestionType() == CsQuestionType.SHORT_ANSWER) {
             List<CsQuestionShortAnswer> answers = csQuestionShortAnswerRepository
-                    .findByQuestion_IdOrderByIsPrimaryDescIdAsc(question.getId());
+                    .findByQuestion_IdOrderByBlankIndexAscIsPrimaryDescIdAsc(question.getId());
             if (answers.isEmpty()) {
                 return null;
             }
@@ -398,7 +399,7 @@ public class CsWrongProblemService {
                 }
 
                 List<CsQuestionShortAnswer> acceptableAnswers = csQuestionShortAnswerRepository
-                        .findByQuestion_IdOrderByIsPrimaryDescIdAsc(question.getId());
+                        .findByQuestion_IdOrderByBlankIndexAscIsPrimaryDescIdAsc(question.getId());
                 if (acceptableAnswers.isEmpty()) {
                     throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "단답형 정답 구성이 올바르지 않습니다.");
                 }
@@ -406,8 +407,7 @@ public class CsWrongProblemService {
                 String submitted = answerText.strip();
                 CsQuestionGradingMode gradingMode = resolveEffectiveGradingMode(question);
 
-                if (gradingMode == CsQuestionGradingMode.MULTI_BLANK_ORDERED
-                        || gradingMode == CsQuestionGradingMode.ORDERING) {
+                if (isOrderedMultiBlankMode(gradingMode)) {
                     List<String> submittedParts = parseOrderedSubmittedAnswers(submitted);
                     List<String> expectedParts = resolveOrderedExpectedAnswers(question, acceptableAnswers);
                     boolean isCorrect = isOrderedAnswerCorrect(submittedParts, expectedParts);
@@ -416,6 +416,18 @@ public class CsWrongProblemService {
                             isCorrect,
                             null,
                             isCorrect ? null : formatOrderedAnswerForFeedback(expectedParts),
+                            question.getExplanation());
+                }
+
+                if (gradingMode == CsQuestionGradingMode.MULTI_BLANK_UNORDERED) {
+                    List<String> submittedParts = parseOrderedSubmittedAnswers(submitted);
+                    List<String> expectedParts = resolveOrderedExpectedAnswers(question, acceptableAnswers);
+                    boolean isCorrect = isUnorderedAnswerCorrect(submittedParts, expectedParts);
+
+                    yield new GradingResult(
+                            isCorrect,
+                            null,
+                            isCorrect ? null : formatUnorderedAnswerForFeedback(expectedParts),
                             question.getExplanation());
                 }
 
@@ -520,9 +532,11 @@ public class CsWrongProblemService {
 
     private String resolveShortAnswerDisplay(CsQuestion question, List<CsQuestionShortAnswer> answers) {
         CsQuestionGradingMode gradingMode = resolveEffectiveGradingMode(question);
-        if (gradingMode == CsQuestionGradingMode.MULTI_BLANK_ORDERED
-                || gradingMode == CsQuestionGradingMode.ORDERING) {
+        if (isOrderedMultiBlankMode(gradingMode)) {
             return formatOrderedAnswerForFeedback(resolveOrderedExpectedAnswers(question, answers));
+        }
+        if (gradingMode == CsQuestionGradingMode.MULTI_BLANK_UNORDERED) {
+            return formatUnorderedAnswerForFeedback(resolveOrderedExpectedAnswers(question, answers));
         }
         return answers.stream()
                 .sorted(Comparator
@@ -563,10 +577,23 @@ public class CsWrongProblemService {
     }
 
     private List<String> resolveOrderedExpectedAnswers(CsQuestion question, List<CsQuestionShortAnswer> acceptableAnswers) {
-        List<String> answerTexts = acceptableAnswers.stream()
+        List<CsQuestionShortAnswer> sortedAnswers = acceptableAnswers.stream()
                 .sorted(Comparator
-                        .comparing((CsQuestionShortAnswer answer) -> !Boolean.TRUE.equals(answer.getIsPrimary()))
+                        .comparing((CsQuestionShortAnswer answer) -> answer.getBlankIndex() == null
+                                ? (short) 1
+                                : answer.getBlankIndex())
+                        .thenComparing((CsQuestionShortAnswer answer) -> !Boolean.TRUE.equals(answer.getIsPrimary()))
                         .thenComparing(CsQuestionShortAnswer::getId))
+                .toList();
+
+        List<String> groupedByBlank = resolveExpectedAnswersByBlankGroup(sortedAnswers);
+        int expectedCount = extractExpectedBlankCount(question.getMetadata());
+        if (groupedByBlank.size() > 1
+                && (expectedCount <= 1 || groupedByBlank.size() == expectedCount)) {
+            return groupedByBlank;
+        }
+
+        List<String> answerTexts = sortedAnswers.stream()
                 .map(this::resolveDisplayAnswerText)
                 .filter(text -> text != null && !text.isBlank())
                 .map(String::trim)
@@ -576,7 +603,6 @@ public class CsWrongProblemService {
             return List.of();
         }
 
-        int expectedCount = extractExpectedBlankCount(question.getMetadata());
         if (expectedCount > 1) {
             if (answerTexts.size() >= expectedCount) {
                 return new ArrayList<>(answerTexts.subList(0, expectedCount));
@@ -594,6 +620,36 @@ public class CsWrongProblemService {
 
         List<String> splitSingle = splitOrderedTokens(answerTexts.get(0));
         return splitSingle.isEmpty() ? answerTexts : splitSingle;
+    }
+
+    private List<String> resolveExpectedAnswersByBlankGroup(List<CsQuestionShortAnswer> sortedAnswers) {
+        Map<Short, List<String>> answersByBlank = new java.util.LinkedHashMap<>();
+        for (CsQuestionShortAnswer answer : sortedAnswers) {
+            String displayText = resolveDisplayAnswerText(answer);
+            if (displayText == null || displayText.isBlank()) {
+                continue;
+            }
+            short blankIndex = answer.getBlankIndex() == null ? 1 : answer.getBlankIndex();
+            answersByBlank.computeIfAbsent(blankIndex, key -> new ArrayList<>())
+                    .add(displayText.trim());
+        }
+
+        List<String> grouped = new ArrayList<>();
+        for (List<String> candidates : answersByBlank.values()) {
+            Set<String> seen = new HashSet<>();
+            List<String> deduplicated = new ArrayList<>();
+            for (String candidate : candidates) {
+                String normalized = normalizeStrict(candidate);
+                if (normalized.isBlank() || !seen.add(normalized)) {
+                    continue;
+                }
+                deduplicated.add(candidate);
+            }
+            if (!deduplicated.isEmpty()) {
+                grouped.add(String.join(" / ", deduplicated));
+            }
+        }
+        return grouped;
     }
 
     private List<String> splitOrderedTokens(String text) {
@@ -627,19 +683,77 @@ public class CsWrongProblemService {
         return true;
     }
 
+    private boolean isUnorderedAnswerCorrect(List<String> submittedParts, List<String> expectedParts) {
+        if (submittedParts.isEmpty() || expectedParts.isEmpty()) {
+            return false;
+        }
+        if (submittedParts.size() != expectedParts.size()) {
+            return false;
+        }
+
+        boolean[] used = new boolean[submittedParts.size()];
+        return matchExpectedPart(expectedParts, submittedParts, used, 0);
+    }
+
+    private boolean matchExpectedPart(
+            List<String> expectedParts,
+            List<String> submittedParts,
+            boolean[] used,
+            int expectedIndex) {
+        if (expectedIndex >= expectedParts.size()) {
+            return true;
+        }
+
+        String expectedPart = expectedParts.get(expectedIndex);
+        for (int submittedIndex = 0; submittedIndex < submittedParts.size(); submittedIndex++) {
+            if (used[submittedIndex]) {
+                continue;
+            }
+            if (!isOrderedPartCorrect(submittedParts.get(submittedIndex), expectedPart)) {
+                continue;
+            }
+
+            used[submittedIndex] = true;
+            if (matchExpectedPart(expectedParts, submittedParts, used, expectedIndex + 1)) {
+                return true;
+            }
+            used[submittedIndex] = false;
+        }
+        return false;
+    }
+
+    private boolean isOrderedMultiBlankMode(CsQuestionGradingMode gradingMode) {
+        return gradingMode == CsQuestionGradingMode.MULTI_BLANK_ORDERED
+                || gradingMode == CsQuestionGradingMode.ORDERING;
+    }
+
     private boolean isOrderedPartCorrect(String submittedPart, String expectedPart) {
         String strictSubmitted = normalizeStrict(submittedPart);
         String relaxedSubmitted = normalizeRelaxed(strictSubmitted);
 
-        String[] expectedOptions = expectedPart.split("[|/]+");
         Set<String> strictCandidates = new HashSet<>();
         Set<String> relaxedCandidates = new HashSet<>();
-        for (String option : expectedOptions) {
+        for (String option : parseExpectedPartOptions(expectedPart)) {
             addCandidateNormalization(strictCandidates, relaxedCandidates, option);
         }
 
         return strictCandidates.contains(strictSubmitted)
                 || (!relaxedSubmitted.isBlank() && relaxedCandidates.contains(relaxedSubmitted));
+    }
+
+    private List<String> parseExpectedPartOptions(String expectedPart) {
+        if (expectedPart == null || expectedPart.isBlank()) {
+            return List.of();
+        }
+        String[] rawTokens = expectedPart.split("[|/]+");
+        List<String> tokens = new ArrayList<>();
+        for (String rawToken : rawTokens) {
+            String normalized = rawToken == null ? "" : rawToken.trim();
+            if (!normalized.isBlank()) {
+                tokens.add(normalized);
+            }
+        }
+        return tokens;
     }
 
     private int extractExpectedBlankCount(String metadata) {
@@ -681,6 +795,13 @@ public class CsWrongProblemService {
             builder.append("(").append(i + 1).append(") ").append(expectedParts.get(i));
         }
         return builder.toString();
+    }
+
+    private String formatUnorderedAnswerForFeedback(List<String> expectedParts) {
+        if (expectedParts == null || expectedParts.isEmpty()) {
+            return null;
+        }
+        return String.join(", ", expectedParts);
     }
 
     private String resolveDisplayAnswerText(CsQuestionShortAnswer answer) {

--- a/apps/backend/src/main/resources/db/migration-postgres/V16__add_cs_short_answer_blank_index.sql
+++ b/apps/backend/src/main/resources/db/migration-postgres/V16__add_cs_short_answer_blank_index.sql
@@ -1,0 +1,39 @@
+ALTER TABLE cs_question_short_answers
+    ADD COLUMN IF NOT EXISTS blank_index SMALLINT;
+
+UPDATE cs_question_short_answers
+SET blank_index = 1
+WHERE blank_index IS NULL OR blank_index < 1;
+
+WITH ranked_multi_blank_answers AS (
+    SELECT
+        sa.id,
+        ROW_NUMBER() OVER (PARTITION BY sa.question_id ORDER BY sa.is_primary DESC, sa.id ASC) AS blank_no
+    FROM cs_question_short_answers sa
+    JOIN cs_questions q ON q.id = sa.question_id
+    WHERE q.question_type = 'SHORT_ANSWER'
+      AND q.grading_mode IN ('MULTI_BLANK_ORDERED', 'MULTI_BLANK_UNORDERED', 'ORDERING')
+)
+UPDATE cs_question_short_answers sa
+SET blank_index = ranked.blank_no
+FROM ranked_multi_blank_answers ranked
+WHERE sa.id = ranked.id;
+
+ALTER TABLE cs_question_short_answers
+    ALTER COLUMN blank_index SET DEFAULT 1;
+
+ALTER TABLE cs_question_short_answers
+    ALTER COLUMN blank_index SET NOT NULL;
+
+ALTER TABLE cs_question_short_answers
+    DROP CONSTRAINT IF EXISTS uk_cs_question_short_answers_question_normalized;
+
+ALTER TABLE cs_question_short_answers
+    DROP CONSTRAINT IF EXISTS uk_cs_question_short_answers_question_blank_normalized;
+
+ALTER TABLE cs_question_short_answers
+    ADD CONSTRAINT uk_cs_question_short_answers_question_blank_normalized
+        UNIQUE (question_id, blank_index, normalized_answer);
+
+CREATE INDEX IF NOT EXISTS idx_cs_question_short_answers_question_blank
+    ON cs_question_short_answers (question_id, blank_index);

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
@@ -412,6 +412,76 @@ class CsAttemptFlowIntegrationTest {
     }
 
     @Test
+    @DisplayName("멀티 빈칸 순서형은 빈칸별 추가 정답(동의어)을 허용한다")
+    void shortAnswer_multiBlankOrdered_acceptsAliasesPerBlank() {
+        User user = createUser("short-multi-blank-ordered-alias");
+        CsDomain domain = createDomain(410, "멀티 빈칸 순서형 별칭 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "멀티 빈칸 순서형 별칭 트랙");
+        CsStage stage = createStage(track, 1);
+
+        CsQuestion question = csQuestionRepository.save(CsQuestion.builder()
+                .stage(stage)
+                .questionType(CsQuestionType.SHORT_ANSWER)
+                .prompt("ACID 속성 중 원자성과 격리성을 순서대로 쓰시오.")
+                .explanation("원자성, 격리성 순서입니다.")
+                .gradingMode(CsQuestionGradingMode.MULTI_BLANK_ORDERED)
+                .metadata("{\"blankCount\":2}")
+                .isActive(true)
+                .build());
+
+        addShortAnswer(question, "원자성", "원자성", 1, true);
+        addShortAnswer(question, "atomic", "atomic", 1, false);
+        addShortAnswer(question, "격리성", "격리성", 2, true);
+        addShortAnswer(question, "isolation", "isolation", 2, false);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+        csAttemptService.startStageAttempt(user.getId(), stage.getId());
+
+        CsAttemptAnswerResponse answer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(question.getId(), null, "atomic|||isolation"));
+
+        assertThat(answer.isCorrect()).isTrue();
+        assertThat(answer.phase()).isEqualTo(CsAttemptPhase.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("멀티 빈칸 순서 무관형은 순서가 달라도 각 빈칸 정답이 있으면 정답 처리한다")
+    void shortAnswer_multiBlankUnordered_acceptsSwappedOrder() {
+        User user = createUser("short-multi-blank-unordered");
+        CsDomain domain = createDomain(411, "멀티 빈칸 순서 무관 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "멀티 빈칸 순서 무관 트랙");
+        CsStage stage = createStage(track, 1);
+
+        CsQuestion question = csQuestionRepository.save(CsQuestion.builder()
+                .stage(stage)
+                .questionType(CsQuestionType.SHORT_ANSWER)
+                .prompt("ACID 속성 중 원자성과 격리성을 쓰시오.")
+                .explanation("원자성, 격리성입니다.")
+                .gradingMode(CsQuestionGradingMode.MULTI_BLANK_UNORDERED)
+                .metadata("{\"blankCount\":2}")
+                .isActive(true)
+                .build());
+
+        addShortAnswer(question, "원자성", "원자성", 1, true);
+        addShortAnswer(question, "atomic", "atomic", 1, false);
+        addShortAnswer(question, "격리성", "격리성", 2, true);
+        addShortAnswer(question, "isolation", "isolation", 2, false);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+        csAttemptService.startStageAttempt(user.getId(), stage.getId());
+
+        CsAttemptAnswerResponse swappedAnswer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage.getId(),
+                new CsAttemptAnswerRequest(question.getId(), null, "isolation|||atomic"));
+
+        assertThat(swappedAnswer.isCorrect()).isTrue();
+        assertThat(swappedAnswer.phase()).isEqualTo(CsAttemptPhase.COMPLETED);
+    }
+
+    @Test
     @DisplayName("기출 회차 완료 시 최고 점수가 저장되고 더 높은 점수로 갱신된다")
     void pastExamBestScore_isSavedAndUpdated() {
         User user = createUser("past-best-score");
@@ -541,10 +611,20 @@ class CsAttemptFlowIntegrationTest {
     }
 
     private void addShortAnswer(CsQuestion question, String answerText, String normalizedAnswer, boolean isPrimary) {
+        addShortAnswer(question, answerText, normalizedAnswer, 1, isPrimary);
+    }
+
+    private void addShortAnswer(
+            CsQuestion question,
+            String answerText,
+            String normalizedAnswer,
+            int blankIndex,
+            boolean isPrimary) {
         csQuestionShortAnswerRepository.save(CsQuestionShortAnswer.builder()
                 .question(question)
                 .answerText(answerText)
                 .normalizedAnswer(normalizedAnswer)
+                .blankIndex((short) blankIndex)
                 .isPrimary(isPrimary)
                 .build());
     }

--- a/apps/frontend/src/domains/admin/components/CsStageEditor.tsx
+++ b/apps/frontend/src/domains/admin/components/CsStageEditor.tsx
@@ -30,7 +30,7 @@ interface CsStageEditorProps {
   exactQuestionCount?: number | null;
 }
 
-type ShortAnswerMode = 'SINGLE' | 'MULTI_BLANK_ORDERED';
+type ShortAnswerMode = 'SINGLE' | 'MULTI_BLANK_ORDERED' | 'MULTI_BLANK_UNORDERED';
 type GuiQuestionTemplateId =
   | 'MULTI_BLANK_TABLE'
   | 'MULTI_BOX_ORDER'
@@ -246,7 +246,7 @@ function QuestionCreateCard({
     { choiceNo: 2, content: '', isAnswer: false },
   ]);
   const [shortAnswers, setShortAnswers] = useState<CSAdminQuestionShortAnswer[]>([
-    { answerText: '', isPrimary: true },
+    { answerText: '', blankIndex: 1, isPrimary: true },
   ]);
   const [submitting, setSubmitting] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
@@ -258,7 +258,7 @@ function QuestionCreateCard({
       setShortAnswerMode('SINGLE');
     }
     if (nextType === 'SHORT_ANSWER') {
-      setShortAnswers((prev) => (prev.length > 0 ? prev : [{ answerText: '', isPrimary: true }]));
+      setShortAnswers((prev) => (prev.length > 0 ? prev : [{ answerText: '', blankIndex: 1, isPrimary: true }]));
       return;
     }
 
@@ -300,9 +300,10 @@ function QuestionCreateCard({
         (draft.shortAnswers ?? []).length > 0
           ? (draft.shortAnswers ?? []).map((answer) => ({
               answerText: answer.answerText,
+              blankIndex: normalizeShortAnswerBlankIndex(answer.blankIndex),
               isPrimary: answer.isPrimary,
             }))
-          : [{ answerText: '', isPrimary: true }],
+          : [{ answerText: '', blankIndex: 1, isPrimary: true }],
       );
       return;
     }
@@ -361,7 +362,14 @@ function QuestionCreateCard({
   };
 
   const handleAddShortAnswer = () => {
-    setShortAnswers([...shortAnswers, { answerText: '', isPrimary: false }]);
+    setShortAnswers([
+      ...shortAnswers,
+      {
+        answerText: '',
+        blankIndex: resolveNewBlankIndex(shortAnswerMode, shortAnswers),
+        isPrimary: false,
+      },
+    ]);
   };
 
   const handleUpdateShortAnswerText = (i: number, val: string) => {
@@ -370,11 +378,32 @@ function QuestionCreateCard({
     setShortAnswers(updated);
   };
 
+  const handleUpdateShortAnswerBlankIndex = (i: number, blankIndex: number) => {
+    const normalizedBlankIndex = Math.max(1, blankIndex || 1);
+    const updated = [...shortAnswers];
+    const target = updated[i];
+    if (!target) return;
+
+    const hadPrimary = Boolean(target.isPrimary);
+    target.blankIndex = normalizedBlankIndex;
+    if (hadPrimary) {
+      updated.forEach((answer, idx) => {
+        if (idx !== i && normalizeShortAnswerBlankIndex(answer.blankIndex) === normalizedBlankIndex) {
+          answer.isPrimary = false;
+        }
+      });
+    }
+    setShortAnswers(updated);
+  };
+
   const handleSetPrimaryShortAnswer = (i: number) => {
+    const target = shortAnswers[i];
+    if (!target) return;
+    const targetBlankIndex = normalizeShortAnswerBlankIndex(target.blankIndex);
     setShortAnswers(
       shortAnswers.map((answer, idx) => ({
         ...answer,
-        isPrimary: idx === i,
+        isPrimary: normalizeShortAnswerBlankIndex(answer.blankIndex) === targetBlankIndex && idx === i,
       })),
     );
   };
@@ -427,16 +456,30 @@ function QuestionCreateCard({
     }
 
     if (questionType === 'SHORT_ANSWER') {
-      const texts = shortAnswers.map((answer) => answer.answerText.trim());
+      const normalizedShortAnswers = normalizeShortAnswersForSubmission(shortAnswers, shortAnswerMode);
+      const texts = normalizedShortAnswers.map((answer) => answer.answerText.trim());
       if (texts.length === 0 || texts.some((text) => !text)) {
         throw new Error('단답형 정답은 최소 1개 이상이며 비어 있을 수 없습니다.');
       }
-      if (shortAnswerMode === 'MULTI_BLANK_ORDERED' && texts.length < 2) {
-        throw new Error('멀티 빈칸 문제는 정답 칸이 최소 2개 이상 필요합니다.');
+      if (isMultiBlankSelectionMode(shortAnswerMode)) {
+        const blankIndexes = new Set(normalizedShortAnswers.map((answer) => answer.blankIndex ?? 1));
+        if (blankIndexes.size < 2) {
+          throw new Error('멀티 빈칸 문제는 서로 다른 빈칸 번호가 최소 2개 이상 필요합니다.');
+        }
+        const maxBlankIndex = Math.max(...Array.from(blankIndexes));
+        for (let blankIndex = 1; blankIndex <= maxBlankIndex; blankIndex += 1) {
+          if (!blankIndexes.has(blankIndex)) {
+            throw new Error(`빈칸 번호는 1부터 순서대로 입력해야 합니다. 누락된 번호: ${blankIndex}`);
+          }
+        }
       }
-      const unique = new Set(texts.map((text) => text.toLowerCase().replace(/\s+/g, '')));
-      if (unique.size !== texts.length) {
-        throw new Error('중복된 단답형 정답이 있습니다.');
+      const unique = new Set(
+        normalizedShortAnswers.map(
+          (answer) => `${answer.blankIndex ?? 1}:${answer.answerText.toLowerCase().replace(/\s+/g, '')}`,
+        ),
+      );
+      if (unique.size !== normalizedShortAnswers.length) {
+        throw new Error('같은 빈칸에 중복된 단답형 정답이 있습니다.');
       }
       return;
     }
@@ -466,7 +509,7 @@ function QuestionCreateCard({
       { choiceNo: 1, content: '', isAnswer: true },
       { choiceNo: 2, content: '', isAnswer: false },
     ]);
-    setShortAnswers([{ answerText: '', isPrimary: true }]);
+    setShortAnswers([{ answerText: '', blankIndex: 1, isPrimary: true }]);
     if (createImageFileRef.current) {
       createImageFileRef.current.value = '';
     }
@@ -482,17 +525,13 @@ function QuestionCreateCard({
       contentMode: resolvedImage.contentMode,
       contentBlocks: resolvedImage.contentBlocks,
       gradingMode: questionType === 'SHORT_ANSWER' ? resolvedShortAnswerMode.gradingMode : inferDefaultGradingMode(questionType),
-      metadata: questionType === 'SHORT_ANSWER' ? resolvedShortAnswerMode.buildMetadata(shortAnswers.length) : null,
+      metadata: questionType === 'SHORT_ANSWER'
+        ? resolvedShortAnswerMode.buildMetadata(resolveBlankCountForMode(shortAnswerMode, shortAnswers))
+        : null,
     };
 
     if (questionType === 'SHORT_ANSWER') {
-      const normalized = shortAnswers.map((answer) => ({
-        answerText: answer.answerText.trim(),
-        isPrimary: Boolean(answer.isPrimary),
-      }));
-      if (!normalized.some((answer) => answer.isPrimary) && normalized.length > 0) {
-        normalized[0].isPrimary = true;
-      }
+      const normalized = normalizeShortAnswersForSubmission(shortAnswers, shortAnswerMode);
       return { ...base, shortAnswers: normalized };
     }
 
@@ -639,16 +678,35 @@ function QuestionCreateCard({
               >
                 <option value="SINGLE">단일 단답 (동의어 허용)</option>
                 <option value="MULTI_BLANK_ORDERED">멀티 빈칸 (순서형)</option>
+                <option value="MULTI_BLANK_UNORDERED">멀티 빈칸 (순서 무관형)</option>
               </select>
             </div>
 
             <div className="font-semibold text-sm">
               {shortAnswerMode === 'MULTI_BLANK_ORDERED'
                 ? '빈칸 정답 목록 (순서대로)'
+                : shortAnswerMode === 'MULTI_BLANK_UNORDERED'
+                  ? '빈칸 정답 목록 (순서 무관)'
                 : '단답형 정답 (다중 허용)'}
             </div>
+            {isMultiBlankSelectionMode(shortAnswerMode) && (
+              <div className="text-[11px] text-muted-foreground">
+                같은 빈칸 번호로 여러 줄을 넣으면 해당 빈칸의 추가 정답(동의어)로 처리됩니다.
+              </div>
+            )}
             {shortAnswers.map((ans, i) => (
               <div key={i} className="flex items-center gap-2">
+                {isMultiBlankSelectionMode(shortAnswerMode) && (
+                  <Input
+                    type="number"
+                    min={1}
+                    value={normalizeShortAnswerBlankIndex(ans.blankIndex)}
+                    onChange={(e) => handleUpdateShortAnswerBlankIndex(i, Number.parseInt(e.target.value, 10) || 1)}
+                    placeholder="빈칸"
+                    className="h-8 w-20 text-sm"
+                    disabled={submitting || !canCreate}
+                  />
+                )}
                 <input
                   type="radio"
                   checked={Boolean(ans.isPrimary)}
@@ -801,7 +859,7 @@ function QuestionFormItem({
       setShortAnswerMode('SINGLE');
     }
     if (nextType === 'SHORT_ANSWER') {
-      setShortAnswers((prev) => (prev.length > 0 ? prev : [{ answerText: '', isPrimary: true }]));
+      setShortAnswers((prev) => (prev.length > 0 ? prev : [{ answerText: '', blankIndex: 1, isPrimary: true }]));
       return;
     }
 
@@ -845,9 +903,10 @@ function QuestionFormItem({
         (draft.shortAnswers ?? []).length > 0
           ? (draft.shortAnswers ?? []).map((answer) => ({
               answerText: answer.answerText,
+              blankIndex: normalizeShortAnswerBlankIndex(answer.blankIndex),
               isPrimary: answer.isPrimary,
             }))
-          : [{ answerText: '', isPrimary: true }],
+          : [{ answerText: '', blankIndex: 1, isPrimary: true }],
       );
       return;
     }
@@ -910,7 +969,14 @@ function QuestionFormItem({
   };
 
   const handleAddShortAnswer = () => {
-    setShortAnswers([...shortAnswers, { answerText: '', isPrimary: false }]);
+    setShortAnswers([
+      ...shortAnswers,
+      {
+        answerText: '',
+        blankIndex: resolveNewBlankIndex(shortAnswerMode, shortAnswers),
+        isPrimary: false,
+      },
+    ]);
   };
 
   const handleUpdateShortAnswerText = (i: number, val: string) => {
@@ -919,11 +985,32 @@ function QuestionFormItem({
     setShortAnswers(updated);
   };
 
+  const handleUpdateShortAnswerBlankIndex = (i: number, blankIndex: number) => {
+    const normalizedBlankIndex = Math.max(1, blankIndex || 1);
+    const updated = [...shortAnswers];
+    const target = updated[i];
+    if (!target) return;
+
+    const hadPrimary = Boolean(target.isPrimary);
+    target.blankIndex = normalizedBlankIndex;
+    if (hadPrimary) {
+      updated.forEach((answer, idx) => {
+        if (idx !== i && normalizeShortAnswerBlankIndex(answer.blankIndex) === normalizedBlankIndex) {
+          answer.isPrimary = false;
+        }
+      });
+    }
+    setShortAnswers(updated);
+  };
+
   const handleSetPrimaryShortAnswer = (i: number) => {
+    const target = shortAnswers[i];
+    if (!target) return;
+    const targetBlankIndex = normalizeShortAnswerBlankIndex(target.blankIndex);
     setShortAnswers(
       shortAnswers.map((answer, idx) => ({
         ...answer,
-        isPrimary: idx === i,
+        isPrimary: normalizeShortAnswerBlankIndex(answer.blankIndex) === targetBlankIndex && idx === i,
       })),
     );
   };
@@ -973,19 +1060,33 @@ function QuestionFormItem({
     }
 
     if (questionType === 'SHORT_ANSWER') {
-      const texts = shortAnswers.map((answer) => answer.answerText.trim());
+      const normalizedShortAnswers = normalizeShortAnswersForSubmission(shortAnswers, shortAnswerMode);
+      const texts = normalizedShortAnswers.map((answer) => answer.answerText.trim());
       if (texts.length === 0) {
         throw new Error('단답형 정답은 최소 1개 이상이어야 합니다.');
       }
       if (texts.some((text) => !text)) {
         throw new Error('비어있는 정답 칸이 있습니다.');
       }
-      if (shortAnswerMode === 'MULTI_BLANK_ORDERED' && texts.length < 2) {
-        throw new Error('멀티 빈칸 문제는 정답 칸이 최소 2개 이상 필요합니다.');
+      if (isMultiBlankSelectionMode(shortAnswerMode)) {
+        const blankIndexes = new Set(normalizedShortAnswers.map((answer) => answer.blankIndex ?? 1));
+        if (blankIndexes.size < 2) {
+          throw new Error('멀티 빈칸 문제는 서로 다른 빈칸 번호가 최소 2개 이상 필요합니다.');
+        }
+        const maxBlankIndex = Math.max(...Array.from(blankIndexes));
+        for (let blankIndex = 1; blankIndex <= maxBlankIndex; blankIndex += 1) {
+          if (!blankIndexes.has(blankIndex)) {
+            throw new Error(`빈칸 번호는 1부터 순서대로 입력해야 합니다. 누락된 번호: ${blankIndex}`);
+          }
+        }
       }
-      const unique = new Set(texts.map((text) => text.toLowerCase().replace(/\s+/g, '')));
-      if (unique.size !== texts.length) {
-        throw new Error('중복된 정답이 존재합니다.');
+      const unique = new Set(
+        normalizedShortAnswers.map(
+          (answer) => `${answer.blankIndex ?? 1}:${answer.answerText.toLowerCase().replace(/\s+/g, '')}`,
+        ),
+      );
+      if (unique.size !== normalizedShortAnswers.length) {
+        throw new Error('같은 빈칸에 중복된 정답이 존재합니다.');
       }
       return;
     }
@@ -1015,18 +1116,12 @@ function QuestionFormItem({
       contentBlocks: resolvedImage.contentBlocks,
       gradingMode: questionType === 'SHORT_ANSWER' ? resolvedShortAnswerMode.gradingMode : gradingMode,
       metadata: questionType === 'SHORT_ANSWER'
-        ? resolvedShortAnswerMode.buildMetadata(shortAnswers.length)
+        ? resolvedShortAnswerMode.buildMetadata(resolveBlankCountForMode(shortAnswerMode, shortAnswers))
         : metadataText,
     };
 
     if (questionType === 'SHORT_ANSWER') {
-      const normalized = shortAnswers.map((answer, i) => ({
-        answerText: answer.answerText.trim(),
-        isPrimary: Boolean(answer.isPrimary),
-      }));
-      if (!normalized.some((answer) => answer.isPrimary) && normalized.length > 0) {
-        normalized[0].isPrimary = true;
-      }
+      const normalized = normalizeShortAnswersForSubmission(shortAnswers, shortAnswerMode);
       return {
         ...base,
         shortAnswers: normalized,
@@ -1198,16 +1293,34 @@ function QuestionFormItem({
                   >
                     <option value="SINGLE">단일 단답 (동의어 허용)</option>
                     <option value="MULTI_BLANK_ORDERED">멀티 빈칸 (순서형)</option>
+                    <option value="MULTI_BLANK_UNORDERED">멀티 빈칸 (순서 무관형)</option>
                   </select>
                 </div>
 
                 <div className="font-semibold text-sm">
                   {shortAnswerMode === 'MULTI_BLANK_ORDERED'
                     ? '빈칸 정답 목록 (순서대로)'
+                    : shortAnswerMode === 'MULTI_BLANK_UNORDERED'
+                      ? '빈칸 정답 목록 (순서 무관)'
                     : '단답형 정답 (다중 허용)'}
                 </div>
+                {isMultiBlankSelectionMode(shortAnswerMode) && (
+                  <div className="text-[11px] text-muted-foreground">
+                    같은 빈칸 번호로 여러 줄을 넣으면 해당 빈칸의 추가 정답(동의어)로 처리됩니다.
+                  </div>
+                )}
                 {shortAnswers.map((ans, i) => (
                   <div key={i} className="flex items-center gap-2">
+                    {isMultiBlankSelectionMode(shortAnswerMode) && (
+                      <Input
+                        type="number"
+                        min={1}
+                        value={normalizeShortAnswerBlankIndex(ans.blankIndex)}
+                        onChange={(e) => handleUpdateShortAnswerBlankIndex(i, Number.parseInt(e.target.value, 10) || 1)}
+                        placeholder="빈칸"
+                        className="h-8 w-20 text-sm"
+                      />
+                    )}
                     <input
                       type="radio"
                       checked={Boolean(ans.isPrimary)}
@@ -1286,6 +1399,11 @@ function QuestionFormItem({
                 <ul className="list-disc list-inside">
                   {question.shortAnswers?.map((ans, i) => (
                     <li key={i}>
+                      {inferShortAnswerModeFromQuestion(question) !== 'SINGLE' && (
+                        <span className="text-xs text-muted-foreground mr-1">
+                          [빈칸 {normalizeShortAnswerBlankIndex(ans.blankIndex)}]
+                        </span>
+                      )}
                       {ans.answerText}{' '}
                       {ans.isPrimary && <span className="text-xs text-primary">(대표 정답)</span>}
                     </li>
@@ -1329,6 +1447,7 @@ function toJsonDraft(questions: CSAdminQuestion[]): CSAdminQuestionDraft[] {
         ...base,
         shortAnswers: question.shortAnswers?.map((answer) => ({
           answerText: answer.answerText,
+          blankIndex: normalizeShortAnswerBlankIndex(answer.blankIndex),
           isPrimary: answer.isPrimary,
         })) ?? [],
       };
@@ -1385,9 +1504,9 @@ function buildEmptyStageExampleDraft(): CSAdminQuestionDraft[] {
       gradingMode: 'MULTI_BLANK_ORDERED',
       metadata: '{"blankCount":3}',
       shortAnswers: [
-        { answerText: '처리량', isPrimary: true },
-        { answerText: '응답시간', isPrimary: false },
-        { answerText: '경과시간', isPrimary: false },
+        { answerText: '처리량', blankIndex: 1, isPrimary: true },
+        { answerText: '응답시간', blankIndex: 2, isPrimary: true },
+        { answerText: '경과시간', blankIndex: 3, isPrimary: true },
       ],
     },
     {
@@ -1456,8 +1575,8 @@ function buildEmptyStageExampleDraft(): CSAdminQuestionDraft[] {
       gradingMode: 'ORDERING',
       metadata: '{"itemCount":4}',
       shortAnswers: [
-        { answerText: '정답8', isPrimary: true },
-        { answerText: '정답8_보조', isPrimary: false },
+        { answerText: '정답8', blankIndex: 1, isPrimary: true },
+        { answerText: '정답8_보조', blankIndex: 1, isPrimary: false },
       ],
     },
     {
@@ -1510,9 +1629,9 @@ function getGuiQuestionTemplates(): Array<{
         gradingMode: 'MULTI_BLANK_ORDERED',
         metadata: '{"blankCount":3}',
         shortAnswers: [
-          { answerText: '처리량', isPrimary: true },
-          { answerText: '응답시간', isPrimary: false },
-          { answerText: '경과시간', isPrimary: false },
+          { answerText: '처리량', blankIndex: 1, isPrimary: true },
+          { answerText: '응답시간', blankIndex: 2, isPrimary: true },
+          { answerText: '경과시간', blankIndex: 3, isPrimary: true },
         ],
       },
     },
@@ -1529,8 +1648,12 @@ function getGuiQuestionTemplates(): Array<{
         gradingMode: 'ORDERING',
         metadata: '{"itemCount":3}',
         shortAnswers: [
-          { answerText: '준비,실행,대기', isPrimary: true },
-          { answerText: 'READY,RUNNING,WAITING', isPrimary: false },
+          { answerText: '준비', blankIndex: 1, isPrimary: true },
+          { answerText: 'READY', blankIndex: 1, isPrimary: false },
+          { answerText: '실행', blankIndex: 2, isPrimary: true },
+          { answerText: 'RUNNING', blankIndex: 2, isPrimary: false },
+          { answerText: '대기', blankIndex: 3, isPrimary: true },
+          { answerText: 'WAITING', blankIndex: 3, isPrimary: false },
         ],
       },
     },
@@ -1565,6 +1688,7 @@ function getGuiQuestionTemplates(): Array<{
           {
             answerText:
               'SELECT 과목이름 AS 과목이름, MIN(점수) AS 최소점수, MAX(점수) AS 최대점수 FROM 성적 GROUP BY 과목이름 HAVING AVG(점수) >= 90',
+            blankIndex: 1,
             isPrimary: true,
           },
         ],
@@ -1615,7 +1739,11 @@ function validateJsonDraft(
     }
 
     if (question.questionType === 'SHORT_ANSWER') {
-      validateShortAnswers(question.shortAnswers, position);
+      validateShortAnswers(
+        question.shortAnswers,
+        position,
+        question.gradingMode ?? inferDefaultGradingMode(question.questionType),
+      );
       return;
     }
 
@@ -1644,6 +1772,7 @@ function validateQuestionModeFields(question: CSAdminQuestionDraft, position: nu
       'SINGLE_CHOICE',
       'SHORT_TEXT_EXACT',
       'MULTI_BLANK_ORDERED',
+      'MULTI_BLANK_UNORDERED',
       'ORDERING',
     ].includes(question.gradingMode)
   ) {
@@ -1696,24 +1825,136 @@ function validateChoices(
   }
 }
 
-function validateShortAnswers(shortAnswers: CSAdminQuestionDraft['shortAnswers'], position: number) {
+function validateShortAnswers(
+  shortAnswers: CSAdminQuestionDraft['shortAnswers'],
+  position: number,
+  gradingMode: CSQuestionGradingMode,
+) {
   if (!shortAnswers || shortAnswers.length === 0) {
     throw new Error(`${position}번 단답형 문제는 shortAnswers가 1개 이상 필요합니다.`);
   }
 
   const normalizedSet = new Set<string>();
+  const blankIndexSet = new Set<number>();
   shortAnswers.forEach((answer) => {
     const text = answer.answerText?.trim();
     if (!text) {
       throw new Error(`${position}번 단답형 문제의 answerText가 비어 있습니다.`);
     }
 
+    const blankIndex = normalizeShortAnswerBlankIndex(answer.blankIndex);
+    blankIndexSet.add(blankIndex);
     const normalized = text.toLowerCase().replace(/\s+/g, '');
-    if (normalizedSet.has(normalized)) {
-      throw new Error(`${position}번 단답형 문제의 정답이 중복되었습니다.`);
+    const dedupeKey = `${blankIndex}:${normalized}`;
+    if (normalizedSet.has(dedupeKey)) {
+      throw new Error(`${position}번 단답형 문제의 같은 빈칸 정답이 중복되었습니다.`);
     }
-    normalizedSet.add(normalized);
+    normalizedSet.add(dedupeKey);
   });
+
+  if (isMultiBlankGradingMode(gradingMode)) {
+    if (blankIndexSet.size < 2) {
+      throw new Error(`${position}번 멀티 빈칸 문제는 서로 다른 빈칸 번호가 최소 2개 이상 필요합니다.`);
+    }
+    const maxBlankIndex = Math.max(...Array.from(blankIndexSet));
+    for (let blankIndex = 1; blankIndex <= maxBlankIndex; blankIndex += 1) {
+      if (!blankIndexSet.has(blankIndex)) {
+        throw new Error(`${position}번 멀티 빈칸 문제의 빈칸 번호가 비연속입니다. 누락: ${blankIndex}`);
+      }
+    }
+    return;
+  }
+
+  if (blankIndexSet.size > 1 || (blankIndexSet.size === 1 && !blankIndexSet.has(1))) {
+    throw new Error(`${position}번 단일 단답 문제는 blankIndex를 1로만 설정할 수 있습니다.`);
+  }
+}
+
+function isMultiBlankGradingMode(gradingMode: CSQuestionGradingMode | undefined): boolean {
+  return gradingMode === 'MULTI_BLANK_ORDERED'
+    || gradingMode === 'MULTI_BLANK_UNORDERED'
+    || gradingMode === 'ORDERING';
+}
+
+function isMultiBlankSelectionMode(mode: ShortAnswerMode): boolean {
+  return mode === 'MULTI_BLANK_ORDERED' || mode === 'MULTI_BLANK_UNORDERED';
+}
+
+function normalizeShortAnswerBlankIndex(blankIndex: number | undefined): number {
+  if (!Number.isFinite(blankIndex) || !blankIndex || blankIndex < 1) {
+    return 1;
+  }
+  return Math.floor(blankIndex);
+}
+
+function resolveNewBlankIndex(
+  mode: ShortAnswerMode,
+  shortAnswers: CSAdminQuestionShortAnswer[],
+): number {
+  if (!isMultiBlankSelectionMode(mode)) {
+    return 1;
+  }
+  const usedIndexes = shortAnswers.map((answer) => normalizeShortAnswerBlankIndex(answer.blankIndex));
+  if (usedIndexes.length === 0) {
+    return 1;
+  }
+  return Math.max(...usedIndexes) + 1;
+}
+
+function resolveBlankCountForMode(
+  mode: ShortAnswerMode,
+  shortAnswers: CSAdminQuestionShortAnswer[],
+): number {
+  if (!isMultiBlankSelectionMode(mode)) {
+    return 1;
+  }
+  const indexes = shortAnswers.map((answer) => normalizeShortAnswerBlankIndex(answer.blankIndex));
+  if (indexes.length === 0) {
+    return 2;
+  }
+  return Math.max(...indexes);
+}
+
+function normalizeShortAnswersForSubmission(
+  shortAnswers: CSAdminQuestionShortAnswer[],
+  mode: ShortAnswerMode,
+): CSAdminQuestionShortAnswer[] {
+  const primaryAssignedByBlank = new Set<number>();
+  const normalized = shortAnswers.map((answer) => {
+    const blankIndex = isMultiBlankSelectionMode(mode)
+      ? normalizeShortAnswerBlankIndex(answer.blankIndex)
+      : 1;
+    const requestedPrimary = Boolean(answer.isPrimary);
+    const isPrimary = requestedPrimary && !primaryAssignedByBlank.has(blankIndex);
+    if (isPrimary) {
+      primaryAssignedByBlank.add(blankIndex);
+    }
+    return {
+      answerText: answer.answerText.trim(),
+      blankIndex,
+      isPrimary,
+    };
+  });
+
+  const firstIndexByBlank = new Map<number, number>();
+  const hasPrimaryByBlank = new Set<number>();
+  normalized.forEach((answer, index) => {
+    const blankIndex = normalizeShortAnswerBlankIndex(answer.blankIndex);
+    if (!firstIndexByBlank.has(blankIndex)) {
+      firstIndexByBlank.set(blankIndex, index);
+    }
+    if (answer.isPrimary) {
+      hasPrimaryByBlank.add(blankIndex);
+    }
+  });
+
+  firstIndexByBlank.forEach((firstIndex, blankIndex) => {
+    if (!hasPrimaryByBlank.has(blankIndex)) {
+      normalized[firstIndex].isPrimary = true;
+    }
+  });
+
+  return normalized;
 }
 
 function toEditableChoices(question: CSAdminQuestion): CSAdminQuestionChoice[] {
@@ -1741,11 +1982,19 @@ function toEditableChoices(question: CSAdminQuestion): CSAdminQuestionChoice[] {
 }
 
 function toEditableShortAnswers(question: CSAdminQuestion): CSAdminQuestionShortAnswer[] {
-  const mapped = (question.shortAnswers ?? []).map((answer) => ({
-    answerText: answer.answerText,
-    isPrimary: answer.isPrimary,
-  }));
-  return mapped.length > 0 ? mapped : [{ answerText: '', isPrimary: true }];
+  const mapped = (question.shortAnswers ?? [])
+    .map((answer) => ({
+      answerText: answer.answerText,
+      blankIndex: normalizeShortAnswerBlankIndex(answer.blankIndex),
+      isPrimary: answer.isPrimary,
+    }))
+    .sort((a, b) => {
+      const blankOrder = normalizeShortAnswerBlankIndex(a.blankIndex) - normalizeShortAnswerBlankIndex(b.blankIndex);
+      if (blankOrder !== 0) return blankOrder;
+      if (a.isPrimary === b.isPrimary) return 0;
+      return a.isPrimary ? -1 : 1;
+    });
+  return mapped.length > 0 ? mapped : [{ answerText: '', blankIndex: 1, isPrimary: true }];
 }
 
 function validateImageFile(file: File) {
@@ -1838,6 +2087,9 @@ function applyImageBlockToContentBlocks(
 
 function inferShortAnswerModeFromQuestion(question: Pick<CSAdminQuestion, 'gradingMode' | 'metadata'>): ShortAnswerMode {
   const gradingMode = question.gradingMode;
+  if (gradingMode === 'MULTI_BLANK_UNORDERED') {
+    return 'MULTI_BLANK_UNORDERED';
+  }
   if (gradingMode === 'MULTI_BLANK_ORDERED' || gradingMode === 'ORDERING') {
     return 'MULTI_BLANK_ORDERED';
   }
@@ -1871,6 +2123,12 @@ function resolveShortAnswerModeBySelection(mode: ShortAnswerMode): {
   if (mode === 'MULTI_BLANK_ORDERED') {
     return {
       gradingMode: 'MULTI_BLANK_ORDERED',
+      buildMetadata: (answerCount: number) => JSON.stringify({ blankCount: Math.max(answerCount, 1) }),
+    };
+  }
+  if (mode === 'MULTI_BLANK_UNORDERED') {
+    return {
+      gradingMode: 'MULTI_BLANK_UNORDERED',
       buildMetadata: (answerCount: number) => JSON.stringify({ blankCount: Math.max(answerCount, 1) }),
     };
   }

--- a/apps/frontend/src/domains/cs/api/csAdminApi.ts
+++ b/apps/frontend/src/domains/cs/api/csAdminApi.ts
@@ -33,6 +33,7 @@ export interface CSAdminQuestionChoice {
 
 export interface CSAdminQuestionShortAnswer {
   answerText: string;
+  blankIndex?: number;
   isPrimary: boolean;
 }
 

--- a/apps/frontend/src/domains/cs/api/csApi.ts
+++ b/apps/frontend/src/domains/cs/api/csApi.ts
@@ -13,6 +13,7 @@ export type CSQuestionGradingMode =
   | 'SINGLE_CHOICE'
   | 'SHORT_TEXT_EXACT'
   | 'MULTI_BLANK_ORDERED'
+  | 'MULTI_BLANK_UNORDERED'
   | 'ORDERING';
 export type CSAttemptPhase = 'FIRST_PASS' | 'RETRY_WRONG' | 'COMPLETED';
 

--- a/apps/frontend/src/domains/cs/components/session/CSQuestionPresenter.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSQuestionPresenter.tsx
@@ -47,8 +47,14 @@ export default function CSQuestionPresenter({
   );
   const isMultiBlankQuestion =
     question.questionType === 'SHORT_ANSWER' &&
-    (question.gradingMode === 'MULTI_BLANK_ORDERED' || question.gradingMode === 'ORDERING') &&
+    (
+      question.gradingMode === 'MULTI_BLANK_ORDERED'
+      || question.gradingMode === 'MULTI_BLANK_UNORDERED'
+      || question.gradingMode === 'ORDERING'
+    ) &&
     multiBlankCount > 1;
+  const isOrderSensitiveMultiBlank =
+    question.gradingMode === 'MULTI_BLANK_ORDERED' || question.gradingMode === 'ORDERING';
   const displayedContentBlocks = useMemo(
     () =>
       parsedContentBlocks.filter((block) => {
@@ -224,7 +230,11 @@ export default function CSQuestionPresenter({
 
       {isMultiBlankQuestion && (
         <div className="mt-4 flex flex-col gap-3">
-          <p className="text-sm text-muted-foreground">각 빈칸의 답을 순서대로 입력해주세요.</p>
+          <p className="text-sm text-muted-foreground">
+            {isOrderSensitiveMultiBlank
+              ? '각 빈칸의 답을 순서대로 입력해주세요.'
+              : '각 빈칸의 답을 입력해주세요. 순서는 상관없습니다.'}
+          </p>
           {Array.from({ length: multiBlankCount }, (_, index) => (
             <div key={`blank-${index}`} className="flex items-center gap-2">
               <span className="w-14 text-sm font-semibold text-muted-foreground">


### PR DESCRIPTION
## 💡 의도 / 배경
기존 단답형 멀티빈칸은 순서형 채점만 지원되어, 정답 집합이 맞아도 입력 순서가 다르면 오답 처리되는 문제가 있었습니다.  
또한 추가 정답(동의어)을 문자열 구분자 파싱에 의존하면 데이터 품질과 운영 안정성이 떨어져, 빈칸별 정답 매핑이 모호해지는 이슈가 있었습니다.

## 🛠️ 작업 내용
- [x] 단답형 채점 모드에 `MULTI_BLANK_UNORDERED`(순서 무관형) 추가
- [x] `cs_question_short_answers`에 `blank_index` 도입 및 유니크 제약을 `(question_id, blank_index, normalized_answer)`로 변경
- [x] 마이그레이션 추가로 기존 데이터 백필/호환 처리 (`V16__add_cs_short_answer_blank_index.sql`)
- [x] 채점 로직 확장  
  - `MULTI_BLANK_ORDERED`: 순서 고정 + 빈칸별 동의어 허용  
  - `MULTI_BLANK_UNORDERED`: 순서 무관 + 빈칸별 동의어 허용
- [x] 관리자 페이지(GUI/JSON)에서 정답 행별 `blankIndex` 입력/검증 지원
- [x] 학습 화면에서 순서무관형 안내 문구/동작 반영
- [x] 통합 테스트 보강 (순서형 동의어, 순서무관형 집합 정답 케이스)

## 🔗 관련 이슈
- Closes #198

## 🖼️ 스크린샷 (선택)
- UI 변경 있음 (관리자 단답형 모드 셀렉트 및 `blankIndex` 입력 필드)
- 필요 시 리뷰 코멘트로 첨부 예정

## 🧪 테스트 방법
- [x] `cmd /c gradlew.bat test --tests com.peekle.domain.cs.service.CsAttemptFlowIntegrationTest` (backend)
- [x] `cmd /c pnpm --filter frontend run type-check` (frontend)
- [ ] `pnpm --filter frontend run test:e2e` 전체 재실행 및 안정성 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [ ] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- `blankIndex` 기반으로 빈칸별 동의어(1:N) 구조를 정규화했습니다.
- 기존 멀티빈칸 데이터와의 호환을 위해 마이그레이션 백필 로직을 넣었으니, 운영 데이터 기준으로 한 번 확인 부탁드립니다.
- e2e 실행 전 기존 3001 서버가 떠 있으면 청크 mismatch가 날 수 있어 서버 재시작 후 검증 권장드립니다.