### PR TITLE
fix: 모달의 우선순위가 낮아서 신고 피드백이 안되는 문제 수정

### DIFF
--- a/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
@@ -30,14 +30,6 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
@@ -407,13 +399,22 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
             } animate-in slide-in-from-bottom sm:slide-in-from-bottom-8 duration-300 pointer-events-auto`}
           >
             <div className="flex flex-col gap-2">
-              <h2
-                className={`text-2xl font-black tracking-tight ${
-                  answerResult.isCorrect ? 'text-emerald-600' : 'text-red-500'
-                }`}
-              >
-                {answerResult.isCorrect ? '정답입니다!' : '틀렸습니다.'}
-              </h2>
+              <div className="flex items-start justify-between gap-3">
+                <h2
+                  className={`text-2xl font-black tracking-tight ${
+                    answerResult.isCorrect ? 'text-emerald-600' : 'text-red-500'
+                  }`}
+                >
+                  {answerResult.isCorrect ? '정답입니다!' : '틀렸습니다.'}
+                </h2>
+                <button
+                  type="button"
+                  className="shrink-0 rounded-md border border-slate-300 bg-white/90 px-2.5 py-1 text-[11px] font-semibold text-slate-700 hover:bg-white"
+                  onClick={() => setClaimDialogOpen((prev) => !prev)}
+                >
+                  문제 신고
+                </button>
+              </div>
               {!answerResult.isCorrect && (
                 <div className="mt-2 flex flex-col gap-3">
                   {wrongFeedback?.answer && (
@@ -459,6 +460,64 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
                 </div>
               )}
             </div>
+            {claimDialogOpen && (
+              <div className="mt-1 rounded-xl border border-slate-300/80 bg-white/95 p-4 shadow-sm">
+                <div className="mb-4">
+                  <p className="text-sm font-semibold text-slate-800">문제 신고</p>
+                  <p className="mt-1 text-xs text-slate-600">
+                    정답/해설/문항 오류를 알려주시면 검토 후 반영하겠습니다.
+                  </p>
+                </div>
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="claim-type">신고 유형</Label>
+                    <Select
+                      value={claimType}
+                      onValueChange={(value) => setClaimType(value as CSQuestionClaimType)}
+                    >
+                      <SelectTrigger id="claim-type">
+                        <SelectValue placeholder="신고 유형을 선택해주세요." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="INCORRECT_ANSWER">정답이 잘못됨</SelectItem>
+                        <SelectItem value="INCORRECT_EXPLANATION">해설이 잘못됨</SelectItem>
+                        <SelectItem value="QUESTION_TEXT_ERROR">문제 문구가 모호/오류</SelectItem>
+                        <SelectItem value="OTHER">기타</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="claim-description">상세 내용</Label>
+                    <Textarea
+                      id="claim-description"
+                      value={claimDescription}
+                      onChange={(event) => setClaimDescription(event.target.value)}
+                      placeholder="어떤 부분이 문제인지 구체적으로 적어주세요. (최소 10자)"
+                      minLength={10}
+                      maxLength={2000}
+                    />
+                    <p className="text-xs text-slate-500">{claimDescription.trim().length}/2000</p>
+                  </div>
+                </div>
+                <div className="mt-4 flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setClaimDialogOpen(false)}
+                    disabled={isClaimSubmitting}
+                  >
+                    취소
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={handleSubmitClaim}
+                    disabled={isClaimSubmitting || claimDescription.trim().length < 10}
+                  >
+                    {isClaimSubmitting ? '제출 중...' : '신고 제출'}
+                  </Button>
+                </div>
+              </div>
+            )}
             <Button
               onClick={handleNextAfterFeedback}
               className={`w-full h-14 mt-4 font-bold text-lg rounded-xl shadow-sm hover:shadow-md transition-all ${
@@ -469,78 +528,11 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
             >
               계속하기
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full h-12 font-semibold rounded-xl"
-              onClick={() => setClaimDialogOpen(true)}
-            >
-              문제 신고
-            </Button>
           </div>
             );
           })()}
         </div>
       )}
