### PR TITLE
feat: 기출문제 유저 플로우 수정

### DIFF
--- a/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSLearningSession.tsx
@@ -93,6 +93,8 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const feedbackAdvanceLockRef = useRef(false);
+  const isPastExamSource = searchParams.get('source') === 'past-exam';
+  const exitPath = isPastExamSource ? '/cs/past-exams' : '/cs';
 
   const [phase, setPhase] = useState<Phase>('loading');
   const [currentQuestion, setCurrentQuestion] = useState<CSQuestionPayload | null>(null);
@@ -174,7 +176,23 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
       if (typeof window !== 'undefined') {
         sessionStorage.setItem(getCSStageResultStorageKey(stageId), JSON.stringify(res));
       }
-      router.replace(`/cs/stage/${stageId}/result`);
+      const resultQuery = new URLSearchParams();
+      const source = searchParams.get('source');
+      const year = searchParams.get('year');
+      const round = searchParams.get('round');
+
+      if (source) {
+        resultQuery.set('source', source);
+      }
+      if (year) {
+        resultQuery.set('year', year);
+      }
+      if (round) {
+        resultQuery.set('round', round);
+      }
+
+      const queryString = resultQuery.toString();
+      router.replace(`/cs/stage/${stageId}/result${queryString ? `?${queryString}` : ''}`);
     } catch (err) {
       console.error(err);
       toast.error('스테이지 결과를 불러오는 데 실패했습니다.');
@@ -281,7 +299,7 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
   }, [answerResult, claimDialogOpen, handleNextAfterFeedback]);
 
   const handleExitConfirm = () => {
-    router.replace('/cs');
+    router.replace(exitPath);
   };
 
   if (phase === 'error') {
@@ -289,7 +307,7 @@ export default function CSLearningSession({ stageId }: CSLearningSessionProps) {
       <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
         <AlertCircle className="w-12 h-12 text-destructive" />
         <h2 className="text-xl font-bold">오류가 발생했습니다</h2>
-        <Button onClick={() => router.replace('/cs')} variant="outline">
+        <Button onClick={() => router.replace(exitPath)} variant="outline">
           돌아가기
         </Button>
       </div>

--- a/apps/frontend/src/domains/cs/components/session/CSResultScreen.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSResultScreen.tsx
@@ -4,18 +4,20 @@ import React from 'react';
 import { CSAttemptCompleteResponse } from '@/domains/cs/api/csApi';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { Trophy, Flame, CheckCircle, ArrowRight, RotateCcw, Coins } from 'lucide-react';
+import { Trophy, Flame, CheckCircle, RotateCcw, Coins } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 interface CSResultScreenProps {
   result: CSAttemptCompleteResponse;
+  isPastExam: boolean;
+  returnPath: string;
 }
 
-export default function CSResultScreen({ result }: CSResultScreenProps) {
+export default function CSResultScreen({ result, isPastExam, returnPath }: CSResultScreenProps) {
   const router = useRouter();
 
   const handleReturnToCS = () => {
-    router.replace('/cs');
+    router.replace(returnPath);
   };
 
   const handleNextStage = () => {
@@ -63,7 +65,16 @@ export default function CSResultScreen({ result }: CSResultScreenProps) {
           </div>
 
           <div className="flex flex-col w-full gap-3">
-            {result.isTrackCompleted ? (
+            {isPastExam ? (
+              <Button
+                variant="outline"
+                className="w-full h-14 text-lg font-bold rounded-2xl"
+                onClick={handleReturnToCS}
+              >
+                <RotateCcw className="w-5 h-5 mr-2" />
+                기출 목록으로 돌아가기
+              </Button>
+            ) : result.isTrackCompleted ? (
               <Button
                 className="w-full h-14 text-lg font-bold rounded-2xl"
                 onClick={handleReturnToCS}
@@ -79,7 +90,6 @@ export default function CSResultScreen({ result }: CSResultScreenProps) {
                     onClick={handleNextStage}
                   >
                     다음 스테이지 풀기
-                    <ArrowRight className="w-5 h-5 ml-2" />
                   </Button>
                 )}
                 <Button

--- a/apps/frontend/src/domains/cs/components/session/CSStageResultPageClient.tsx
+++ b/apps/frontend/src/domains/cs/components/session/CSStageResultPageClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Loader2 } from 'lucide-react';
 
 import { CSAttemptCompleteResponse } from '@/domains/cs/api/csApi';
@@ -14,6 +14,9 @@ interface CSStageResultPageClientProps {
 
 export default function CSStageResultPageClient({ stageId }: CSStageResultPageClientProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const isPastExam = searchParams.get('source') === 'past-exam';
+  const returnPath = isPastExam ? '/cs/past-exams' : '/cs';
   const [result, setResult] = useState<CSAttemptCompleteResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -22,7 +25,7 @@ export default function CSStageResultPageClient({ stageId }: CSStageResultPageCl
     const raw = sessionStorage.getItem(key);
 
     if (!raw) {
-      router.replace('/cs');
+      router.replace(returnPath);
       return;
     }
 
@@ -34,9 +37,9 @@ export default function CSStageResultPageClient({ stageId }: CSStageResultPageCl
       setIsLoading(false);
     } catch (error) {
       console.error('Failed to parse CS stage result:', error);
-      router.replace('/cs');
+      router.replace(returnPath);
     }
-  }, [router, stageId]);
+  }, [returnPath, router, stageId]);
 
   if (isLoading || !result) {
     return (
@@ -47,5 +50,5 @@ export default function CSStageResultPageClient({ stageId }: CSStageResultPageCl
     );
   }
 
-  return <CSResultScreen result={result} />;
+  return <CSResultScreen result={result} isPastExam={isPastExam} returnPath={returnPath} />;
 }


### PR DESCRIPTION
## 💡 의도 / 배경
기출문제 풀이 완료 후 결과화면에서 `다음 스테이지 풀기`가 노출되어 사용자 흐름이 분산되고,  
`나가기` 시 커리큘럼(`/cs`)으로 이동해 기출 컨텍스트가 끊기는 문제가 있었습니다.  
기출 풀이 사용자는 결과 이후 자연스럽게 기출 목록으로 복귀할 수 있어야 하므로 플로우를 정리했습니다.

## 🛠️ 작업 내용
- [x] `source=past-exam`인 경우 결과화면에서 `다음 스테이지 풀기` 버튼 비노출 처리
- [x] 기출 풀이/결과 화면에서 `나가기` 및 `목록으로 돌아가기` 동작을 `/cs/past-exams`로 라우팅
- [x] 세션 완료 후 결과 페이지 이동 시 `source/year/round` 쿼리 전달로 진입 컨텍스트 유지
- [x] 결과 데이터 누락/파싱 실패 시에도 기출 진입 케이스는 `/cs/past-exams`로 안전 복귀

## 🔗 관련 이슈
- Closes #209

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] `pnpm --filter frontend exec tsc --noEmit`
- [x] 수동 테스트 1: 정보처리기사 기출 진입 → 문제 풀이 완료 → 결과화면에서 `다음 스테이지 풀기` 미노출 확인
- [x] 수동 테스트 2: 결과화면 `기출 목록으로 돌아가기` 클릭 시 `/cs/past-exams` 이동 확인
- [x] 수동 테스트 3: 풀이 중 `나가기` 클릭 시 `/cs/past-exams` 이동 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
`source=past-exam` 분기 기반으로 동작합니다.  
일반 커리큘럼 진입(`source` 없음)에서는 기존 플로우가 유지되는지 함께 확인 부탁드립니다.