### PR TITLE
feat: 신고된 문제 한번에 보는 기능 추가

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsAdminController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/controller/CsAdminController.java
@@ -2,15 +2,19 @@ package com.peekle.domain.cs.controller;
 
 import com.peekle.domain.cs.dto.request.CsAdminDomainNameRequest;
 import com.peekle.domain.cs.dto.request.CsAdminImagePresignRequest;
+import com.peekle.domain.cs.dto.request.CsAdminClaimStatusUpdateRequest;
 import com.peekle.domain.cs.dto.request.CsAdminQuestionShortAnswersUpdateRequest;
 import com.peekle.domain.cs.dto.request.CsAdminQuestionUpdateRequest;
 import com.peekle.domain.cs.dto.request.CsAdminStageQuestionImportRequest;
 import com.peekle.domain.cs.dto.request.CsAdminTrackCreateRequest;
+import com.peekle.domain.cs.dto.response.CsAdminClaimOverviewPageResponse;
 import com.peekle.domain.cs.dto.response.CsAdminClaimsPlaceholderResponse;
 import com.peekle.domain.cs.dto.response.CsAdminQuestionImportResponse;
 import com.peekle.domain.cs.dto.response.CsAdminQuestionResponse;
 import com.peekle.domain.cs.dto.response.CsAdminTrackResponse;
 import com.peekle.domain.cs.dto.response.CsDomainResponse;
+import com.peekle.domain.cs.enums.CsQuestionClaimStatus;
+import com.peekle.domain.cs.enums.CsQuestionClaimType;
 import com.peekle.domain.cs.service.CsAdminContentService;
 import com.peekle.global.dto.ApiResponse;
 import jakarta.validation.Valid;
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -139,6 +144,38 @@ public class CsAdminController {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long stageId) {
         return ApiResponse.success(csAdminContentService.getStageClaims(userId, stageId));
+    }
+
+    @GetMapping("/claims")
+    public ApiResponse<CsAdminClaimOverviewPageResponse> getClaims(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) CsQuestionClaimStatus status,
+            @RequestParam(required = false) CsQuestionClaimType claimType,
+            @RequestParam(required = false) Integer domainId,
+            @RequestParam(required = false) Long trackId,
+            @RequestParam(required = false) Long stageId,
+            @RequestParam(required = false) Long questionId,
+            @RequestParam(required = false, defaultValue = "0") Integer page,
+            @RequestParam(required = false, defaultValue = "20") Integer size) {
+        return ApiResponse.success(csAdminContentService.getClaims(
+                userId,
+                status,
+                claimType,
+                domainId,
+                trackId,
+                stageId,
+                questionId,
+                page,
+                size));
+    }
+
+    @PutMapping("/claims/{claimId}/status")
+    public ApiResponse<Void> updateClaimStatus(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long claimId,
+            @Valid @RequestBody CsAdminClaimStatusUpdateRequest request) {
+        csAdminContentService.updateClaimStatus(userId, claimId, request.status());
+        return ApiResponse.success();
     }
 
     @PostMapping("/images/presigned-url")

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsAdminClaimStatusUpdateRequest.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/request/CsAdminClaimStatusUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.peekle.domain.cs.dto.request;
+
+import com.peekle.domain.cs.enums.CsQuestionClaimStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record CsAdminClaimStatusUpdateRequest(
+        @NotNull CsQuestionClaimStatus status) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminClaimOverviewItemResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminClaimOverviewItemResponse.java
@@ -1,0 +1,20 @@
+package com.peekle.domain.cs.dto.response;
+
+import com.peekle.domain.cs.enums.CsQuestionClaimStatus;
+import com.peekle.domain.cs.enums.CsQuestionClaimType;
+
+public record CsAdminClaimOverviewItemResponse(
+        Long claimId,
+        Long questionId,
+        Integer domainId,
+        String domainName,
+        Long trackId,
+        Integer trackNo,
+        String trackName,
+        Long stageId,
+        Integer stageNo,
+        CsQuestionClaimType claimType,
+        CsQuestionClaimStatus status,
+        String description,
+        String createdAt) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminClaimOverviewPageResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/dto/response/CsAdminClaimOverviewPageResponse.java
@@ -1,0 +1,10 @@
+package com.peekle.domain.cs.dto.response;
+
+import java.util.List;
+
+public record CsAdminClaimOverviewPageResponse(
+        List<CsAdminClaimOverviewItemResponse> content,
+        Integer page,
+        Integer size,
+        Long totalElements) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsQuestionClaim.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/entity/CsQuestionClaim.java
@@ -64,4 +64,8 @@ public class CsQuestionClaim extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private CsQuestionClaimStatus status = CsQuestionClaimStatus.RECEIVED;
+
+    public void updateStatus(CsQuestionClaimStatus status) {
+        this.status = status;
+    }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionClaimRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/repository/CsQuestionClaimRepository.java
@@ -1,7 +1,13 @@
 package com.peekle.domain.cs.repository;
 
 import com.peekle.domain.cs.entity.CsQuestionClaim;
