### PR TITLE
fix: cs 퀴즈 무한로딩문제 해결

### DIFF
--- a/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
@@ -101,6 +101,7 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
   const initSession = useCallback(async () => {
     try {
       setPhase('loading');
+      let hasTrackInfoFromBootstrap = false;
 
       try {
         const bootstrap = await fetchCSBootstrap();
@@ -112,7 +113,7 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
               trackNo: bootstrap.progress.currentTrackNo,
               stageNo: matchedStage.stageNo
             });
-            return;
+            hasTrackInfoFromBootstrap = true;
           }
         }
       } catch (err) {
@@ -120,7 +121,7 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
       }
 
       const source = searchParams.get('source');
-      if (source === 'past-exam') {
+      if (!hasTrackInfoFromBootstrap && source === 'past-exam') {
         const year = searchParams.get('year');
         const round = searchParams.get('round');
         if (year && round) {


### PR DESCRIPTION
## 💡 의도 / 배경
CS 스테이지 진입 시 무한 로딩이 발생하는 버그를 수정했습니다.  
원인은 `CSLearningSession` 초기화 로직에서 `fetchCSBootstrap()`로 stage 정보를 찾으면 조기 `return`되어, 실제 문제 로딩 API(`startCSStageAttempt`)가 호출되지 않는 흐름이었습니다.

## 🛠️ 작업 내용
- [x] `CSLearningSession.initSession`에서 bootstrap 매칭 시 조기 `return` 제거
- [x] `hasTrackInfoFromBootstrap` 플래그를 도입해 트랙 정보 세팅과 문제 로딩 흐름을 분리
- [x] `past-exam` 트랙 정보 fallback은 bootstrap 정보가 없을 때만 적용하도록 조건 보완

## 🔗 관련 이슈
- Closes #200

## 🖼️ 스크린샷 (선택)
UI 변경 없음

## 🧪 테스트 방법
- [x] 관리자 JSON 모드에서 문제 세트 등록 후 `/cs/stage/{stageId}` 진입
- [x] 로딩 화면에서 멈추지 않고 첫 문제 화면으로 전환되는지 확인
- [x] `pnpm -C apps/frontend lint` 통과 확인 (기존 저장소 전반의 lint/prettier 이슈로 실패)

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가? (이슈 번호 입력 필요)
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가? (기존 전역 lint 이슈로 미통과)

## 💬 리뷰어에게 (선택)
핵심 확인 포인트는 `initSession`의 제어 흐름입니다.  
bootstrap 메타 정보 조회 성공 여부와 관계없이 `startCSStageAttempt(stageId)`가 항상 실행되는지 중점 리뷰 부탁드립니다.