-
-      <Dialog open={claimDialogOpen} onOpenChange={setClaimDialogOpen}>
-        <DialogContent className="rounded-2xl sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>문제 신고</DialogTitle>
-            <DialogDescription>
-              정답/해설/문항 오류를 알려주시면 검토 후 반영하겠습니다.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="claim-type">신고 유형</Label>
-              <Select value={claimType} onValueChange={(value) => setClaimType(value as CSQuestionClaimType)}>
-                <SelectTrigger id="claim-type">
-                  <SelectValue placeholder="신고 유형을 선택해주세요." />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="INCORRECT_ANSWER">정답이 잘못됨</SelectItem>
-                  <SelectItem value="INCORRECT_EXPLANATION">해설이 잘못됨</SelectItem>
-                  <SelectItem value="QUESTION_TEXT_ERROR">문제 문구가 모호/오류</SelectItem>
-                  <SelectItem value="OTHER">기타</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="claim-description">상세 내용</Label>
-              <Textarea
-                id="claim-description"
-                value={claimDescription}
-                onChange={(event) => setClaimDescription(event.target.value)}
-                placeholder="어떤 부분이 문제인지 구체적으로 적어주세요. (최소 10자)"
-                minLength={10}
-                maxLength={2000}
-              />
-              <p className="text-xs text-muted-foreground">{claimDescription.trim().length}/2000</p>
-            </div>
-          </div>
-
-          <DialogFooter className="gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setClaimDialogOpen(false)}
-              disabled={isClaimSubmitting}
-            >
-              취소
-            </Button>
-            <Button
-              type="button"
-              onClick={handleSubmitClaim}
-              disabled={isClaimSubmitting || claimDescription.trim().length < 10}
-            >
-              {isClaimSubmitting ? '제출 중...' : '신고 제출'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## 💡 의도 / 배경
CS 퀴즈 풀이 중 `정답입니다!/틀렸습니다.` 피드백 화면에서 정답/해설/문항 오류를 즉시 신고할 수 있는 기능이 필요했습니다.  
기존에는 신고 진입 경로가 없었고, 모바일에서는 신고 모달 우선순위(z-index) 문제로 실제 신고가 어려운 이슈가 있어 함께 개선했습니다.

## 🛠️ 작업 내용
- [x] CS 문제 신고 기능(사용자 신고 API + 저장 + 관리자 조회) 구현
- [x] 피드백 UI 내 신고 UX 개선 (제목 우측 작은 신고 버튼 + 모바일 우선순위 이슈 해결)

상세:
- 사용자 신고 API 추가: `POST /api/cs/stages/{stageId}/claims`
- 신고 저장 스키마/엔티티/레포지토리/서비스 추가 (`cs_question_claims`)
- 신고 정책 반영:
  - 동일 유저-동일 문항 24시간 1회 제한
  - 유저 일일 5회 제한
  - 상세 내용 최소 10자
- 관리자 신고 내역 조회 활성화: `GET /api/cs/admin/stages/{stageId}/claims`
- 프론트 피드백 화면 수정:
  - `정답입니다!/틀렸습니다.` 오른쪽에 작은 `문제 신고` 버튼 배치
  - 별도 Dialog 제거, 피드백 모달 내부 인라인 신고 패널로 변경 (모바일 클릭 불가 이슈 해결)

## 🔗 관련 이슈
- Closes #203

## 🖼️ 스크린샷 (선택)
- UI 변경 있음 (피드백 헤더 우측 신고 버튼, 인라인 신고 패널)
- 스크린샷 첨부 예정

## 🧪 테스트 방법
- [x] 백엔드 컴파일: `cmd /c gradlew.bat compileJava`
- [x] 프론트 타입체크: `cmd /c pnpm type-check`

리뷰어 확인 가이드:
1. CS 스테이지 진입 후 문제 제출
2. 피드백 모달 헤더 오른쪽 `문제 신고` 버튼 클릭
3. 신고 유형/상세 내용(10자 이상) 입력 후 제출
4. 관리자 페이지 > CS 콘텐츠 관리 > 신고 내역 탭에서 접수 내역 확인
5. 모바일 뷰에서 신고 패널이 정상 클릭/입력/제출되는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?
  - 백엔드 compile, 프론트 type-check 통과
  - 프론트 전체 lint는 기존 전역 이슈로 미통과

## 💬 리뷰어에게 (선택)
모바일에서 신고가 안 되던 핵심 원인은 별도 신고 Dialog의 우선순위/포커스 충돌 가능성이었습니다.  
이번 PR에서는 신고 입력 UI를 피드백 모달 내부 인라인 패널로 통합해 모바일 동작 안정성을 우선 확보했습니다.