+import com.peekle.domain.cs.enums.CsQuestionClaimStatus;
+import com.peekle.domain.cs.enums.CsQuestionClaimType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,4 +22,43 @@ public interface CsQuestionClaimRepository extends JpaRepository<CsQuestionClaim
     long countByUser_IdAndCreatedAtGreaterThanEqual(Long userId, LocalDateTime since);
 
     List<CsQuestionClaim> findByStage_IdOrderByCreatedAtDesc(Long stageId);
+
+    @Query(
+            value = """
+                    select claim
+                    from CsQuestionClaim claim
+                    join fetch claim.question question
+                    join fetch claim.stage stage
+                    join fetch stage.track track
+                    join fetch track.domain domain
+                    where (:status is null or claim.status = :status)
+                      and (:claimType is null or claim.claimType = :claimType)
+                      and (:domainId is null or domain.id = :domainId)
+                      and (:trackId is null or track.id = :trackId)
+                      and (:stageId is null or stage.id = :stageId)
+                      and (:questionId is null or question.id = :questionId)
+                    order by claim.createdAt desc, claim.id desc
+                    """,
+            countQuery = """
+                    select count(claim)
+                    from CsQuestionClaim claim
+                    join claim.question question
+                    join claim.stage stage
+                    join stage.track track
+                    join track.domain domain
+                    where (:status is null or claim.status = :status)
+                      and (:claimType is null or claim.claimType = :claimType)
+                      and (:domainId is null or domain.id = :domainId)
+                      and (:trackId is null or track.id = :trackId)
+                      and (:stageId is null or stage.id = :stageId)
+                      and (:questionId is null or question.id = :questionId)
+                    """)
+    Page<CsQuestionClaim> findPagedByFilters(
+            @Param("status") CsQuestionClaimStatus status,
+            @Param("claimType") CsQuestionClaimType claimType,
+            @Param("domainId") Integer domainId,
+            @Param("trackId") Long trackId,
+            @Param("stageId") Long stageId,
+            @Param("questionId") Long questionId,
+            Pageable pageable);
 }

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAdminContentService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsAdminContentService.java
@@ -8,6 +8,8 @@ import com.peekle.domain.cs.dto.request.CsAdminQuestionShortAnswersUpdateRequest
 import com.peekle.domain.cs.dto.request.CsAdminQuestionUpdateRequest;
 import com.peekle.domain.cs.dto.request.CsAdminStageQuestionImportRequest;
 import com.peekle.domain.cs.dto.request.CsAdminTrackCreateRequest;
+import com.peekle.domain.cs.dto.response.CsAdminClaimOverviewItemResponse;
+import com.peekle.domain.cs.dto.response.CsAdminClaimOverviewPageResponse;
 import com.peekle.domain.cs.dto.response.CsAdminClaimItemResponse;
 import com.peekle.domain.cs.dto.response.CsAdminClaimsPlaceholderResponse;
 import com.peekle.domain.cs.dto.response.CsAdminQuestionChoiceResponse;
