### PR TITLE
feat: 모바일에서 툴바에 nav bar 가리는 현상 수정

### DIFF
--- a/apps/frontend/src/app/(main)/layout.tsx
+++ b/apps/frontend/src/app/(main)/layout.tsx
@@ -14,7 +14,7 @@ export default async function MainLayout({
   const user = await getMyProfile();
 
   return (
-    <div className="flex h-[100dvh] min-h-screen overflow-hidden lg:h-auto lg:min-h-screen lg:overflow-visible">
+    <div className="flex h-screen supports-[height:100dvh]:h-[100dvh] overflow-hidden lg:h-auto lg:min-h-screen lg:overflow-visible">
       <Sidebar user={user} />
       <MainContentWrapper>
         <main className="flex-1 min-h-0 w-full max-w-7xl mx-auto overflow-y-auto px-4 py-0 lg:px-8 lg:overflow-visible">

--- a/apps/frontend/src/app/(main)/not-found.tsx
+++ b/apps/frontend/src/app/(main)/not-found.tsx
@@ -3,7 +3,7 @@ import { FileQuestion } from 'lucide-react';
 
 export default function NotFound() {
   return (
-    <div className="flex h-[calc(100vh-4rem)] flex-col items-center justify-center gap-6 text-center animate-in fade-in zoom-in-95 duration-300">
+    <div className="flex h-[calc(100vh-4rem)] supports-[height:100dvh]:h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 text-center animate-in fade-in zoom-in-95 duration-300">
       <div className="w-24 h-24 bg-muted/30 rounded-full flex items-center justify-center mb-2 animate-bounce">
         <FileQuestion className="w-12 h-12 text-muted-foreground" />
       </div>

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import { ThemeProvider } from '@/domains/settings/components/ThemeProvider';
 import SettingsModal from '@/domains/settings/components/SettingsModal';
@@ -14,6 +14,12 @@ export const metadata: Metadata = {
   icons: {
     icon: '/favicon.png',
   },
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
 };
 
 export default function RootLayout({

--- a/apps/frontend/src/app/not-found.tsx
+++ b/apps/frontend/src/app/not-found.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export default function NotFound() {
   return (
-    <div className="flex h-[calc(100vh-4rem)] flex-col items-center justify-center gap-4">
+    <div className="flex h-[calc(100vh-4rem)] supports-[height:100dvh]:h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-4">
       <h2 className="text-2xl font-bold">404 - 페이지를 찾을 수 없습니다</h2>
       <p className="text-muted-foreground">요청하신 리소스가 존재하지 않거나 삭제되었습니다.</p>
       <Link

--- a/apps/frontend/src/domains/profile/components/CCHistoryList.tsx
+++ b/apps/frontend/src/domains/profile/components/CCHistoryList.tsx
@@ -166,7 +166,7 @@ export function CCHistoryList({ initialHistory }: Props) {
       {/* relative for calendar popover context if needed, though usually popover is near trigger */}
       <div className="flex-1 flex flex-col min-w-0 transition-all duration-200">
         <div
-          className={`h-[calc(100vh-120px)] flex flex-col transition-all duration-300 ease-in-out ${selectedSubmission ? 'pr-[480px]' : ''}`}
+          className={`h-[calc(100vh-120px)] supports-[height:100dvh]:h-[calc(100dvh-120px)] flex flex-col transition-all duration-300 ease-in-out ${selectedSubmission ? 'pr-[480px]' : ''}`}
         >
           {/* 1. Header & Filters */}
           <div className="flex-none mb-6 space-y-4">

--- a/apps/frontend/src/domains/study/components/CCStudyRoomMobileLayout.tsx
+++ b/apps/frontend/src/domains/study/components/CCStudyRoomMobileLayout.tsx
@@ -29,7 +29,7 @@ export function CCStudyRoomMobileLayout({
   }, [viewMode, setMobileTab]);
 
   return (
-    <div className="flex h-[100dvh] flex-col bg-background text-foreground overflow-hidden w-full">
+    <div className="flex h-screen supports-[height:100dvh]:h-[100dvh] flex-col bg-background text-foreground overflow-hidden w-full">
       {header && <header className="shrink-0 border-b border-border">{header}</header>}
 
       <main className="relative flex flex-col flex-1 min-h-0 overflow-hidden w-full">
@@ -53,50 +53,52 @@ export function CCStudyRoomMobileLayout({
       </main>
 
       {/* Bottom Navigation Bar */}
-      <nav className="shrink-0 flex items-center justify-around border-t border-border bg-card h-[64px] pb-safe z-50 w-full shadow-[0_-4px_10px_-4px_rgba(0,0,0,0.05)]">
-        <button
-          onClick={() => setMobileTab('video')}
-          className={cn(
-            'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
-            mobileTab === 'video' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
-          )}
-        >
-          <Video className="w-5 h-5" />
-          <span className="text-[10px] font-medium mt-0.5">화상</span>
-        </button>
-        
-        <button
-          onClick={() => setMobileTab('code')}
-          className={cn(
-            'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
-            mobileTab === 'code' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
-          )}
-        >
-          <Code2 className="w-5 h-5" />
-          <span className="text-[10px] font-medium mt-0.5">코드</span>
-        </button>
-        
-        <button
-          onClick={() => setMobileTab('problems')}
-          className={cn(
-            'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
-            mobileTab === 'problems' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
-          )}
-        >
-          <ListTodo className="w-5 h-5" />
-          <span className="text-[10px] font-medium mt-0.5">문제</span>
-        </button>
-        
-        <button
-          onClick={() => setMobileTab('chat')}
-          className={cn(
-            'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
-            mobileTab === 'chat' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
-          )}
-        >
-          <MessageSquare className="w-5 h-5" />
-          <span className="text-[10px] font-medium mt-0.5">소통</span>
-        </button>
+      <nav className="shrink-0 border-t border-border bg-card z-50 w-full shadow-[0_-4px_10px_-4px_rgba(0,0,0,0.05)] pb-[env(safe-area-inset-bottom)]">
+        <div className="flex h-[64px] items-center justify-around">
+          <button
+            onClick={() => setMobileTab('video')}
+            className={cn(
+              'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
+              mobileTab === 'video' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
+            )}
+          >
+            <Video className="w-5 h-5" />
+            <span className="text-[10px] font-medium mt-0.5">화상</span>
+          </button>
+
+          <button
+            onClick={() => setMobileTab('code')}
+            className={cn(
+              'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
+              mobileTab === 'code' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
+            )}
+          >
+            <Code2 className="w-5 h-5" />
+            <span className="text-[10px] font-medium mt-0.5">코드</span>
+          </button>
+
+          <button
+            onClick={() => setMobileTab('problems')}
+            className={cn(
+              'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
+              mobileTab === 'problems' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
+            )}
+          >
+            <ListTodo className="w-5 h-5" />
+            <span className="text-[10px] font-medium mt-0.5">문제</span>
+          </button>
+
+          <button
+            onClick={() => setMobileTab('chat')}
+            className={cn(
+              'flex flex-col items-center justify-center w-full h-full gap-1 transition-colors',
+              mobileTab === 'chat' ? 'text-primary' : 'text-muted-foreground hover:text-foreground/80'
+            )}
+          >
+            <MessageSquare className="w-5 h-5" />
+            <span className="text-[10px] font-medium mt-0.5">소통</span>
+          </button>
+        </div>
       </nav>
     </div>
   );

--- a/apps/frontend/src/domains/workbook/components/AddToWorkbookModal.tsx
+++ b/apps/frontend/src/domains/workbook/components/AddToWorkbookModal.tsx
@@ -147,7 +147,7 @@ export function AddToWorkbookModal({
                 className={cn(
                     'bg-card border-border shadow-2xl flex flex-col gap-0',
                     isMobile
-                        ? 'w-[calc(100vw-1rem)] max-w-none h-[calc(100vh-1.5rem)] max-h-[calc(100vh-1.5rem)] rounded-2xl top-3 translate-y-0 p-4 overflow-hidden'
+                        ? 'w-[calc(100vw-1rem)] max-w-none h-[calc(100vh-1.5rem)] max-h-[calc(100vh-1.5rem)] supports-[height:100dvh]:h-[calc(100dvh-1.5rem)] supports-[height:100dvh]:max-h-[calc(100dvh-1.5rem)] rounded-2xl top-3 translate-y-0 p-4 overflow-hidden'
                         : 'sm:max-w-[420px] rounded-3xl p-6 max-h-[85vh]'
                 )}
             >


### PR DESCRIPTION
## 💡 의도 / 배경
모바일 브라우저(iOS Safari/Android Chrome 등)에서 하단 툴바/제스처 영역과 앱 하단 네비게이션이 겹치면서,
일부 버튼이 가려지거나 터치가 어려운 문제가 있었습니다.  
브라우저 UI 노출/숨김 상태와 관계없이 하단 네비게이션이 항상 보이고 클릭 가능하도록 레이아웃을 보완했습니다.

## 🛠️ 작업 내용
- [x] `viewport-fit=cover` 적용으로 safe-area 계산이 동작하도록 루트 viewport 설정 추가
- [x] 모바일 높이 계산을 `100vh` 단독 의존에서 `100dvh` 우선(`h-screen` fallback 유지) 방식으로 정리
- [x] 스터디 모바일 하단 nav의 `pb-safe`(미정의 클래스) 제거 후 `pb-[env(safe-area-inset-bottom)]` 적용
- [x] 하단 nav 구조를 `64px 본체 + safe-area`로 분리해 툴바/제스처 영역 겹침 방지
- [x] 모바일 관련 일부 화면(not-found, 히스토리, 모달)도 `100dvh` 대응으로 화면 잘림 완화

## 🔗 관련 이슈
- Closes #207

## 🖼️ 스크린샷 (선택)
- iOS Safari: 하단 주소창 표시/숨김 각각 캡처 필요
- Android Chrome: 하단/상단 UI 변화 시 캡처 필요

## 🧪 테스트 방법
- [x] 타입체크: `pnpm -C apps/frontend exec tsc --noEmit --pretty false`
- [ ] iOS Safari에서 `/study` 진입 후 하단 nav 가림/터치 여부 확인
- [ ] Android Chrome에서 스크롤로 브라우저 UI 변화 시 하단 nav 가림/터치 여부 확인
- [ ] `/workbooks`, `/profile/.../history` 등 모바일 높이 영향 화면 회귀 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
모바일 브라우저별(특히 iOS Safari) safe-area 동작 차이가 있어,
툴바 노출/숨김 전환 상황에서 하단 nav가 항상 노출되고 탭 가능한지 중점 확인 부탁드립니다.