### PR TITLE
feat: CS 트랙 경계 노출 및 스킵 연동 개선

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsController.java
@@ -13,6 +13,7 @@ import com.peekle.domain.cs.dto.response.CsDomainResponse;
 import com.peekle.domain.cs.dto.response.CsDomainSubmitResponse;
 import com.peekle.domain.cs.dto.response.CsMyDomainItemResponse;
 import com.peekle.domain.cs.dto.response.CsPastExamCatalogResponse;
+import com.peekle.domain.cs.dto.response.CsTrackSkipResponse;
 import com.peekle.domain.cs.dto.response.CsWrongProblemPageResponse;
 import com.peekle.domain.cs.dto.response.CsWrongReviewAnswerResponse;
 import com.peekle.domain.cs.dto.response.CsWrongReviewCompleteResponse;
@@ -110,6 +111,12 @@ public class CsController {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long stageId) {
         return ApiResponse.success(csAttemptService.completeAttempt(userId, stageId));
+    }
+
+    @PostMapping("/tracks/current/skip")
+    public ApiResponse<CsTrackSkipResponse> skipCurrentTrack(
+            @AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(csAttemptService.skipCurrentTrack(userId));
     }
 
     @GetMapping("/wrong-problems")

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsStageStatusResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsStageStatusResponse.java
@@ -5,6 +5,8 @@ import com.peekle.domain.cs.enums.CsStageStatus;
 public record CsStageStatusResponse(
         Long stageId,
         Integer stageNo,
+        Integer trackNo,
+        String trackName,
         CsStageStatus status,
         String lockReason) {
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsTrackSkipResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsTrackSkipResponse.java
@@ -1,0 +1,9 @@
+package com.peekle.domain.cs.dto.response;
+
+public record CsTrackSkipResponse(
+        Integer skippedTrackNo,
+        Integer nextTrackNo,
+        Integer nextStageNo,
+        Long nextStageId,
+        Boolean isCurriculumCompleted) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAttemptService.java
@@ -7,6 +7,8 @@ import com.peekle.domain.cs.dto.response.CsAttemptProgressResponse;
 import com.peekle.domain.cs.dto.response.CsAttemptStartResponse;
 import com.peekle.domain.cs.dto.response.CsQuestionChoiceResponse;
 import com.peekle.domain.cs.dto.response.CsQuestionPayloadResponse;
+import com.peekle.domain.cs.dto.response.CsTrackSkipResponse;
+import com.peekle.domain.cs.entity.CsDomainTrack;
 import com.peekle.domain.cs.entity.CsPastExamBestScore;
 import com.peekle.domain.cs.entity.CsQuestion;
 import com.peekle.domain.cs.entity.CsQuestionChoice;
@@ -19,6 +21,7 @@ import com.peekle.domain.cs.enums.CsAttemptPhase;
 import com.peekle.domain.cs.enums.CsQuestionGradingMode;
 import com.peekle.domain.cs.enums.CsQuestionType;
 import com.peekle.domain.cs.enums.CsTrackLearningMode;
+import com.peekle.domain.cs.repository.CsDomainTrackRepository;
 import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
 import com.peekle.domain.cs.repository.CsQuestionRepository;
 import com.peekle.domain.cs.repository.CsQuestionShortAnswerRepository;
@@ -26,6 +29,7 @@ import com.peekle.domain.cs.repository.CsPastExamBestScoreRepository;
 import com.peekle.domain.cs.repository.CsStageAttemptLogRepository;
 import com.peekle.domain.cs.repository.CsStageRepository;
 import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
+import com.peekle.domain.cs.repository.CsUserProfileRepository;
 import com.peekle.domain.cs.repository.CsWrongProblemRepository;
 import com.peekle.domain.cs.service.store.CsAttemptSession;
 import com.peekle.domain.cs.service.store.CsAttemptStore;
@@ -48,6 +52,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -67,15 +72,20 @@ public class CsAttemptService {
     private static final Pattern ITEM_COUNT_PATTERN = Pattern.compile("\"itemCount\"\\s*:\\s*(\\d+)");
 
     private static final String LOCK_REASON_PREVIOUS_STAGE = "이전 스테이지를 먼저 완료해야 합니다.";
-    private static final String LOCK_REASON_NOT_CURRENT_TRACK = "현재 학습 중인 트랙만 입장할 수 있습니다.";
+    private static final String LOCK_REASON_FUTURE_TRACK = "해당 트랙은 아직 해금되지 않았습니다.";
+    private static final String LOCK_REASON_SKIP_ONLY_CURRICULUM = "현재 진행 중인 커리큘럼 트랙만 스킵할 수 있습니다.";
+
+    private static final short FIRST_STAGE_NO = 1;
 
     private final CsStageRepository csStageRepository;
+    private final CsDomainTrackRepository csDomainTrackRepository;
     private final CsQuestionRepository csQuestionRepository;
     private final CsQuestionChoiceRepository csQuestionChoiceRepository;
     private final CsQuestionShortAnswerRepository csQuestionShortAnswerRepository;
     private final CsPastExamBestScoreRepository csPastExamBestScoreRepository;
     private final CsStageAttemptLogRepository csStageAttemptLogRepository;
     private final CsUserDomainProgressRepository csUserDomainProgressRepository;
+    private final CsUserProfileRepository csUserProfileRepository;
     private final CsWrongProblemRepository csWrongProblemRepository;
     private final CsAttemptStore csAttemptStore;
     private final UserRepository userRepository;
@@ -210,11 +220,12 @@ public class CsAttemptService {
         persistStageAttemptLog(user, stage, correctCount, totalQuestionCount);
         updatePastExamBestScoreIfNeeded(user, stage, correctRate);
 
-        Long nextStageId = resolveNextStageId(stage);
-        boolean isTrackCompleted = nextStageId == null;
+        NextStageProgress nextStage = resolveNextStageProgress(stage);
+        Long nextStageId = nextStage == null ? null : nextStage.stageId();
+        boolean isTrackCompleted = nextStage == null;
 
         if (stage.getTrack().getLearningMode() == CsTrackLearningMode.CURRICULUM) {
-            updateDomainProgressIfNeeded(userId, stage, nextStageId);
+            updateDomainProgressIfNeeded(userId, stage, nextStage);
         }
         StreakResult streak = applyStreak(user);
         if (earnedScore > 0) {
@@ -236,6 +247,47 @@ public class CsAttemptService {
                 earnedScore,
                 totalScore,
                 nextStageId);
+    }
+
+    @Transactional
+    public CsTrackSkipResponse skipCurrentTrack(Long userId) {
+        getUser(userId);
+
+        CsUserDomainProgress progress = resolveCurrentDomainProgress(userId);
+        CsDomainTrack currentTrack = csDomainTrackRepository
+                .findByDomain_IdAndTrackNo(progress.getDomain().getId(), progress.getCurrentTrackNo())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CS_TRACK_NOT_FOUND));
+
+        if (currentTrack.getLearningMode() != CsTrackLearningMode.CURRICULUM) {
+            throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_SKIP_ONLY_CURRICULUM);
+        }
+
+        short lastStageNo = csStageRepository.findTopByTrack_IdOrderByStageNoDesc(currentTrack.getId())
+                .map(CsStage::getStageNo)
+                .orElse(progress.getCurrentStageNo());
+
+        clearTrackAttemptSessions(userId, currentTrack.getId());
+
+        NextStageProgress nextStage = resolveNextTrackFirstStage(currentTrack);
+        if (nextStage != null) {
+            progress.advanceTo(nextStage.trackNo(), nextStage.stageNo());
+            return new CsTrackSkipResponse(
+                    (int) currentTrack.getTrackNo(),
+                    (int) nextStage.trackNo(),
+                    (int) nextStage.stageNo(),
+                    nextStage.stageId(),
+                    false);
+        }
+
+        short completionCursor = (short) (lastStageNo + 1);
+        progress.advanceTo(currentTrack.getTrackNo(), completionCursor);
+
+        return new CsTrackSkipResponse(
+                (int) currentTrack.getTrackNo(),
+                null,
+                null,
+                null,
+                true);
     }
 
     private void persistStageAttemptLog(User user, CsStage stage, int correctCount, int totalQuestionCount) {
@@ -477,13 +529,74 @@ public class CsAttemptService {
         }
     }
 