@@ -26,6 +28,8 @@ import com.peekle.domain.cs.entity.CsQuestionShortAnswer;
 import com.peekle.domain.cs.entity.CsStage;
 import com.peekle.domain.cs.entity.CsUserDomainProgress;
 import com.peekle.domain.cs.enums.CsQuestionContentMode;
+import com.peekle.domain.cs.enums.CsQuestionClaimStatus;
+import com.peekle.domain.cs.enums.CsQuestionClaimType;
 import com.peekle.domain.cs.enums.CsQuestionGradingMode;
 import com.peekle.domain.cs.enums.CsQuestionType;
 import com.peekle.domain.cs.enums.CsTrackLearningMode;
@@ -46,6 +50,8 @@ import com.peekle.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -373,6 +379,75 @@ public class CsAdminContentService {
                 items.size(),
                 items.isEmpty() ? "등록된 신고 내역이 없습니다." : "최신 신고 내역입니다.",
                 items);
+    }
+
+    public CsAdminClaimOverviewPageResponse getClaims(
+            Long userId,
+            CsQuestionClaimStatus status,
+            CsQuestionClaimType claimType,
+            Integer domainId,
+            Long trackId,
+            Long stageId,
+            Long questionId,
+            Integer page,
+            Integer size) {
+        assertAdmin(userId);
+
+        int normalizedPage = page == null ? 0 : Math.max(page, 0);
+        int normalizedSize = size == null ? 20 : Math.max(1, Math.min(size, 100));
+
+        Page<CsQuestionClaim> resultPage = csQuestionClaimRepository.findPagedByFilters(
+                status,
+                claimType,
+                domainId,
+                trackId,
+                stageId,
+                questionId,
+                PageRequest.of(normalizedPage, normalizedSize));
+
+        List<CsAdminClaimOverviewItemResponse> content = resultPage.getContent()
+                .stream()
+                .map(this::toClaimOverviewItemResponse)
+                .toList();
+
+        return new CsAdminClaimOverviewPageResponse(
+                content,
+                normalizedPage,
+                normalizedSize,
+                resultPage.getTotalElements());
+    }
+
+    @Transactional
+    public void updateClaimStatus(Long userId, Long claimId, CsQuestionClaimStatus status) {
+        assertAdmin(userId);
+        if (status == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "상태 값은 필수입니다.");
+        }
+
+        CsQuestionClaim claim = csQuestionClaimRepository.findById(claimId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "신고 내역을 찾을 수 없습니다."));
+        claim.updateStatus(status);
+    }
+
+    private CsAdminClaimOverviewItemResponse toClaimOverviewItemResponse(CsQuestionClaim claim) {
+        CsStage stage = claim.getStage();
+        CsDomainTrack track = stage.getTrack();
+        CsDomain domain = track.getDomain();
+
+        return new CsAdminClaimOverviewItemResponse(
+                claim.getId(),
+                claim.getQuestion().getId(),
+                domain.getId(),
+                domain.getName(),
+                track.getId(),
+                (int) track.getTrackNo(),
+                track.getName(),
+                stage.getId(),
+                (int) stage.getStageNo(),
+                claim.getClaimType(),
+                claim.getStatus(),
+                claim.getDescription(),
+                claim.getCreatedAt() == null ? "" : claim.getCreatedAt().toString());
     }
 
     private CsAdminClaimItemResponse toClaimItemResponse(CsQuestionClaim claim) {

--- a/apps/backend/src/main/java/com/peekle/domain/cs/service/CsQuestionClaimService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/cs/service/CsQuestionClaimService.java
@@ -24,7 +24,7 @@ import java.time.ZonedDateTime;
 @Transactional(readOnly = true)
 public class CsQuestionClaimService {
 
-    private static final int DAILY_CLAIM_LIMIT = 5;
+    private static final int DAILY_CLAIM_LIMIT = 20;
     private static final int SAME_QUESTION_COOLDOWN_HOURS = 24;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
@@ -75,7 +75,7 @@ public class CsQuestionClaimService {
         LocalDateTime startOfDay = LocalDate.now(KST_ZONE).atStartOfDay();
         long todayCount = csQuestionClaimRepository.countByUser_IdAndCreatedAtGreaterThanEqual(userId, startOfDay);
         if (todayCount >= DAILY_CLAIM_LIMIT) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "하루 신고 가능 횟수(5회)를 초과했습니다.");
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "하루 신고 가능 횟수(20회)를 초과했습니다.");
         }
     }
 