-    private Long resolveNextStageId(CsStage stage) {
-        return csStageRepository.findByTrack_IdAndStageNo(stage.getTrack().getId(), (short) (stage.getStageNo() + 1))
-                .map(CsStage::getId)
-                .orElse(null);
+    private NextStageProgress resolveNextStageProgress(CsStage stage) {
+        Optional<CsStage> nextStageInTrack = csStageRepository.findByTrack_IdAndStageNo(
+                stage.getTrack().getId(),
+                (short) (stage.getStageNo() + 1));
+        if (nextStageInTrack.isPresent()) {
+            CsStage next = nextStageInTrack.get();
+            return new NextStageProgress(next.getId(), stage.getTrack().getTrackNo(), next.getStageNo());
+        }
+
+        if (stage.getTrack().getLearningMode() != CsTrackLearningMode.CURRICULUM) {
+            return null;
+        }
+
+        return resolveNextTrackFirstStage(stage.getTrack());
     }
 
-    private void updateDomainProgressIfNeeded(Long userId, CsStage stage, Long nextStageId) {
+    private NextStageProgress resolveNextTrackFirstStage(CsDomainTrack currentTrack) {
+        Integer domainId = currentTrack.getDomain().getId();
+        short currentTrackNo = currentTrack.getTrackNo();
+
+        List<CsDomainTrack> tracks = csDomainTrackRepository.findByDomain_IdOrderByTrackNoAsc(domainId);
+        for (CsDomainTrack track : tracks) {
+            if (track.getLearningMode() != CsTrackLearningMode.CURRICULUM) {
+                continue;
+            }
+            if (track.getTrackNo() <= currentTrackNo) {
+                continue;
+            }
+
+            Optional<CsStage> firstStage = csStageRepository.findByTrack_IdAndStageNo(track.getId(), FIRST_STAGE_NO);
+            if (firstStage.isPresent()) {
+                CsStage next = firstStage.get();
+                return new NextStageProgress(next.getId(), track.getTrackNo(), next.getStageNo());
+            }
+        }
+
+        return null;
+    }
+
+    private CsUserDomainProgress resolveCurrentDomainProgress(Long userId) {
+        List<CsUserDomainProgress> progresses = csUserDomainProgressRepository.findByUser_IdOrderByUpdatedAtDesc(userId);
+        if (progresses.isEmpty()) {
+            throw new BusinessException(ErrorCode.CS_DOMAIN_NOT_STUDYING);
+        }
+
+        Integer currentDomainId = csUserProfileRepository.findByUserIdWithCurrentDomain(userId)
+                .map(profile -> profile.getCurrentDomain())
+                .map(domain -> domain.getId())
+                .orElse(null);
+
+        if (currentDomainId == null) {
+            return progresses.get(0);
+        }
+
+        return progresses.stream()
+                .filter(progress -> progress.getDomain().getId().equals(currentDomainId))
+                .findFirst()
+                .orElse(progresses.get(0));
+    }
+
+    private void clearTrackAttemptSessions(Long userId, Long trackId) {
+        List<CsStage> trackStages = csStageRepository.findByTrack_IdOrderByStageNoAsc(trackId);
+        for (CsStage trackStage : trackStages) {
+            csAttemptStore.delete(userId, trackStage.getId());
+        }
+    }
+
+    private void updateDomainProgressIfNeeded(Long userId, CsStage stage, NextStageProgress nextStage) {
         Integer domainId = stage.getTrack().getDomain().getId();
         CsUserDomainProgress progress = csUserDomainProgressRepository.findByUser_IdAndDomain_Id(userId, domainId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CS_DOMAIN_PROGRESS_NOT_FOUND));
@@ -494,11 +607,11 @@ public class CsAttemptService {
         if (!progress.getCurrentStageNo().equals(stage.getStageNo())) {
             return;
         }
-        if (nextStageId == null) {
+        if (nextStage == null) {
             return;
         }
 
-        progress.advanceTo(progress.getCurrentTrackNo(), (short) (stage.getStageNo() + 1));
+        progress.advanceTo(nextStage.trackNo(), nextStage.stageNo());
     }
 
     private StreakResult applyStreak(User user) {
@@ -558,11 +671,11 @@ public class CsAttemptService {
         short targetTrackNo = stage.getTrack().getTrackNo();
         short targetStageNo = stage.getStageNo();
 
-        if (targetTrackNo != currentTrackNo) {
-            throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_NOT_CURRENT_TRACK);
+        if (targetTrackNo > currentTrackNo) {
+            throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_FUTURE_TRACK);
         }
 
-        if (targetStageNo > currentStageNo) {
+        if (targetTrackNo == currentTrackNo && targetStageNo > currentStageNo) {
             throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_PREVIOUS_STAGE);
         }
     }
@@ -936,5 +1049,8 @@ public class CsAttemptService {
             Integer correctChoiceNo,
             String correctAnswer,
             String explanation) {
+    }
+
+    private record NextStageProgress(Long stageId, Short trackNo, Short stageNo) {
     }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsDomainService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsDomainService.java
@@ -46,7 +46,7 @@ public class CsDomainService {
     private static final short INITIAL_TRACK_NO = 1;
     private static final short INITIAL_STAGE_NO = 1;
     private static final String LOCK_REASON_PREVIOUS_STAGE = "이전 스테이지를 먼저 완료해야 합니다.";
-    private static final String LOCK_REASON_NOT_CURRENT_TRACK = "현재 학습 중인 트랙만 입장할 수 있습니다.";
+    private static final String LOCK_REASON_FUTURE_TRACK = "해당 트랙은 아직 해금되지 않았습니다.";
 
     private final CsDomainRepository csDomainRepository;
     private final CsDomainTrackRepository csDomainTrackRepository;
@@ -238,34 +238,76 @@ public class CsDomainService {
     }
 
     private List<CsStageStatusResponse> toStageStatusResponses(CsUserDomainProgress progress) {
-        CsDomainTrack track = csDomainTrackRepository
-                .findByDomain_IdAndTrackNo(progress.getDomain().getId(), progress.getCurrentTrackNo())
-                .orElseThrow(() -> new BusinessException(ErrorCode.CS_TRACK_NOT_FOUND));
-
-        List<CsStage> stages = csStageRepository.findByTrack_IdOrderByStageNoAsc(track.getId());
-        List<CsStageStatusResponse> responses = new ArrayList<>(stages.size());
+        Integer domainId = progress.getDomain().getId();
+        short currentTrackNo = progress.getCurrentTrackNo();
         short currentStageNo = progress.getCurrentStageNo();
 
-        for (CsStage stage : stages) {
-            short stageNo = stage.getStageNo();
-            if (stageNo < currentStageNo) {
+        List<CsDomainTrack> tracks = csDomainTrackRepository
+                .findByDomain_IdOrderByTrackNoAsc(domainId)
+                .stream()
+                .filter(t -> t.getTrackNo() <= currentTrackNo + 1)
+                .toList();
+
+        List<CsStageStatusResponse> responses = new ArrayList<>();
+
+        for (CsDomainTrack track : tracks) {
+            List<CsStage> stages = csStageRepository.findByTrack_IdOrderByStageNoAsc(track.getId());
+            if (stages.isEmpty()) continue;
+
+            short trackNo = track.getTrackNo();
+            String trackName = track.getName();
+
+            if (trackNo == currentTrackNo + 1) {
+                // Next track: just show the first stage as locked
+                CsStage firstStage = stages.get(0);
                 responses.add(new CsStageStatusResponse(
-                        stage.getId(),
-                        (int) stageNo,
-                        CsStageStatus.COMPLETED,
-                        null));
-            } else if (stageNo == currentStageNo) {
-                responses.add(new CsStageStatusResponse(
-                        stage.getId(),
-                        (int) stageNo,
-                        CsStageStatus.IN_PROGRESS,
-                        null));
-            } else {
-                responses.add(new CsStageStatusResponse(
-                        stage.getId(),
-                        (int) stageNo,
+                        firstStage.getId(),
+                        (int) firstStage.getStageNo(),
+                        (int) trackNo,
+                        trackName,
                         CsStageStatus.LOCKED,
-                        LOCK_REASON_PREVIOUS_STAGE));
+                        "이전 트랙을 먼저 완료해야 합니다."));
+                continue;
+            }
+
+            for (CsStage stage : stages) {
+                short stageNo = stage.getStageNo();
+
+                if (trackNo < currentTrackNo) {
+                    responses.add(new CsStageStatusResponse(
+                            stage.getId(),
+                            (int) stageNo,
+                            (int) trackNo,
+                            trackName,
+                            CsStageStatus.COMPLETED,
+                            null));
+                } else {
+                    if (stageNo < currentStageNo) {
+                        responses.add(new CsStageStatusResponse(
+                                stage.getId(),
+                                (int) stageNo,
+                                (int) trackNo,
+                                trackName,
+                                CsStageStatus.COMPLETED,
+                                null));
+                    } else if (stageNo == currentStageNo) {
+                        responses.add(new CsStageStatusResponse(
+                                stage.getId(),
+                                (int) stageNo,
+                                (int) trackNo,
+                                trackName,
+                                CsStageStatus.IN_PROGRESS,
+                                null));
+                    } else {
+                        responses.add(new CsStageStatusResponse(
+                                stage.getId(),
+                                (int) stageNo,
+                                (int) trackNo,
+                                trackName,
+                                CsStageStatus.LOCKED,
+                                LOCK_REASON_PREVIOUS_STAGE));
+                    }
+                }
             }
         }
         return responses;
@@ -277,11 +319,11 @@ public class CsDomainService {
         short targetTrackNo = stage.getTrack().getTrackNo();
         short targetStageNo = stage.getStageNo();
 
-        if (targetTrackNo != currentTrackNo) {
-            throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_NOT_CURRENT_TRACK);
+        if (targetTrackNo > currentTrackNo) {
+            throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_FUTURE_TRACK);
         }
 
-        if (targetStageNo > currentStageNo) {
+        if (targetTrackNo == currentTrackNo && targetStageNo > currentStageNo) {
             throw new BusinessException(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS, LOCK_REASON_PREVIOUS_STAGE);
         }
     }

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsAttemptFlowIntegrationTest.java
@@ -4,6 +4,7 @@ import com.peekle.domain.cs.dto.request.CsAttemptAnswerRequest;
 import com.peekle.domain.cs.dto.response.CsAttemptAnswerResponse;
 import com.peekle.domain.cs.dto.response.CsAttemptCompleteResponse;
 import com.peekle.domain.cs.dto.response.CsAttemptStartResponse;
+import com.peekle.domain.cs.dto.response.CsTrackSkipResponse;
 import com.peekle.domain.cs.entity.CsDomain;
 import com.peekle.domain.cs.entity.CsDomainTrack;
 import com.peekle.domain.cs.entity.CsPastExamBestScore;
@@ -172,6 +173,129 @@ class CsAttemptFlowIntegrationTest {
         assertThat(csUserDomainProgressRepository.findByUser_IdAndDomain_Id(user.getId(), domain.getId()))
                 .get()
                 .satisfies(progress -> assertThat(progress.getCurrentStageNo()).isEqualTo((short) 2));
+    }
+
+    @Test
+    @DisplayName("커리큘럼 트랙 마지막 스테이지 완료 시 다음 트랙 1번 스테이지를 해금한다")
+    void completeAttempt_unlocksFirstStageOfNextTrack() {
+        User user = createUser("attempt-next-track");
+        CsDomain domain = createDomain(412, "트랙 경계 도메인");
+        CsDomainTrack track1 = createTrack(domain, 1, "1트랙");
+        CsDomainTrack track2 = createTrack(domain, 2, "2트랙");
+        CsStage stage1 = createStage(track1, 1);
+        CsStage stage2First = createStage(track2, 1);
+        CsQuestion question = createMultipleChoiceQuestion(stage1, "트랙 경계 문제");
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+
+        csAttemptService.startStageAttempt(user.getId(), stage1.getId());
+        CsAttemptAnswerResponse answer = csAttemptService.submitAnswer(
+                user.getId(),
+                stage1.getId(),
+                new CsAttemptAnswerRequest(question.getId(), 1, null));
+        assertThat(answer.isLast()).isTrue();
+        assertThat(answer.phase()).isEqualTo(CsAttemptPhase.COMPLETED);
+
+        CsAttemptCompleteResponse completeResponse = csAttemptService.completeAttempt(user.getId(), stage1.getId());
+        assertThat(completeResponse.isTrackCompleted()).isFalse();
+        assertThat(completeResponse.nextStageId()).isEqualTo(stage2First.getId());
+
+        assertThat(csUserDomainProgressRepository.findByUser_IdAndDomain_Id(user.getId(), domain.getId()))
+                .get()
+                .satisfies(progress -> {
+                    assertThat(progress.getCurrentTrackNo()).isEqualTo((short) 2);
+                    assertThat(progress.getCurrentStageNo()).isEqualTo((short) 1);
+                });
+    }
+
+    @Test
+    @DisplayName("현재 트랙 스킵 시 다음 트랙 1번 스테이지로 이동하고 점수/스트릭은 변하지 않는다")
+    void skipCurrentTrack_movesToNextTrackWithoutScoreOrStreak() {
+        User user = createUser("skip-next-track");
+        CsDomain domain = createDomain(413, "스킵 도메인");
+        CsDomainTrack track1 = createTrack(domain, 1, "1트랙");
+        CsDomainTrack track2 = createTrack(domain, 2, "2트랙");
+        CsStage stage1 = createStage(track1, 1);
+        CsStage stage2First = createStage(track2, 1);
+        CsQuestion question = createMultipleChoiceQuestion(stage1, "스킵 테스트 문제");
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+        csAttemptService.startStageAttempt(user.getId(), stage1.getId());
+
+        CsTrackSkipResponse skipResponse = csAttemptService.skipCurrentTrack(user.getId());
+        assertThat(skipResponse.skippedTrackNo()).isEqualTo(1);
+        assertThat(skipResponse.nextTrackNo()).isEqualTo(2);
+        assertThat(skipResponse.nextStageNo()).isEqualTo(1);
+        assertThat(skipResponse.nextStageId()).isEqualTo(stage2First.getId());
+        assertThat(skipResponse.isCurriculumCompleted()).isFalse();
+
+        assertThat(csUserDomainProgressRepository.findByUser_IdAndDomain_Id(user.getId(), domain.getId()))
+                .get()
+                .satisfies(progress -> {
+                    assertThat(progress.getCurrentTrackNo()).isEqualTo((short) 2);
+                    assertThat(progress.getCurrentStageNo()).isEqualTo((short) 1);
+                });
+
+        assertThat(userRepository.findById(user.getId()))
+                .get()
+                .satisfies(savedUser -> {
+                    assertThat(savedUser.getLeaguePoint()).isEqualTo(0);
+                    assertThat(savedUser.getLastSolvedDate()).isNull();
+                });
+
+        assertThatThrownBy(() -> csAttemptService.submitAnswer(
+                user.getId(),
+                stage1.getId(),
+                new CsAttemptAnswerRequest(question.getId(), 1, null)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.CS_ATTEMPT_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("마지막 커리큘럼 트랙을 스킵하면 최종 완료 상태를 반환한다")
+    void skipCurrentTrack_onLastTrack_returnsCurriculumCompleted() {
+        User user = createUser("skip-last-track");
+        CsDomain domain = createDomain(414, "마지막 트랙 도메인");
+        CsDomainTrack track = createTrack(domain, 1, "유일 트랙");
+        createStage(track, 1);
+        createStage(track, 2);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+
+        CsTrackSkipResponse skipResponse = csAttemptService.skipCurrentTrack(user.getId());
+        assertThat(skipResponse.skippedTrackNo()).isEqualTo(1);
+        assertThat(skipResponse.nextTrackNo()).isNull();
+        assertThat(skipResponse.nextStageNo()).isNull();
+        assertThat(skipResponse.nextStageId()).isNull();
+        assertThat(skipResponse.isCurriculumCompleted()).isTrue();
+
+        assertThat(csUserDomainProgressRepository.findByUser_IdAndDomain_Id(user.getId(), domain.getId()))
+                .get()
+                .satisfies(progress -> {
+                    assertThat(progress.getCurrentTrackNo()).isEqualTo((short) 1);
+                    assertThat(progress.getCurrentStageNo()).isEqualTo((short) 3);
+                });
+    }
+
+    @Test
+    @DisplayName("현재 트랙이 커리큘럼이 아니면 트랙 스킵을 허용하지 않는다")
+    void skipCurrentTrack_forPastExamTrack_throwsForbidden() {
+        User user = createUser("skip-past-exam");
+        CsDomain domain = createDomain(415, "기출 스킵 제한 도메인");
+        CsDomainTrack pastExamTrack = createPastExamTrack(domain, 1, "2024 기출", 2024);
+        createStage(pastExamTrack, 1);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+
+        assertThatThrownBy(() -> csAttemptService.skipCurrentTrack(user.getId()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.CS_FORBIDDEN_STAGE_ACCESS);
+                });
     }
 
     @Test

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsDomainServiceIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsDomainServiceIntegrationTest.java
@@ -3,12 +3,18 @@ package com.peekle.domain.cs.service;
 import com.peekle.domain.cs.dto.response.CsBootstrapResponse;
 import com.peekle.domain.cs.dto.response.CsCurrentDomainChangeResponse;
 import com.peekle.domain.cs.dto.response.CsDomainSubmitResponse;
+import com.peekle.domain.cs.dto.response.CsStageStatusResponse;
 import com.peekle.domain.cs.entity.CsDomain;
 import com.peekle.domain.cs.entity.CsDomainTrack;
+import com.peekle.domain.cs.entity.CsStage;
+import com.peekle.domain.cs.entity.CsUserDomainProgress;
 import com.peekle.domain.cs.entity.CsUserProfile;
 import com.peekle.domain.cs.repository.CsDomainRepository;
 import com.peekle.domain.cs.repository.CsDomainTrackRepository;
+import com.peekle.domain.cs.repository.CsStageRepository;
+import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
 import com.peekle.domain.cs.repository.CsUserProfileRepository;
+import com.peekle.domain.cs.enums.CsStageStatus;
 import com.peekle.domain.user.entity.User;
 import com.peekle.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +44,12 @@ class CsDomainServiceIntegrationTest {
 
     @Autowired
     private CsDomainTrackRepository csDomainTrackRepository;
+
+    @Autowired
+    private CsStageRepository csStageRepository;
+
+    @Autowired
+    private CsUserDomainProgressRepository csUserDomainProgressRepository;
 
     @Autowired
     private CsUserProfileRepository csUserProfileRepository;
@@ -90,6 +104,62 @@ class CsDomainServiceIntegrationTest {
         assertThat(response.progress()).isNull();
     }
 
+    @Test
+    @DisplayName("현재 트랙 학습 중이면 다음 트랙 1번 스테이지가 미리 노출된다")
+    void bootstrap_showsPreviewOfNextTrackFirstStage() {
+        User user = createUser("preview-next-track");
+        CsDomain domain = createDomain(101, "트랙 프리뷰 도메인");
+        CsDomainTrack track1 = createTrack(domain, 1, "1트랙");
+        CsDomainTrack track2 = createTrack(domain, 2, "2트랙");
+        createStages(track1, 5);
+        List<CsStage> track2Stages = createStages(track2, 5);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+
+        CsBootstrapResponse response = csDomainService.getBootstrap(user.getId());
+        assertThat(response.stages()).hasSize(6);
+
+        CsStageStatusResponse preview = response.stages().get(5);
+        assertThat(preview.trackNo()).isEqualTo(2);
+        assertThat(preview.stageNo()).isEqualTo(1);
+        assertThat(preview.stageId()).isEqualTo(track2Stages.get(0).getId());
+        assertThat(preview.status()).isEqualTo(CsStageStatus.LOCKED);
+    }
+
+    @Test
+    @DisplayName("2번 트랙 학습 중이어도 1번 트랙 스테이지가 상단에 유지된다")
+    void bootstrap_whenStudyingTrack2_keepsTrack1StagesVisible() {
+        User user = createUser("track2-with-track1-visible");
+        CsDomain domain = createDomain(102, "트랙 가시성 도메인");
+        CsDomainTrack track1 = createTrack(domain, 1, "1트랙");
+        CsDomainTrack track2 = createTrack(domain, 2, "2트랙");
+        CsDomainTrack track3 = createTrack(domain, 3, "3트랙");
+        createStages(track1, 5);
+        createStages(track2, 5);
+        createStages(track3, 5);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+        CsUserDomainProgress progress = csUserDomainProgressRepository
+                .findByUser_IdAndDomain_Id(user.getId(), domain.getId())
+                .orElseThrow();
+        progress.advanceTo((short) 2, (short) 1);
+
+        CsBootstrapResponse response = csDomainService.getBootstrap(user.getId());
+        assertThat(response.progress()).isNotNull();
+        assertThat(response.progress().currentTrackNo()).isEqualTo(2);
+        assertThat(response.stages()).isNotEmpty();
+
+        List<CsStageStatusResponse> track1Stages = response.stages().stream()
+                .filter(stage -> stage.trackNo() == 1)
+                .toList();
+        assertThat(track1Stages).hasSize(5);
+        assertThat(track1Stages).allSatisfy(stage -> assertThat(stage.status()).isEqualTo(CsStageStatus.COMPLETED));
+
+        assertThat(response.stages().stream()
+                .anyMatch(stage -> stage.trackNo() == 3 && stage.stageNo() == 1))
+                .isTrue();
+    }
+
     private User createUser(String suffix) {
         return userRepository.save(User.builder()
                 .socialId("social-" + suffix)
@@ -102,16 +172,34 @@ class CsDomainServiceIntegrationTest {
     }
 
     private CsDomain createDomainWithTrack(int domainId, String domainName, String trackName) {
-        CsDomain domain = csDomainRepository.save(CsDomain.builder()
+        CsDomain domain = createDomain(domainId, domainName);
+        createTrack(domain, 1, trackName);
+        return domain;
+    }
+
+    private CsDomain createDomain(int domainId, String domainName) {
+        return csDomainRepository.save(CsDomain.builder()
                 .id(domainId)
                 .name(domainName)
                 .build());
+    }
 
-        csDomainTrackRepository.save(CsDomainTrack.builder()
+    private CsDomainTrack createTrack(CsDomain domain, int trackNo, String trackName) {
+        return csDomainTrackRepository.save(CsDomainTrack.builder()
                 .domain(domain)
-                .trackNo((short) 1)
+                .trackNo((short) trackNo)
                 .name(trackName)
                 .build());
-        return domain;
+    }
+
+    private List<CsStage> createStages(CsDomainTrack track, int stageCount) {
+        java.util.ArrayList<CsStage> stages = new java.util.ArrayList<>();
+        for (int stageNo = 1; stageNo <= stageCount; stageNo++) {
+            stages.add(csStageRepository.save(CsStage.builder()
+                    .track(track)
+                    .stageNo((short) stageNo)
+                    .build()));
+        }
+        return stages;
     }
 }

--- a/apps/backend/src/test/java/com/peekle/domain/cs/service/CsStageMapAndStartIntegrationTest.java
+++ b/apps/backend/src/test/java/com/peekle/domain/cs/service/CsStageMapAndStartIntegrationTest.java
@@ -14,6 +14,7 @@ import com.peekle.domain.cs.repository.CsDomainTrackRepository;
 import com.peekle.domain.cs.repository.CsQuestionChoiceRepository;
 import com.peekle.domain.cs.repository.CsQuestionRepository;
 import com.peekle.domain.cs.repository.CsStageRepository;
+import com.peekle.domain.cs.repository.CsUserDomainProgressRepository;
 import com.peekle.domain.user.entity.User;
 import com.peekle.domain.user.repository.UserRepository;
 import com.peekle.global.exception.BusinessException;
@@ -53,6 +54,9 @@ class CsStageMapAndStartIntegrationTest {
 
     @Autowired
     private CsQuestionChoiceRepository csQuestionChoiceRepository;
+
+    @Autowired
+    private CsUserDomainProgressRepository csUserDomainProgressRepository;
 
     @Test
     @DisplayName("bootstrap 응답에 완료/진행/잠금 스테이지 상태가 포함된다")
@@ -116,6 +120,33 @@ class CsStageMapAndStartIntegrationTest {
         assertThat(response.firstQuestion().questionId()).isEqualTo(question.getId());
         assertThat(response.firstQuestion().questionType()).isEqualTo(CsQuestionType.MULTIPLE_CHOICE);
         assertThat(response.firstQuestion().choices()).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("현재 2트랙 학습 중이어도 과거 1트랙 스테이지는 다시 진입할 수 있다")
+    void startAttempt_pastTrackStage_isAllowed() {
+        User user = createUser("past-track-access");
+        CsDomain domain = createDomain(304, "과거 트랙 재진입 도메인");
+        CsDomainTrack track1 = createTrack(domain, 1, "1트랙");
+        CsDomainTrack track2 = createTrack(domain, 2, "2트랙");
+
+        CsStage track1Stage1 = createStage(track1, 1);
+        createMultipleChoiceQuestion(track1Stage1);
+        CsStage track1Stage2 = createStage(track1, 2);
+        CsQuestion question = createMultipleChoiceQuestion(track1Stage2);
+
+        CsStage track2Stage1 = createStage(track2, 1);
+        createMultipleChoiceQuestion(track2Stage1);
+
+        csDomainService.addMyDomain(user.getId(), domain.getId());
+        csUserDomainProgressRepository.findByUser_IdAndDomain_Id(user.getId(), domain.getId())
+                .orElseThrow()
+                .advanceTo((short) 2, (short) 1);
+
+        CsAttemptStartResponse response = csDomainService.startStageAttempt(user.getId(), track1Stage2.getId());
+
+        assertThat(response.stageId()).isEqualTo(track1Stage2.getId());
+        assertThat(response.firstQuestion().questionId()).isEqualTo(question.getId());
     }
 
     private User createUser(String suffix) {

--- a/apps/frontend/src/app/(main)/cs/page.tsx
+++ b/apps/frontend/src/app/(main)/cs/page.tsx
@@ -3,18 +3,30 @@
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Loader2 } from 'lucide-react';
-import { fetchCSBootstrap, CSBootstrapResponse } from '@/domains/cs/api/csApi';
+import { fetchCSBootstrap, skipCurrentCSTrack, CSBootstrapResponse } from '@/domains/cs/api/csApi';
 import DomainSelection from '@/domains/cs/components/DomainSelection';
 import LearningMap from '@/domains/cs/components/LearningMap';
 import CSTopBar from '@/domains/cs/components/CSTopBar';
 import CSModeSwitch from '@/domains/cs/components/CSModeSwitch';
 import { toast } from 'sonner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 
 export default function CSPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [bootstrapData, setBootstrapData] = useState<CSBootstrapResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [skipDialogOpen, setSkipDialogOpen] = useState(false);
+  const [skipTargetTrack, setSkipTargetTrack] = useState<{ trackNo: number; trackName?: string } | null>(null);
   const forceSelection = searchParams.get('mode') === 'add';
 
   const setAddMode = (isAddMode: boolean) => {
@@ -42,6 +54,28 @@ export default function CSPage() {
   useEffect(() => {
     loadBootstrap();
   }, []);
+
+  const handleSkipTrack = async () => {
+    try {
+      setSkipDialogOpen(false);
+      setLoading(true);
+      const skipResult = await skipCurrentCSTrack();
+      if (skipResult.isCurriculumCompleted) {
+        toast.success('마지막 트랙을 스킵해 커리큘럼을 완료했습니다.');
+      } else {
+        toast.success(`트랙을 스킵했습니다. (${skipResult.nextTrackNo}-${skipResult.nextStageNo}로 이동)`);
+      }
+      await loadBootstrap();
+    } catch (error) {
+      toast.error('트랙 스킵에 실패했습니다.');
+      setLoading(false);
+    }
+  };
+
+  const handleRequestSkipTrack = (targetTrackNo: number, targetTrackName?: string) => {
+    setSkipTargetTrack({ trackNo: targetTrackNo, trackName: targetTrackName });
+    setSkipDialogOpen(true);
+  };
 
   if (loading) {
     return (
@@ -105,7 +139,11 @@ export default function CSPage() {
       <div className="bg-card rounded-2xl p-8 shadow-sm">
         {bootstrapData?.progress ? (
           <div className="w-full flex flex-col items-center">
-            <LearningMap progress={bootstrapData.progress} stages={bootstrapData.stages ?? []} />
+            <LearningMap
+              progress={bootstrapData.progress}
+              stages={bootstrapData.stages ?? []}
+              onRequestSkipTrack={handleRequestSkipTrack}
+            />
           </div>
         ) : (
           <div className="p-8 border border-dashed border-primary/30 rounded-xl bg-primary/5 text-center">
@@ -113,6 +151,25 @@ export default function CSPage() {
           </div>
         )}
       </div>
+
+      <AlertDialog open={skipDialogOpen} onOpenChange={setSkipDialogOpen}>
+        <AlertDialogContent className="rounded-2xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle>트랙 스킵</AlertDialogTitle>
+            <AlertDialogDescription>
+              {skipTargetTrack
+                ? `현재 트랙의 남은 단계를 모두 건너뛰고 ${skipTargetTrack.trackNo}트랙의 첫 번째 단계${skipTargetTrack.trackName ? `(${skipTargetTrack.trackName})` : ''}로 이동하시겠습니까?`
+                : '현재 트랙의 남은 단계를 모두 건너뛰고 다음 트랙의 첫 번째 단계로 이동하시겠습니까?'}
+              <br /><br />
+              <span className="text-destructive font-medium">※ 스킵한 단계는 완료로 간주되지 않으며 점수가 부여되지 않습니다. 잠금/미래 스테이지의 개별 스킵은 불가합니다.</span>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="gap-2 sm:gap-0 mt-2">
+            <AlertDialogCancel className="rounded-xl">취소</AlertDialogCancel>
+            <AlertDialogAction onClick={handleSkipTrack} className="rounded-xl bg-primary">스킵하기</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/frontend/src/domains/cs/api/csApi.ts
+++ b/apps/frontend/src/domains/cs/api/csApi.ts
@@ -28,6 +28,8 @@ export type CSStageStatus = 'COMPLETED' | 'IN_PROGRESS' | 'LOCKED';
 export interface CSStageStatusItem {
   stageId: number;
   stageNo: number;
+  trackNo?: number;
+  trackName?: string;
   status: CSStageStatus;
   lockReason: string | null;
 }
@@ -116,6 +118,14 @@ export interface CSAttemptCompleteResponse {
   earnedScore: number;
   totalScore: number;
   nextStageId: number | null;
+}
+
+export interface CSTrackSkipResponse {
+  skippedTrackNo: number;
+  nextTrackNo: number | null;
+  nextStageNo: number | null;
+  nextStageId: number | null;
+  isCurriculumCompleted: boolean;
 }
 
 export type CSWrongProblemStatus = 'ACTIVE' | 'CLEARED';
@@ -295,6 +305,19 @@ export const completeCSStageAttempt = async (
     },
   );
   return assertApiData(response, '스테이지 결과 조회에 실패했습니다.');
+};
+
+/**
+ * 현재 트랙 스킵
+ */
+export const skipCurrentCSTrack = async (): Promise<CSTrackSkipResponse> => {
+  const response = await apiFetch<CSTrackSkipResponse>(
+    '/api/cs/tracks/current/skip',
+    {
+      method: 'POST',
+    },
+  );
+  return assertApiData(response, '현재 트랙 스킵에 실패했습니다.');
 };
 
 /**

--- a/apps/frontend/src/domains/cs/components/LearningMap.tsx
+++ b/apps/frontend/src/domains/cs/components/LearningMap.tsx
@@ -4,13 +4,14 @@ import React from 'react';
 import { useEffect, useRef } from 'react';
 import { CSProgress, CSStageStatusItem } from '@/domains/cs/api/csApi';
 import { cn } from '@/lib/utils';
-import { Check, Lock, Play } from 'lucide-react';
+import { Check, FastForward, Lock, Play } from 'lucide-react';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 
 interface LearningMapProps {
   progress: CSProgress;
   stages: CSStageStatusItem[];
+  onRequestSkipTrack?: (targetTrackNo: number, targetTrackName?: string) => void;
 }
 
 const STAGE_WIDTH = 96; // w-24 (96px)
@@ -43,14 +44,16 @@ const getConnectorStyle = (i: number): React.CSSProperties => {
   };
 };
 
-export default function LearningMap({ progress, stages }: LearningMapProps) {
+export default function LearningMap({ progress, stages, onRequestSkipTrack }: LearningMapProps) {
   const router = useRouter();
   const { currentTrackNo, currentStageNo } = progress;
   const stageButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const stageCount = stages.length;
 
   useEffect(() => {
-    const targetIndex = stages.findIndex((stage) => stage.stageNo === currentStageNo);
+    const targetIndex = stages.findIndex(
+      (stage) => (stage.trackNo ?? currentTrackNo) === currentTrackNo && stage.stageNo === currentStageNo,
+    );
     if (targetIndex < 0 || targetIndex >= stageCount) return;
 
     const target = stageButtonRefs.current[targetIndex];
@@ -75,14 +78,26 @@ export default function LearningMap({ progress, stages }: LearningMapProps) {
       `[DEBUG] LearningMap Stage Clicked: Track ${currentTrackNo}, StageNo ${stage.stageNo}, StageId ${stage.stageId}, State: ${stage.status}`,
     );
     
+    const targetTrackNo = stage.trackNo ?? currentTrackNo;
+    const isNextTrackPreviewStage = targetTrackNo === currentTrackNo + 1 && stage.stageNo === 1;
+
+    if (isNextTrackPreviewStage) {
+      if (onRequestSkipTrack) {
+        onRequestSkipTrack(targetTrackNo, stage.trackName);
+      } else {
+        toast.info('트랙 스킵 기능을 사용할 수 없습니다.');
+      }
+      return;
+    }
+
     if (stage.status === 'LOCKED') {
       toast.info(stage.lockReason || '이전 단계를 먼저 클리어해주세요 🔒');
       return;
     }
 
     const query = new URLSearchParams({
-      trackName: progress.currentTrackName,
-      trackNo: String(currentTrackNo),
+      trackName: stage.trackName ?? progress.currentTrackName,
+      trackNo: String(stage.trackNo ?? currentTrackNo),
       stageNo: String(stage.stageNo),
     });
     router.push(`/cs/stage/${stage.stageId}?${query.toString()}`);
@@ -99,6 +114,11 @@ export default function LearningMap({ progress, stages }: LearningMapProps) {
       >
         {stages.map((stage, i) => {
           const stageNo = stage.stageNo;
+          const currentStageTrackNo = stage.trackNo ?? currentTrackNo;
+          const isNextTrackPreviewStage = currentStageTrackNo === currentTrackNo + 1 && stageNo === 1;
+          const prevStageTrackNo = i > 0 ? (stages[i - 1].trackNo ?? currentTrackNo) : currentStageTrackNo;
+          const isTrackStart = i === 0 || currentStageTrackNo !== prevStageTrackNo;
+
           const state = stage.status;
           const offsetX = getOffset(i);
           const isNotLast = i < stageCount - 1;
@@ -133,27 +153,51 @@ export default function LearningMap({ progress, stages }: LearningMapProps) {
                 />
               )}
 
+              {/* 트랙 구분 라벨 및 선 */}
+              {isTrackStart && (
+                <div 
+                  className="absolute flex items-center justify-center pointer-events-none"
+                  style={{ 
+                    top: -GAP_Y / 2, 
+                    left: `calc(50% - ${offsetX}px)`,
+                    transform: 'translate(-50%, -50%)',
+                    width: 'min(100vw, 400px)',
+                    zIndex: 0
+                  }}
+                >
+                   <div className="flex-1 h-px bg-border border-t border-dashed border-border/80" />
+                   <div className="px-4 py-1.5 bg-background rounded-full border-2 border-primary/20 text-[11px] font-bold text-primary shadow-sm tracking-wide shrink-0 mx-3 backdrop-blur-sm">
+                     TRACK {currentStageTrackNo} {stage.trackName ? `· ${stage.trackName}` : ''}
+                   </div>
+                   <div className="flex-1 h-px bg-border border-t border-dashed border-border/80" />
+                </div>
+              )}
+
               {/* 본체 버튼 (사각형) */}
               <button
                 ref={(element) => {
                   stageButtonRefs.current[i] = element;
                 }}
                 onClick={() => handleStageClick(stage)}
+
+
                 className={cn(
                   'relative z-10 w-full h-full rounded-2xl flex flex-col items-center justify-center transition-all duration-200 font-bold border-[3px] select-none text-sm tracking-wider',
                   {
-                    'bg-primary border-primary text-primary-foreground shadow-[0_5px_0_rgba(0,0,0,0.15)] hover:bg-primary/95 hover:brightness-110 active:shadow-none active:translate-y-[5px]': state === 'COMPLETED',
-                    'bg-background border-primary text-primary shadow-[0_5px_0_hsl(var(--primary)/0.6)] active:shadow-none active:translate-y-[5px] animate-float': state === 'IN_PROGRESS',
-                    'bg-surface-2 border-border text-muted-foreground shadow-[0_5px_0_hsl(var(--border))] active:shadow-none active:translate-y-[5px] opacity-80 cursor-not-allowed': state === 'LOCKED',
+                    'bg-amber-50 border-amber-300 text-amber-700 shadow-[0_5px_0_hsl(35_90%_70%)] hover:bg-amber-100 active:shadow-none active:translate-y-[5px]': isNextTrackPreviewStage,
+                    'bg-primary border-primary text-primary-foreground shadow-[0_5px_0_rgba(0,0,0,0.15)] hover:bg-primary/95 hover:brightness-110 active:shadow-none active:translate-y-[5px]': !isNextTrackPreviewStage && state === 'COMPLETED',
+                    'bg-background border-primary text-primary shadow-[0_5px_0_hsl(var(--primary)/0.6)] active:shadow-none active:translate-y-[5px] animate-float': !isNextTrackPreviewStage && state === 'IN_PROGRESS',
+                    'bg-surface-2 border-border text-muted-foreground shadow-[0_5px_0_hsl(var(--border))] active:shadow-none active:translate-y-[5px] opacity-80 cursor-not-allowed': !isNextTrackPreviewStage && state === 'LOCKED',
                   }
                 )}
               >
+                {isNextTrackPreviewStage && <FastForward className="w-5 h-5 mb-1" strokeWidth={2.5} />}
                 {state === 'COMPLETED' && <Check className="w-7 h-7 mb-1" strokeWidth={3} />}
                 {state === 'IN_PROGRESS' && <Play className="w-6 h-6 mb-1 ml-1" strokeWidth={3} fill="currentColor" />}
-                {state === 'LOCKED' && <Lock className="w-5 h-5 mb-1 opacity-50" strokeWidth={2.5} />}
+                {!isNextTrackPreviewStage && state === 'LOCKED' && <Lock className="w-5 h-5 mb-1 opacity-50" strokeWidth={2.5} />}
                 
                 <span>
-                  {currentTrackNo}-{stageNo}
+                  {stage.trackNo ?? currentTrackNo}-{stageNo}
                 </span>
 
                 {/* 진행 중인 단계 강조 글로우 효과 */}


### PR DESCRIPTION
## 💡 의도 / 배경
CS 커리큘럼 맵에서 트랙 경계 전환 UX와 진행도 연동이 부족해 학습 흐름이 끊기는 문제가 있었습니다.
특히 트랙 전환 지점(예: `1-5 -> 2-1`) 노출/해금, 트랙 스킵 동작, 과거 트랙 재학습 허용 정책이 서로 일관되지 않아 사용자 경험이 혼란스러웠습니다.
이번 PR에서는 맵 노출 정책, 스킵 UX, 백엔드 접근/진행도 로직을 함께 정리해 실제 학습 플로우와 맞췄습니다.

## 🛠️ 작업 내용
- [x] CS 맵에서 트랙 경계 정보를 강화
- [x] 각 트랙 시작 지점에 트랙 라벨/구분선 표시 (1트랙 포함)
- [x] 다음 트랙 1번 스테이지를 프리뷰/강조 색상으로 표시
- [x] 다음 트랙 1번 클릭 시 스킵 확인 모달 노출 후 트랙 스킵 API 호출
- [x] 상단 고정 `현재 트랙 스킵` 버튼 제거, 맵 기반 상호작용으로 통일
- [x] 백엔드 `POST /api/cs/tracks/current/skip` 추가 및 응답 DTO(`CsTrackSkipResponse`) 추가
- [x] 커리큘럼 완료 로직 개선: 트랙 마지막 완료 시 다음 트랙 1번으로 자연 전환
- [x] 과거 트랙 재학습 허용: 미래 트랙만 차단하도록 접근 정책 수정
- [x] bootstrap stage 응답에 트랙 정보(`trackNo`, `trackName`) 반영
- [x] 통합 테스트 보강 (트랙 경계 노출/전환/스킵/과거 트랙 접근)

## 🔗 관련 이슈
- Closes #202

## 🖼️ 스크린샷 (선택)
- UI 변경 포함 (트랙 라벨/구분선, 다음 트랙 1번 강조, 스킵 확인 모달)
- 스크린샷 첨부 예정

## 🧪 테스트 방법
- [x] 백엔드 통합 테스트 실행  
  `cmd /c gradlew.bat test --tests com.peekle.domain.cs.service.CsStageMapAndStartIntegrationTest --tests com.peekle.domain.cs.service.CsDomainServiceIntegrationTest --tests com.peekle.domain.cs.service.CsAttemptFlowIntegrationTest`
- [x] 프론트 타입 체크 실행  
  `cmd /c pnpm --filter frontend type-check`
- [x] 수동 확인
  - `/cs` 진입 시 각 트랙 시작 라벨이 노출되는지 확인
  - 다음 트랙 1번이 강조 표시되는지 확인
  - 다음 트랙 1번 클릭 시 스킵 확인 모달이 뜨고 승인 시 다음 트랙으로 이동하는지 확인
  - 2트랙 학습 중에도 1트랙 스테이지 재진입이 가능한지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
- 과거 트랙 재학습 허용 정책(미래 트랙만 차단)이 기획 의도와 맞는지 최종 확인 부탁드립니다.
- 다음 트랙 1번 강조 색상(amber 톤)과 라벨 문구 톤이 디자인 가이드에 맞는지 피드백 부탁드립니다.