--- a/apps/frontend/src/app/admin/cs-claims/page.tsx
+++ b/apps/frontend/src/app/admin/cs-claims/page.tsx
@@ -1,0 +1,449 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/components/ui/use-toast';
+import { CSDomain } from '@/domains/cs/api/csApi';
+import {
+  CSAdminClaimOverviewPageResponse,
+  CSAdminClaimOverviewQuery,
+  CSAdminClaimStatus,
+  CSAdminClaimType,
+  CSAdminTrack,
+  fetchAdminClaimsOverview,
+  fetchAdminDomains,
+  fetchAdminTracks,
+  updateAdminClaimStatus,
+} from '@/domains/cs/api/csAdminApi';
+
+const PAGE_SIZE = 20;
+
+const STATUS_LABEL_MAP: Record<CSAdminClaimStatus, string> = {
+  RECEIVED: '접수',
+  REVIEWED: '검토중',
+  RESOLVED: '완료',
+};
+
+const CLAIM_TYPE_LABEL_MAP: Record<CSAdminClaimType, string> = {
+  INCORRECT_ANSWER: '정답 오류',
+  INCORRECT_EXPLANATION: '해설 오류',
+  QUESTION_TEXT_ERROR: '문항 오류/모호함',
+  OTHER: '기타',
+};
+
+type SelectAllStatus = CSAdminClaimStatus | 'ALL';
+type SelectAllClaimType = CSAdminClaimType | 'ALL';
+
+export default function CsClaimsAdminPage() {
+  const { toast } = useToast();
+  const [domains, setDomains] = useState<CSDomain[]>([]);
+  const [tracks, setTracks] = useState<CSAdminTrack[]>([]);
+  const [data, setData] = useState<CSAdminClaimOverviewPageResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+  const [expandedClaimId, setExpandedClaimId] = useState<number | null>(null);
+  const [updatingStatusClaimId, setUpdatingStatusClaimId] = useState<number | null>(null);
+
+  const [status, setStatus] = useState<SelectAllStatus>('ALL');
+  const [claimType, setClaimType] = useState<SelectAllClaimType>('ALL');
+  const [domainId, setDomainId] = useState<number | null>(null);
+  const [trackId, setTrackId] = useState<number | null>(null);
+  const [stageId, setStageId] = useState<number | null>(null);
+  const [questionIdInput, setQuestionIdInput] = useState('');
+
+  const [appliedQuery, setAppliedQuery] = useState<CSAdminClaimOverviewQuery>({});
+
+  const selectedTrack = useMemo(
+    () => tracks.find((track) => track.trackId === trackId) ?? null,
+    [tracks, trackId],
+  );
+
+  const totalPages = useMemo(() => {
+    if (!data) return 1;
+    return Math.max(1, Math.ceil(data.totalElements / data.size));
+  }, [data]);
+
+  const loadDomains = async () => {
+    try {
+      const response = await fetchAdminDomains();
+      setDomains(response);
+    } catch (err) {
+      toast({
+        variant: 'destructive',
+        title: '오류',
+        description: err instanceof Error ? err.message : '도메인 목록을 불러오지 못했습니다.',
+      });
+    }
+  };
+
+  const loadTracks = async (nextDomainId: number) => {
+    try {
+      const response = await fetchAdminTracks(nextDomainId);
+      setTracks(response);
+    } catch (err) {
+      setTracks([]);
+      toast({
+        variant: 'destructive',
+        title: '오류',
+        description: err instanceof Error ? err.message : '트랙 목록을 불러오지 못했습니다.',
+      });
+    }
+  };
+
+  const loadClaims = async (query: CSAdminClaimOverviewQuery, nextPage: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchAdminClaimsOverview({
+        ...query,
+        page: nextPage,
+        size: PAGE_SIZE,
+      });
+      setData(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '신고 목록을 불러오지 못했습니다.');
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadDomains();
+  }, []);
+
+  useEffect(() => {
+    void loadClaims(appliedQuery, page);
+  }, [appliedQuery, page]);
+
+  const handleApplyFilters = () => {
+    const trimmedQuestionId = questionIdInput.trim();
+    let parsedQuestionId: number | undefined;
+
+    if (trimmedQuestionId.length > 0) {
+      if (!/^\d+$/.test(trimmedQuestionId)) {
+        toast({
+          variant: 'destructive',
+          title: '오류',
+          description: '문항 ID는 숫자만 입력해주세요.',
+        });
+        return;
+      }
+      parsedQuestionId = Number(trimmedQuestionId);
+    }
+
+    const nextQuery: CSAdminClaimOverviewQuery = {
+      status: status === 'ALL' ? undefined : status,
+      claimType: claimType === 'ALL' ? undefined : claimType,
+      domainId: domainId ?? undefined,
+      trackId: trackId ?? undefined,
+      stageId: stageId ?? undefined,
+      questionId: parsedQuestionId,
+    };
+
+    setExpandedClaimId(null);
+    setPage(0);
+    setAppliedQuery(nextQuery);
+  };
+
+  const handleResetFilters = () => {
+    setStatus('ALL');
+    setClaimType('ALL');
+    setDomainId(null);
+    setTrackId(null);
+    setStageId(null);
+    setQuestionIdInput('');
+    setTracks([]);
+    setExpandedClaimId(null);
+    setPage(0);
+    setAppliedQuery({});
+  };
+
+  const handleDomainChange = async (value: string) => {
+    if (value === 'ALL') {
+      setDomainId(null);
+      setTrackId(null);
+      setStageId(null);
+      setTracks([]);
+      return;
+    }
+
+    const parsed = Number(value);
+    setDomainId(parsed);
+    setTrackId(null);
+    setStageId(null);
+    await loadTracks(parsed);
+  };
+
+  const handleUpdateClaimStatus = async (claimId: number, nextStatus: CSAdminClaimStatus) => {
+    try {
+      setUpdatingStatusClaimId(claimId);
+      await updateAdminClaimStatus(claimId, nextStatus);
+      toast({ title: '신고 처리 상태를 변경했습니다.' });
+      await loadClaims(appliedQuery, page);
+    } catch (err) {
+      toast({
+        variant: 'destructive',
+        title: '오류',
+        description: err instanceof Error ? err.message : '신고 상태 변경에 실패했습니다.',
+      });
+    } finally {
+      setUpdatingStatusClaimId(null);
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-5">
+      <div className="mb-4">
+        <h1 className="text-2xl font-bold tracking-tight">CS 신고 통합 관리</h1>
+        <p className="text-muted-foreground">전체 신고 내역을 한 번에 조회하고 처리 상태를 변경할 수 있습니다.</p>
+      </div>
+
+      <Card className="mb-4">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">필터</CardTitle>
+          <CardDescription>조건을 선택한 뒤 조회를 눌러주세요.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <Select value={status} onValueChange={(value) => setStatus(value as SelectAllStatus)}>
+              <SelectTrigger>
+                <SelectValue placeholder="상태" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">전체 상태</SelectItem>
+                <SelectItem value="RECEIVED">접수</SelectItem>
+                <SelectItem value="REVIEWED">검토중</SelectItem>
+                <SelectItem value="RESOLVED">완료</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select value={claimType} onValueChange={(value) => setClaimType(value as SelectAllClaimType)}>
+              <SelectTrigger>
+                <SelectValue placeholder="신고 유형" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">전체 유형</SelectItem>
+                <SelectItem value="INCORRECT_ANSWER">정답 오류</SelectItem>
+                <SelectItem value="INCORRECT_EXPLANATION">해설 오류</SelectItem>
+                <SelectItem value="QUESTION_TEXT_ERROR">문항 오류/모호함</SelectItem>
+                <SelectItem value="OTHER">기타</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Input
+              value={questionIdInput}
+              onChange={(event) => setQuestionIdInput(event.target.value)}
+              placeholder="문항 ID (숫자)"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <Select value={domainId === null ? 'ALL' : String(domainId)} onValueChange={handleDomainChange}>
+              <SelectTrigger>
+                <SelectValue placeholder="도메인" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">전체 도메인</SelectItem>
+                {domains.map((domain) => (
+                  <SelectItem key={domain.id} value={String(domain.id)}>
+                    {domain.id}. {domain.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={trackId === null ? 'ALL' : String(trackId)}
+              onValueChange={(value) => {
+                if (value === 'ALL') {
+                  setTrackId(null);
+                  setStageId(null);
+                  return;
+                }
+                setTrackId(Number(value));
+                setStageId(null);
+              }}
+              disabled={domainId === null || tracks.length === 0}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="트랙" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">전체 트랙</SelectItem>
+                {tracks.map((track) => (
+                  <SelectItem key={track.trackId} value={String(track.trackId)}>
+                    {track.trackNo}. {track.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={stageId === null ? 'ALL' : String(stageId)}
+              onValueChange={(value) => {
+                if (value === 'ALL') {
+                  setStageId(null);
+                  return;
+                }
+                setStageId(Number(value));
+              }}
+              disabled={trackId === null || !selectedTrack}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="스테이지" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">전체 스테이지</SelectItem>
+                {(selectedTrack?.stages ?? []).map((stage) => (
+                  <SelectItem key={stage.stageId} value={String(stage.stageId)}>
+                    스테이지 {stage.stageNo}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={handleResetFilters}>
+              초기화
+            </Button>
+            <Button onClick={handleApplyFilters}>조회</Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-lg">신고 내역</CardTitle>
+          <CardDescription>
+            총 <span className="font-semibold text-foreground">{data?.totalElements ?? 0}</span>건
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          {loading && (
+            <div className="flex items-center justify-center gap-2 py-10 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              <span>신고 내역을 불러오는 중입니다...</span>
+            </div>
+          )}
+
+          {!loading && error && (
+            <div className="rounded-xl border border-destructive/20 bg-destructive/5 px-4 py-6 text-sm text-destructive">
+              <div className="mb-3">{error}</div>
+              <Button variant="outline" onClick={() => void loadClaims(appliedQuery, page)}>
+                다시 시도
+              </Button>
+            </div>
+          )}
+
+          {!loading && !error && data && data.content.length === 0 && (
+            <div className="py-10 text-center text-muted-foreground">조건에 맞는 신고 내역이 없습니다.</div>
+          )}
+
+          {!loading &&
+            !error &&
+            data &&
+            data.content.map((item) => {
+              const isExpanded = expandedClaimId === item.claimId;
+              const shortDescription =
+                item.description.length > 120 ? `${item.description.slice(0, 120)}...` : item.description;
+
+              return (
+                <Card key={item.claimId} className="border-border/60">
+                  <CardContent className="p-4">
+                    <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant="outline">{STATUS_LABEL_MAP[item.status]}</Badge>
+                        <Badge variant="secondary">{CLAIM_TYPE_LABEL_MAP[item.claimType]}</Badge>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {new Date(item.createdAt).toLocaleString('ko-KR')}
+                      </div>
+                    </div>
+
+                    <div className="mb-2 text-sm text-muted-foreground">
+                      문항 ID: <span className="font-semibold text-foreground">{item.questionId}</span> · 도메인{' '}
+                      <span className="font-semibold text-foreground">{item.domainId}. {item.domainName}</span> · 트랙{' '}
+                      <span className="font-semibold text-foreground">{item.trackNo}. {item.trackName}</span> · 스테이지{' '}
+                      <span className="font-semibold text-foreground">{item.stageNo}</span>
+                    </div>
+
+                    <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
+                      {isExpanded ? item.description : shortDescription}
+                    </p>
+
+                    <div className="mt-3 flex flex-wrap justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant={item.status === 'RECEIVED' ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => void handleUpdateClaimStatus(item.claimId, 'RECEIVED')}
+                        disabled={updatingStatusClaimId === item.claimId || item.status === 'RECEIVED'}
+                      >
+                        접수
+                      </Button>
+                      <Button
+                        type="button"
+                        variant={item.status === 'REVIEWED' ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => void handleUpdateClaimStatus(item.claimId, 'REVIEWED')}
+                        disabled={updatingStatusClaimId === item.claimId || item.status === 'REVIEWED'}
+                      >
+                        검토중
+                      </Button>
+                      <Button
+                        type="button"
+                        variant={item.status === 'RESOLVED' ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => void handleUpdateClaimStatus(item.claimId, 'RESOLVED')}
+                        disabled={updatingStatusClaimId === item.claimId || item.status === 'RESOLVED'}
+                      >
+                        완료
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setExpandedClaimId(isExpanded ? null : item.claimId)}
+                      >
+                        {isExpanded ? '접기' : '상세'}
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+
+          {!loading && !error && data && data.totalElements > 0 && (
+            <div className="mt-2 flex items-center justify-between">
+              <Button
+                variant="outline"
+                onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+                disabled={page <= 0}
+              >
+                이전
+              </Button>
+              <div className="text-sm text-muted-foreground">
+                {page + 1} / {totalPages} 페이지
+              </div>
+              <Button
+                variant="outline"
+                onClick={() => setPage((prev) => prev + 1)}
+                disabled={page + 1 >= totalPages}
+              >
+                다음
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/layout.tsx
+++ b/apps/frontend/src/app/admin/layout.tsx
@@ -18,6 +18,12 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
               >
                 CS 콘텐츠
               </Link>
+              <Link
+                href="/admin/cs-claims"
+                className="flex items-center text-sm font-medium text-muted-foreground"
+              >
+                신고 관리
+              </Link>
             </nav>
           </div>
           <div className="flex flex-1 items-center justify-end space-x-4">

--- a/apps/frontend/src/domains/cs/api/csAdminApi.ts
+++ b/apps/frontend/src/domains/cs/api/csAdminApi.ts
@@ -94,6 +94,43 @@ export interface CSAdminStageClaimsResponse {
   items: CSAdminClaimItem[];
 }
 
+export type CSAdminClaimStatus = 'RECEIVED' | 'REVIEWED' | 'RESOLVED';
+export type CSAdminClaimType = 'INCORRECT_ANSWER' | 'INCORRECT_EXPLANATION' | 'QUESTION_TEXT_ERROR' | 'OTHER';
+
+export interface CSAdminClaimOverviewItem {
+  claimId: number;
+  questionId: number;
+  domainId: number;
+  domainName: string;
+  trackId: number;
+  trackNo: number;
+  trackName: string;
+  stageId: number;
+  stageNo: number;
+  claimType: CSAdminClaimType;
+  status: CSAdminClaimStatus;
+  description: string;
+  createdAt: string;
+}
+
+export interface CSAdminClaimOverviewPageResponse {
+  content: CSAdminClaimOverviewItem[];
+  page: number;
+  size: number;
+  totalElements: number;
+}
+
+export interface CSAdminClaimOverviewQuery {
+  status?: CSAdminClaimStatus;
+  claimType?: CSAdminClaimType;
+  domainId?: number;
+  trackId?: number;
+  stageId?: number;
+  questionId?: number;
+  page?: number;
+  size?: number;
+}
+
 function assertApiData<T>(response: ApiResponse<T>, defaultMessage: string): T {
   if (!response.success || response.data === null || response.data === undefined) {
     throw new Error(response.error?.message || defaultMessage);
@@ -216,6 +253,39 @@ export const updateAdminQuestionShortAnswers = async (questionId: number, payloa
 export const fetchAdminStageClaims = async (stageId: number): Promise<CSAdminStageClaimsResponse> => {
   const response = await apiFetch<CSAdminStageClaimsResponse>(`/api/cs/admin/stages/${stageId}/claims`);
   return assertApiData(response, '클레임 목록을 불러오지 못했습니다.');
+};
+
+export const fetchAdminClaimsOverview = async (
+  query: CSAdminClaimOverviewQuery = {},
+): Promise<CSAdminClaimOverviewPageResponse> => {
+  const params = new URLSearchParams();
+  if (query.status) params.set('status', query.status);
+  if (query.claimType) params.set('claimType', query.claimType);
+  if (typeof query.domainId === 'number') params.set('domainId', String(query.domainId));
+  if (typeof query.trackId === 'number') params.set('trackId', String(query.trackId));
+  if (typeof query.stageId === 'number') params.set('stageId', String(query.stageId));
+  if (typeof query.questionId === 'number') params.set('questionId', String(query.questionId));
+  if (typeof query.page === 'number') params.set('page', String(query.page));
+  if (typeof query.size === 'number') params.set('size', String(query.size));
+
+  const queryString = params.toString();
+  const response = await apiFetch<CSAdminClaimOverviewPageResponse>(
+    `/api/cs/admin/claims${queryString ? `?${queryString}` : ''}`,
+  );
+  return assertApiData(response, '통합 신고 목록을 불러오지 못했습니다.');
+};
+
+export const updateAdminClaimStatus = async (
+  claimId: number,
+  status: CSAdminClaimStatus,
+): Promise<void> => {
+  const response = await apiFetch<void>(`/api/cs/admin/claims/${claimId}/status`, {
+    method: 'PUT',
+    body: JSON.stringify({ status }),
+  });
+  if (!response.success) {
+    throw new Error(response.error?.message || '신고 상태 변경에 실패했습니다.');
+  }
 };
 
 export const getAdminQuestionImagePresignedUrl = async (


### PR DESCRIPTION
## 💡 의도 / 배경
기존에는 신고 내역을 스테이지 단위로만 확인할 수 있어 운영자가 전체 신고를 빠르게 파악하기 어려웠습니다.  
또한 신고 대응 방식은 삭제보다 상태 기반 관리가 더 적합하다고 판단되어, 관리자에서 신고 상태를 직접 변경할 수 있도록 개선했습니다.  
추가로 신고 일일 제한을 운영 요청에 맞춰 5회에서 20회로 상향했습니다.

## 🛠️ 작업 내용
- [x] 관리자 통합 신고 조회 기능 추가
- [x] 관리자 신고 상태 변경 기능 추가 (RECEIVED / REVIEWED / RESOLVED)
- [x] 관리자 신고 삭제 UI 제거 및 상태 처리 중심으로 전환
- [x] 신고 일일 제한 5회 → 20회로 변경
- [x] 관리자 메뉴에 `신고 관리` 진입 링크 추가
- [x] 통합 조회 필터/페이지네이션/에러/빈 상태 UI 구현

## 🔗 관련 이슈
- Closes #211

## 🖼️ 스크린샷 (선택)
- 없음

## 🧪 테스트 방법
- [x] 백엔드 컴파일 확인: `apps/backend`에서 `gradlew.bat compileJava`
- [x] 프론트 타입체크 확인: `apps/frontend`에서 `pnpm exec tsc --noEmit`
- [x] 관리자 페이지 수동 확인
- [x] `/admin/cs-claims` 진입 후 필터(상태/유형/도메인/트랙/스테이지/문항ID) 조회 동작 확인
- [x] 목록 항목 상태를 `접수/검토중/완료`로 변경 시 즉시 반영 확인
- [x] 기존 스테이지별 신고 조회(`admin/cs-content` 내 claims 탭) 정상 동작 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
통합 신고 관리 페이지는 현재 상태 변경 중심으로 설계되어 있습니다.  
필요하면 후속으로 “상태 변경 이력(누가/언제)” 컬럼 및 감사 로그를 추가할 수 있습니다.