### PR TITLE
feat: 리트코드 문제 번역 api 구현

### DIFF
--- a/apps/backend/build.gradle
+++ b/apps/backend/build.gradle
@@ -97,6 +97,22 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    description = 'Runs unit tests only.'
+    exclude '**/*IntegrationTest.class'
+    exclude '**/*ConcurrencyTest.class'
+    exclude '**/PeekleBackendApplicationTests.class'
+}
+
+tasks.register('integrationTest', Test) {
+    group = 'verification'
+    description = 'Runs Spring context/integration tests that may require local infrastructure.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    shouldRunAfter test
+    include '**/*IntegrationTest.class'
+    include '**/*ConcurrencyTest.class'
+    include '**/PeekleBackendApplicationTests.class'
 }
 
 // 환경별 실행을 위한 편의용 태스크 (GradleBuild 타입)

--- a/apps/backend/src/main/java/com/peekle/domain/leetcode/controller/LeetcodeTranslationController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/leetcode/controller/LeetcodeTranslationController.java
@@ -1,0 +1,42 @@
+package com.peekle.domain.leetcode.controller;
+
+import com.peekle.domain.leetcode.dto.request.LeetcodeTranslationRequest;
+import com.peekle.domain.leetcode.dto.response.LeetcodeTranslationResponse;
+import com.peekle.domain.leetcode.service.GeminiTranslationService;
+import com.peekle.domain.leetcode.service.LeetcodeTranslationQuotaService;
+import com.peekle.global.dto.ApiResponse;
+import com.peekle.global.exception.BusinessException;
+import com.peekle.global.exception.ErrorCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/leetcode")
+@RequiredArgsConstructor
+@Slf4j
+public class LeetcodeTranslationController {
+
+    private final GeminiTranslationService geminiTranslationService;
+    private final LeetcodeTranslationQuotaService leetcodeTranslationQuotaService;
+
+    @PostMapping("/translate")
+    public ApiResponse<LeetcodeTranslationResponse> translate(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody LeetcodeTranslationRequest request
+    ) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        log.info("LeetCode 번역 요청 - userId: {}, count: {}", userId, request.texts().size());
+        geminiTranslationService.validateRequest(request.texts());
+        leetcodeTranslationQuotaService.consume(userId);
+        return ApiResponse.success(new LeetcodeTranslationResponse(geminiTranslationService.translate(request.texts())));
+    }
+}

--- a/apps/backend/src/main/java/com/peekle/domain/leetcode/dto/request/LeetcodeTranslationRequest.java
+++ b/apps/backend/src/main/java/com/peekle/domain/leetcode/dto/request/LeetcodeTranslationRequest.java
@@ -1,0 +1,15 @@
+package com.peekle.domain.leetcode.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record LeetcodeTranslationRequest(
+        @NotEmpty(message = "번역할 텍스트가 필요합니다.")
+        @Size(max = 20, message = "한 번에 최대 20개까지 번역할 수 있습니다.")
+        List<@NotBlank(message = "번역할 텍스트는 비어 있을 수 없습니다.")
+                @Size(max = 2000, message = "텍스트는 2000자를 넘을 수 없습니다.") String> texts
+) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/leetcode/dto/response/LeetcodeTranslationResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/leetcode/dto/response/LeetcodeTranslationResponse.java
@@ -1,0 +1,6 @@
+package com.peekle.domain.leetcode.dto.response;
+
+import java.util.List;
+
+public record LeetcodeTranslationResponse(List<String> translations) {
+}

--- a/apps/backend/src/main/java/com/peekle/domain/leetcode/service/GeminiTranslationService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/leetcode/service/GeminiTranslationService.java
@@ -1,0 +1,195 @@
+package com.peekle.domain.leetcode.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.peekle.global.exception.BusinessException;
+import com.peekle.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class GeminiTranslationService {
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final String apiKey;
+    private final String model;
+    private final int maxBatchSize;
+    private final int maxTextLength;
+    private final int maxTotalLength;
+
+    public GeminiTranslationService(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            @Value("${gemini.api-key:}") String apiKey,
+            @Value("${gemini.model:gemini-2.5-flash-lite}") String model,
+            @Value("${leetcode.translation.max-batch-size:20}") int maxBatchSize,
+            @Value("${leetcode.translation.max-text-length:2000}") int maxTextLength,
+            @Value("${leetcode.translation.max-total-length:12000}") int maxTotalLength
+    ) {
+        this.restClient = restClientBuilder.baseUrl("https://generativelanguage.googleapis.com").build();
+        this.objectMapper = objectMapper;
+        this.apiKey = apiKey;
+        this.model = model;
+        this.maxBatchSize = maxBatchSize;
+        this.maxTextLength = maxTextLength;
+        this.maxTotalLength = maxTotalLength;
+    }
+
+    public List<String> translate(List<String> texts) {
+        validateRequest(texts);
+
+        if (!StringUtils.hasText(apiKey)) {
+            throw new BusinessException(ErrorCode.TRANSLATION_API_KEY_MISSING);
+        }
+
+        try {
+            JsonNode response = restClient.post()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/v1beta/models/{model}:generateContent")
+                            .queryParam("key", apiKey)
+                            .build(model))
+                    .body(createRequestBody(texts))
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            return parseTranslations(response, texts.size());
+        } catch (RestClientResponseException e) {
+            log.warn("Gemini 번역 API 오류 - status: {}, body: {}",
+                    e.getStatusCode(), abbreviate(e.getResponseBodyAsString()));
+            throw new BusinessException(ErrorCode.TRANSLATION_PROVIDER_ERROR);
+        } catch (RestClientException e) {
+            log.warn("Gemini 번역 API 호출 실패", e);
+            throw new BusinessException(ErrorCode.TRANSLATION_PROVIDER_ERROR);
+        } catch (JsonProcessingException e) {
+            log.warn("Gemini 번역 응답 파싱 실패", e);
+            throw new BusinessException(ErrorCode.TRANSLATION_INVALID_RESPONSE);
+        }
+    }
+
+    public void validateRequest(List<String> texts) {
+        if (texts == null || texts.isEmpty() || texts.size() > maxBatchSize) {
+            throw new BusinessException(
+                    ErrorCode.TRANSLATION_REQUEST_TOO_LARGE,
+                    "한 번에 번역할 수 있는 문장은 최대 %d개입니다.".formatted(maxBatchSize)
+            );
+        }
+
+        int totalLength = 0;
+        for (String text : texts) {
+            if (!StringUtils.hasText(text)) {
+                throw new BusinessException(ErrorCode.TRANSLATION_REQUEST_TOO_LARGE, "번역할 텍스트는 비어 있을 수 없습니다.");
+            }
+            if (text.length() > maxTextLength) {
+                throw new BusinessException(
+                        ErrorCode.TRANSLATION_REQUEST_TOO_LARGE,
+                        "번역 텍스트는 문장당 최대 %d자까지 가능합니다.".formatted(maxTextLength)
+                );
+            }
+            totalLength += text.length();
+        }
+
+        if (totalLength > maxTotalLength) {
+            throw new BusinessException(
+                    ErrorCode.TRANSLATION_REQUEST_TOO_LARGE,
+                    "번역 요청은 전체 %d자까지 가능합니다.".formatted(maxTotalLength)
+            );
+        }
+    }
+
+    private Map<String, Object> createRequestBody(List<String> texts) throws JsonProcessingException {
+        return Map.of(
+                "contents", List.of(Map.of(
+                        "role", "user",
+                        "parts", List.of(Map.of("text", createPrompt(texts)))
+                )),
+                "generationConfig", Map.of(
+                        "temperature", 0.1,
+                        "responseMimeType", "application/json"
+                )
+        );
+    }
+
+    private String createPrompt(List<String> texts) throws JsonProcessingException {
+        return """
+                You translate LeetCode problem statement or solution analysis fragments from English to Korean.
+                Return only a valid JSON object in this exact shape: {"translations":["..."]}.
+
+                Rules:
+                - Keep the number and order of translations exactly the same as the input array.
+                - Preserve placeholder markers exactly as-is, including §0§, §1§, §2§ and __peekle_0__ style markers.
+                - Preserve programming identifiers, numbers, code values, booleans, and inline code meaning.
+                - Do not translate labels named Input or Output if they appear.
+                - Translate Explanation text naturally into Korean.
+                - Do not add commentary, markdown, or extra keys.
+
+                Input JSON array:
+                %s
+                """.formatted(objectMapper.writeValueAsString(texts));
+    }
+
+    private List<String> parseTranslations(JsonNode response, int expectedSize) throws JsonProcessingException {
+        if (response == null) {
+            throw new BusinessException(ErrorCode.TRANSLATION_INVALID_RESPONSE);
+        }
+
+        String text = response.path("candidates")
+                .path(0)
+                .path("content")
+                .path("parts")
+                .path(0)
+                .path("text")
+                .asText();
+
+        if (!StringUtils.hasText(text)) {
+            throw new BusinessException(ErrorCode.TRANSLATION_INVALID_RESPONSE);
+        }
+
+        JsonNode parsed = objectMapper.readTree(stripJsonFence(text));
+        JsonNode translationsNode = parsed.isArray() ? parsed : parsed.path("translations");
+
+        if (!translationsNode.isArray() || translationsNode.size() != expectedSize) {
+            throw new BusinessException(ErrorCode.TRANSLATION_INVALID_RESPONSE);
+        }
+
+        List<String> translations = new ArrayList<>(expectedSize);
+        translationsNode.forEach(node -> translations.add(node.asText()));
+        return translations;
+    }
+
+    private String stripJsonFence(String text) {
+        String trimmed = text.trim();
+        if (!trimmed.startsWith("```")) {
+            return trimmed;
+        }
+
+        int firstNewline = trimmed.indexOf('\n');
+        if (firstNewline < 0) {
+            return trimmed;
+        }
+
+        String withoutOpeningFence = trimmed.substring(firstNewline + 1).trim();
+        if (withoutOpeningFence.endsWith("```")) {
+            return withoutOpeningFence.substring(0, withoutOpeningFence.length() - 3).trim();
+        }
+        return withoutOpeningFence;
+    }
+
+    private String abbreviate(String value) {
+        if (value == null || value.length() <= 500) {
+            return value;
+        }
+        return value.substring(0, 500) + "...";
+    }
+}

--- a/apps/backend/src/main/java/com/peekle/domain/leetcode/service/LeetcodeTranslationQuotaService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/leetcode/service/LeetcodeTranslationQuotaService.java
@@ -1,0 +1,101 @@
+package com.peekle.domain.leetcode.service;
+
+import com.peekle.global.exception.BusinessException;
+import com.peekle.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@Slf4j
+public class LeetcodeTranslationQuotaService {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
+    private static final java.time.ZoneId SEOUL_ZONE = java.time.ZoneId.of("Asia/Seoul");
+
+    private final StringRedisTemplate redisTemplate;
+    private final int dailyLimit;
+    private final int hourlyLimit;
+
+    public LeetcodeTranslationQuotaService(
+            StringRedisTemplate redisTemplate,
+            @Value("${leetcode.translation.daily-limit:10}") int dailyLimit,
+            @Value("${leetcode.translation.hourly-limit:50}") int hourlyLimit
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.dailyLimit = dailyLimit;
+        this.hourlyLimit = hourlyLimit;
+    }
+
+    public void consume(Long userId) {
+        consumeGlobalHourly(userId);
+        consumeDaily(userId);
+    }
+
+    private void consumeGlobalHourly(Long userId) {
+        String key = createGlobalHourlyKey();
+        Long usedCount = redisTemplate.opsForValue().increment(key);
+
+        if (usedCount != null && usedCount == 1L) {
+            redisTemplate.expire(key, secondsUntilNextHour());
+        }
+
+        if (usedCount != null && usedCount > hourlyLimit) {
+            log.info("LeetCode 번역 전체 시간당 제한 초과 - userId: {}, usedCount: {}, limit: {}",
+                    userId, usedCount, hourlyLimit);
+            throw new BusinessException(
+                    ErrorCode.TRANSLATION_HOURLY_LIMIT_EXCEEDED,
+                    "전체 사용자 기준 최근 1시간 번역 요청이 %d회를 넘었어요. 제작자의 Gemini 토큰 비용과 서버를 보호하기 위해 잠시 제한 중입니다. 잠시 후 다시 시도해 주세요. 양해 부탁드립니다."
+                            .formatted(hourlyLimit)
+            );
+        }
+    }
+
+    private void consumeDaily(Long userId) {
+        String key = createDailyKey(userId);
+        Long usedCount = redisTemplate.opsForValue().increment(key);
+
+        if (usedCount != null && usedCount == 1L) {
+            redisTemplate.expire(key, secondsUntilTomorrow());
+        }
+
+        if (usedCount != null && usedCount > dailyLimit) {
+            log.info("LeetCode 번역 일일 제한 초과 - userId: {}, usedCount: {}, limit: {}",
+                    userId, usedCount, dailyLimit);
+            throw new BusinessException(
+                    ErrorCode.TRANSLATION_DAILY_LIMIT_EXCEEDED,
+                    "오늘 번역 가능 횟수 %d회를 모두 사용했어요. 제작자의 Gemini 토큰 비용 보호를 위해 제한 중입니다. 내일 다시 이용해 주세요. 양해 부탁드립니다."
+                            .formatted(dailyLimit)
+            );
+        }
+    }
+
+    private String createDailyKey(Long userId) {
+        String date = LocalDate.now(SEOUL_ZONE).format(DATE_FORMATTER);
+        return "leetcode:translation:quota:%s:%d".formatted(date, userId);
+    }
+
+    private String createGlobalHourlyKey() {
+        String dateHour = ZonedDateTime.now(SEOUL_ZONE).format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+        return "leetcode:translation:quota:hour:%s:global".formatted(dateHour);
+    }
+
+    private Duration secondsUntilTomorrow() {
+        ZonedDateTime now = ZonedDateTime.now(SEOUL_ZONE);
+        ZonedDateTime tomorrow = now.toLocalDate().plusDays(1).atStartOfDay(SEOUL_ZONE);
+        return Duration.between(now, tomorrow).plusMinutes(5);
+    }
+
+    private Duration secondsUntilNextHour() {
+        ZonedDateTime now = ZonedDateTime.now(SEOUL_ZONE);
+        ZonedDateTime nextHour = now.truncatedTo(ChronoUnit.HOURS).plusHours(1);
+        return Duration.between(now, nextHour).plusMinutes(5);
+    }
+}

--- a/apps/backend/src/main/java/com/peekle/global/exception/ErrorCode.java
+++ b/apps/backend/src/main/java/com/peekle/global/exception/ErrorCode.java
@@ -69,6 +69,14 @@ public enum ErrorCode {
     GAME_NOT_HOST(HttpStatus.FORBIDDEN, "GAME_010", "방장만 수행할 수 있는 작업입니다."),
     GAME_CANNOT_KICK_SELF(HttpStatus.BAD_REQUEST, "GAME_011", "자기 자신을 강퇴할 수 없습니다."),
 
+    // Translation
+    TRANSLATION_REQUEST_TOO_LARGE(HttpStatus.BAD_REQUEST, "TRANSLATION_001", "번역 요청이 너무 큽니다."),
+    TRANSLATION_API_KEY_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "TRANSLATION_002", "번역 API 키가 설정되어 있지 않습니다."),
+    TRANSLATION_PROVIDER_ERROR(HttpStatus.BAD_GATEWAY, "TRANSLATION_003", "번역 제공자 호출에 실패했습니다."),
+    TRANSLATION_INVALID_RESPONSE(HttpStatus.BAD_GATEWAY, "TRANSLATION_004", "번역 응답 형식이 올바르지 않습니다."),
+    TRANSLATION_DAILY_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "TRANSLATION_005", "일일 번역 가능 횟수를 모두 사용했습니다."),
+    TRANSLATION_HOURLY_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "TRANSLATION_006", "시간당 번역 가능 횟수를 모두 사용했습니다."),
+
     // CS
     CS_DOMAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "CS_001", "도메인을 찾을 수 없습니다."),
     CS_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "CS_002", "트랙을 찾을 수 없습니다."),

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -133,6 +133,18 @@ livekit:
   api-key: ${LIVEKIT_API_KEY:devkey}
   api-secret: ${LIVEKIT_API_SECRET:secret}
 
+gemini:
+  api-key: ${GEMINI_API_KEY:}
+  model: ${GEMINI_MODEL:gemini-2.5-flash-lite}
+
+leetcode:
+  translation:
+    daily-limit: ${LEETCODE_TRANSLATION_DAILY_LIMIT:10}
+    hourly-limit: ${LEETCODE_TRANSLATION_HOURLY_LIMIT:50}
+    max-batch-size: ${LEETCODE_TRANSLATION_MAX_BATCH_SIZE:20}
+    max-text-length: ${LEETCODE_TRANSLATION_MAX_TEXT_LENGTH:2000}
+    max-total-length: ${LEETCODE_TRANSLATION_MAX_TOTAL_LENGTH:12000}
+
 problem:
   sync:
     monthly:

--- a/apps/extension/content/leetcode-localizer.js
+++ b/apps/extension/content/leetcode-localizer.js
@@ -4,9 +4,38 @@
 
     const STORAGE_KEY = 'leetcodeKoreanEnabled';
     const STYLE_ID = 'peekle-leetcode-localizer-style';
+    const TRANSLATE_TOOLBAR_ID = 'peekle-problem-translation-toolbar';
+    const TRANSLATE_BUTTON_ID = 'peekle-problem-translate-button';
+    const TRANSLATION_STATUS_ID = 'peekle-problem-translation-status';
+    const ANALYSIS_TRANSLATE_TOOLBAR_ID = 'peekle-analysis-translation-toolbar';
+    const ANALYSIS_TRANSLATE_BUTTON_ID = 'peekle-analysis-translate-button';
+    const ANALYSIS_TRANSLATION_STATUS_ID = 'peekle-analysis-translation-status';
+    const DEFAULT_API_BASE_URL = 'https://peekle.today';
+    const PEEKLE_TOKEN_KEY = 'peekle_token';
+    const TRANSLATION_CACHE_KEY = 'peekle_leetcode_translation_cache_v1';
+    const TRANSLATION_BATCH_SIZE = 20;
+    const MAX_TRANSLATION_CACHE_ITEMS = 600;
     const originalTextByNode = new WeakMap();
     const originalAttributesByElement = new WeakMap();
+    const originalProblemHtmlByElement = new Map();
+    const originalProblemTextByNode = new Map();
     let enabled = false;
+    let problemTranslationActive = false;
+    let apiBaseUrlPromise = null;
+    let translationCachePromise = null;
+    let cachedProblemTranslationRunning = false;
+    let lastCachedProblemSignature = null;
+    let manuallyRestoredProblemKey = null;
+    let currentProblemKey = null;
+    const originalAnalysisTextByNode = new Map();
+    let analysisTranslationActive = false;
+    let analysisTranslationRunning = false;
+    let cachedAnalysisTranslationRunning = false;
+    let lastCachedAnalysisSignature = null;
+    let activeAnalysisSignature = null;
+    let manuallyRestoredAnalysisSignature = null;
+    let glossaryTranslationQueued = false;
+    let glossaryTranslationRunning = false;
 
     const TEXT_TRANSLATIONS = new Map([
         ['Problem List', '문제 목록'],
@@ -705,8 +734,1153 @@
             [data-peekle-strip-after]::after {
                 content: '' !important;
             }
+
+            #${TRANSLATE_TOOLBAR_ID} {
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+                gap: 8px;
+                margin: 8px 0 12px;
+            }
+
+            #${TRANSLATE_BUTTON_ID} {
+                appearance: none;
+                border: 1px solid rgba(229, 62, 148, 0.38);
+                border-radius: 6px;
+                background: #e24ea0;
+                color: #ffffff;
+                cursor: pointer;
+                font-size: 13px;
+                font-weight: 700;
+                line-height: 1;
+                padding: 9px 12px;
+                transition: background-color 120ms ease, opacity 120ms ease;
+            }
+
+            #${TRANSLATE_BUTTON_ID}:hover {
+                background: #cc3f8e;
+            }
+
+            #${TRANSLATE_BUTTON_ID}:disabled {
+                cursor: not-allowed;
+                opacity: 0.68;
+            }
+
+            #${TRANSLATION_STATUS_ID} {
+                color: #71717a;
+                font-size: 12px;
+                line-height: 1.4;
+            }
+
+            #${ANALYSIS_TRANSLATE_TOOLBAR_ID} {
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+                gap: 8px;
+                margin: 8px 0 10px;
+            }
+
+            #${ANALYSIS_TRANSLATE_BUTTON_ID} {
+                appearance: none;
+                border: 1px solid rgba(0, 122, 255, 0.32);
+                border-radius: 6px;
+                background: #2f7cf6;
+                color: #ffffff;
+                cursor: pointer;
+                font-size: 12px;
+                font-weight: 700;
+                line-height: 1;
+                padding: 8px 11px;
+                transition: background-color 120ms ease, opacity 120ms ease;
+            }
+
+            #${ANALYSIS_TRANSLATE_BUTTON_ID}:hover {
+                background: #2668d8;
+            }
+
+            #${ANALYSIS_TRANSLATE_BUTTON_ID}:disabled {
+                cursor: not-allowed;
+                opacity: 0.68;
+            }
+
+            #${ANALYSIS_TRANSLATION_STATUS_ID} {
+                color: #71717a;
+                font-size: 12px;
+                line-height: 1.4;
+            }
+
         `;
         document.documentElement.appendChild(style);
+    }
+
+    function isProblemPage() {
+        return /^\/problems\/[^/]+\/?/.test(window.location.pathname);
+    }
+
+    function getProblemKey() {
+        return window.location.pathname.match(/^\/problems\/([^/]+)/)?.[1] || '';
+    }
+
+    function syncCurrentProblemState() {
+        const nextProblemKey = getProblemKey();
+        if (currentProblemKey === nextProblemKey) return;
+
+        currentProblemKey = nextProblemKey;
+        problemTranslationActive = false;
+        cachedProblemTranslationRunning = false;
+        lastCachedProblemSignature = null;
+        manuallyRestoredProblemKey = null;
+        analysisTranslationActive = false;
+        analysisTranslationRunning = false;
+        cachedAnalysisTranslationRunning = false;
+        lastCachedAnalysisSignature = null;
+        activeAnalysisSignature = null;
+        manuallyRestoredAnalysisSignature = null;
+        originalProblemHtmlByElement.clear();
+        originalProblemTextByNode.clear();
+        originalAnalysisTextByNode.clear();
+    }
+
+    function findProblemDescription() {
+        if (!isProblemPage()) return null;
+
+        const selectors = [
+            '[data-track-load="description_content"]',
+            '[data-cy="question-content"]',
+            'div[class*="question-content"]',
+            'div[class*="description"]'
+        ];
+
+        for (const selector of selectors) {
+            const element = document.querySelector(selector);
+            if (element?.innerText?.trim().length > 40) {
+                return element;
+            }
+        }
+
+        return null;
+    }
+
+    function removeProblemTranslationUi() {
+        document.getElementById(TRANSLATE_TOOLBAR_ID)?.remove();
+    }
+
+    function removeAnalysisTranslationUi() {
+        document.getElementById(ANALYSIS_TRANSLATE_TOOLBAR_ID)?.remove();
+    }
+
+    function setTranslationStatus(message) {
+        const status = document.getElementById(TRANSLATION_STATUS_ID);
+        if (!status) return;
+        status.textContent = message || '';
+    }
+
+    function setTranslationButtonLoading(isLoading) {
+        const button = document.getElementById(TRANSLATE_BUTTON_ID);
+        if (!button) return;
+
+        button.disabled = isLoading;
+        button.textContent = isLoading
+            ? '번역 중...'
+            : problemTranslationActive
+                ? '원문 보기'
+                : '문제 번역';
+    }
+
+    function syncTranslationButtonText() {
+        setTranslationButtonLoading(false);
+    }
+
+    function setAnalysisTranslationStatus(message) {
+        const status = document.getElementById(ANALYSIS_TRANSLATION_STATUS_ID);
+        if (!status) return;
+        status.textContent = message || '';
+    }
+
+    function setAnalysisTranslationButtonLoading(isLoading) {
+        const button = document.getElementById(ANALYSIS_TRANSLATE_BUTTON_ID);
+        if (!button) return;
+
+        button.disabled = isLoading;
+        button.textContent = isLoading
+            ? '번역 중...'
+            : analysisTranslationActive
+                ? 'AI 분석 원문 보기'
+                : 'AI 분석 번역';
+    }
+
+    function syncAnalysisTranslationButtonText() {
+        setAnalysisTranslationButtonLoading(false);
+    }
+
+    function rememberProblemElement(element) {
+        if (!originalProblemHtmlByElement.has(element)) {
+            originalProblemHtmlByElement.set(element, element.innerHTML);
+        }
+    }
+
+    function rememberTextNode(node) {
+        if (!originalProblemTextByNode.has(node)) {
+            originalProblemTextByNode.set(node, node.nodeValue);
+        }
+    }
+
+    function restoreProblemTranslations(root) {
+        for (const [node, text] of Array.from(originalProblemTextByNode.entries())) {
+            if (!node.isConnected) {
+                originalProblemTextByNode.delete(node);
+                continue;
+            }
+
+            if (root && root !== document.body && !root.contains(node)) continue;
+
+            node.nodeValue = text;
+            originalProblemTextByNode.delete(node);
+        }
+
+        for (const [element, html] of Array.from(originalProblemHtmlByElement.entries())) {
+            if (!element.isConnected) {
+                originalProblemHtmlByElement.delete(element);
+                continue;
+            }
+
+            if (root && root !== document.body && !root.contains(element)) continue;
+
+            element.innerHTML = html;
+            element.removeAttribute('data-peekle-ai-translated');
+            originalProblemHtmlByElement.delete(element);
+        }
+    }
+
+    function rememberAnalysisTextNode(node) {
+        if (!originalAnalysisTextByNode.has(node)) {
+            originalAnalysisTextByNode.set(node, node.nodeValue);
+        }
+    }
+
+    function getAnalysisTextNodeSourceText(node) {
+        return originalAnalysisTextByNode.get(node) || originalTextByNode.get(node) || node.nodeValue || '';
+    }
+
+    function restoreAnalysisTranslations(root) {
+        for (const [node, text] of Array.from(originalAnalysisTextByNode.entries())) {
+            if (!node.isConnected) {
+                originalAnalysisTextByNode.delete(node);
+                continue;
+            }
+
+            if (root && root !== document.body && !root.contains(node)) continue;
+
+            node.nodeValue = text;
+            originalAnalysisTextByNode.delete(node);
+        }
+    }
+
+    function restoreOriginalTextInClone(source, clone) {
+        const sourceWalker = document.createTreeWalker(source, NodeFilter.SHOW_TEXT);
+        const cloneWalker = document.createTreeWalker(clone, NodeFilter.SHOW_TEXT);
+
+        while (sourceWalker.nextNode() && cloneWalker.nextNode()) {
+            const original = originalTextByNode.get(sourceWalker.currentNode);
+            if (original !== undefined) {
+                cloneWalker.currentNode.nodeValue = original;
+            }
+        }
+    }
+
+    function getElementSourceText(element) {
+        const originalHtml = originalProblemHtmlByElement.get(element);
+        const clone = element.cloneNode(false);
+
+        if (originalHtml !== undefined) {
+            clone.innerHTML = originalHtml;
+        } else {
+            const deepClone = element.cloneNode(true);
+            restoreOriginalTextInClone(element, deepClone);
+            return (deepClone.innerText || deepClone.textContent || '')
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+        }
+
+        return (clone.innerText || clone.textContent || '').replace(/\n{3,}/g, '\n\n').trim();
+    }
+
+    function getTextNodeSourceText(node) {
+        return originalProblemTextByNode.get(node) || originalTextByNode.get(node) || node.nodeValue || '';
+    }
+
+    function hasTranslatableEnglish(text) {
+        return /[A-Za-z]{2}/.test(text);
+    }
+
+    function isExampleHeading(text) {
+        return /^Example\s+\d+:$/i.test(text.trim());
+    }
+
+    function isSectionOnlyHeading(text) {
+        return /^(Constraints|Follow[-\s]?up):$/i.test(text.trim());
+    }
+
+    function isMostlyCodeLike(text) {
+        const compact = text.replace(/\s+/g, '');
+        if (!compact) return true;
+
+        const letters = (compact.match(/[A-Za-z]/g) || []).length;
+        return letters / compact.length < 0.25;
+    }
+
+    function shouldTranslateProblemBlock(element) {
+        if (element.closest('pre, code')) return false;
+
+        const text = getElementSourceText(element).replace(/\s+/g, ' ').trim();
+        if (!text || !hasTranslatableEnglish(text)) return false;
+        if (isExampleHeading(text) || isSectionOnlyHeading(text)) return false;
+        if (isMostlyCodeLike(text)) return false;
+
+        return true;
+    }
+
+    function shouldTranslateGlossaryBlock(element) {
+        if (element.dataset.peekleAiTranslated === 'true') return false;
+        if (element.closest('pre, code')) return false;
+
+        const text = getElementSourceText(element).replace(/\s+/g, ' ').trim();
+        if (!text || !hasTranslatableEnglish(text)) return false;
+        if (isMostlyCodeLike(text)) return false;
+
+        return true;
+    }
+
+    function shouldPreserveInlineElement(element) {
+        if (element.tagName === 'CODE' || element.tagName === 'BUTTON') return true;
+        if (element.matches('[class*="cursor-pointer"]')) return true;
+        return Boolean(element.querySelector('button'));
+    }
+
+    function buildRichTranslationSource(element) {
+        const preserved = [];
+
+        function walk(node) {
+            if (node.nodeType === Node.TEXT_NODE) {
+                return getTextNodeSourceText(node);
+            }
+
+            if (node.nodeType !== Node.ELEMENT_NODE) return '';
+
+            if (shouldPreserveInlineElement(node)) {
+                const token = `§${preserved.length}§`;
+                preserved.push({ token, node });
+                return token;
+            }
+
+            return Array.from(node.childNodes).map(walk).join('');
+        }
+
+        return {
+            preserved,
+            sourceText: Array.from(element.childNodes).map(walk).join('').replace(/\s+/g, ' ').trim()
+        };
+    }
+
+    function renderRichTranslation(element, translatedText, preserved) {
+        const tokenPattern = /§\s*(\d+)\s*§|\[\[\s*(\d+)\s*\]\]|__\s*peekle\s*[_\s-]*(\d+)\s*__/gi;
+        const preservedByIndex = new Map(preserved.map((item, index) => [String(index), item.node]));
+        const usedTokenIndexes = new Set();
+        const insertedTokenCounts = new Map();
+        const parts = [];
+        let lastIndex = 0;
+        let match;
+
+        while ((match = tokenPattern.exec(translatedText)) !== null) {
+            if (match.index > lastIndex) {
+                parts.push(document.createTextNode(translatedText.slice(lastIndex, match.index)));
+            }
+
+            const tokenIndex = match[1] || match[2] || match[3];
+            const preservedNode = preservedByIndex.get(tokenIndex);
+            if (preservedNode) {
+                usedTokenIndexes.add(tokenIndex);
+                const insertCount = insertedTokenCounts.get(tokenIndex) || 0;
+                insertedTokenCounts.set(tokenIndex, insertCount + 1);
+                parts.push(insertCount === 0 ? preservedNode : preservedNode.cloneNode(true));
+            }
+
+            lastIndex = match.index + match[0].length;
+        }
+
+        if (lastIndex < translatedText.length) {
+            parts.push(document.createTextNode(translatedText.slice(lastIndex)));
+        }
+
+        if (preserved.length > 0 && usedTokenIndexes.size === 0) {
+            element.textContent = translatedText.trim();
+            return;
+        }
+
+        element.replaceChildren(...parts);
+    }
+
+    function applyElementTranslation(element, translatedText) {
+        rememberProblemElement(element);
+        element.textContent = translatedText.trim();
+        element.dataset.peekleAiTranslated = 'true';
+    }
+
+    function applyTextNodeTranslation(node, translatedText) {
+        const original = getTextNodeSourceText(node);
+        const leading = original.match(/^\s*/)?.[0] || '';
+        const trailing = original.match(/\s*$/)?.[0] || '';
+
+        rememberTextNode(node);
+        node.nodeValue = `${leading}${translatedText.trim()}${trailing}`;
+    }
+
+    function createBlockTranslationTarget(element) {
+        const richSource = buildRichTranslationSource(element);
+
+        return {
+            getSourceText() {
+                return richSource.sourceText || getElementSourceText(element);
+            },
+            apply(translatedText) {
+                if (richSource.preserved.length > 0) {
+                    rememberProblemElement(element);
+                    renderRichTranslation(element, translatedText.trim(), richSource.preserved);
+                    element.dataset.peekleAiTranslated = 'true';
+                    return;
+                }
+
+                applyElementTranslation(element, translatedText);
+            }
+        };
+    }
+
+    function createTextNodeTranslationTarget(node) {
+        return {
+            getSourceText() {
+                return getTextNodeSourceText(node).trim();
+            },
+            apply(translatedText) {
+                applyTextNodeTranslation(node, translatedText);
+            }
+        };
+    }
+
+    function isStrongLabel(node, label) {
+        if (node?.nodeType !== Node.ELEMENT_NODE || node.tagName !== 'STRONG') {
+            return false;
+        }
+
+        const normalized = node.textContent.trim().replace(/\s+/g, ' ').toLowerCase();
+        if (normalized === `${label}:`) return true;
+
+        return label === 'explanation' && normalized === '설명:';
+    }
+
+    function createExplanationTranslationTarget(pre, labelNode, textNodes) {
+        return {
+            getSourceText() {
+                return textNodes.map(getTextNodeSourceText).join('').trim();
+            },
+            apply(translatedText) {
+                rememberProblemElement(pre);
+                textNodes.forEach(rememberTextNode);
+                labelNode.textContent = '설명:';
+
+                const [firstNode, ...restNodes] = textNodes;
+                if (!firstNode) return;
+
+                const original = getTextNodeSourceText(firstNode);
+                const leading = original.match(/^\s*/)?.[0] || ' ';
+                const lastOriginal = getTextNodeSourceText(textNodes[textNodes.length - 1]);
+                const trailing = lastOriginal.match(/\s*$/)?.[0] || '\n';
+
+                firstNode.nodeValue = `${leading}${translatedText.trim()}${trailing}`;
+                restNodes.forEach((node) => {
+                    node.nodeValue = '';
+                });
+            }
+        };
+    }
+
+    function createPlainPreExplanationTarget(pre) {
+        const sourceText = getElementSourceText(pre);
+        const lines = sourceText.split('\n');
+        const explanationLineIndex = lines.findIndex((line) => /^\s*Explanation:\s*/i.test(line));
+
+        if (explanationLineIndex === -1) return null;
+
+        const explanationText = lines[explanationLineIndex].replace(/^\s*Explanation:\s*/i, '').trim();
+        if (!explanationText) return null;
+
+        return {
+            getSourceText() {
+                return explanationText;
+            },
+            apply(translatedText) {
+                rememberProblemElement(pre);
+                lines[explanationLineIndex] = lines[explanationLineIndex]
+                    .replace(/^\s*Explanation:\s*/i, '설명: ')
+                    .replace(explanationText, translatedText.trim());
+                pre.textContent = lines.join('\n');
+            }
+        };
+    }
+
+    function collectPreExplanationTargets(content) {
+        const targets = [];
+
+        content.querySelectorAll('pre').forEach((pre) => {
+            const childNodes = Array.from(pre.childNodes);
+            let matched = false;
+
+            childNodes.forEach((node, index) => {
+                if (!isStrongLabel(node, 'explanation')) return;
+
+                const textNodes = [];
+                for (let i = index + 1; i < childNodes.length; i += 1) {
+                    const nextNode = childNodes[i];
+                    if (nextNode.nodeType === Node.ELEMENT_NODE && nextNode.tagName === 'STRONG') {
+                        break;
+                    }
+                    if (nextNode.nodeType === Node.TEXT_NODE) {
+                        textNodes.push(nextNode);
+                    }
+                }
+
+                const sourceText = textNodes.map(getTextNodeSourceText).join('').trim();
+                if (!sourceText || !hasTranslatableEnglish(sourceText)) return;
+
+                matched = true;
+                targets.push(createExplanationTranslationTarget(pre, node, textNodes));
+            });
+
+            if (!matched) {
+                const fallbackTarget = createPlainPreExplanationTarget(pre);
+                if (fallbackTarget) {
+                    targets.push(fallbackTarget);
+                }
+            }
+        });
+
+        return targets;
+    }
+
+    function collectProblemTranslationTargets(content) {
+        const targets = [];
+
+        content.querySelectorAll('p, li').forEach((element) => {
+            if (shouldTranslateProblemBlock(element)) {
+                targets.push(createBlockTranslationTarget(element));
+            }
+        });
+
+        Array.from(content.childNodes).forEach((node) => {
+            if (node.nodeType !== Node.TEXT_NODE) return;
+
+            const text = getTextNodeSourceText(node).trim();
+            if (!text || !hasTranslatableEnglish(text) || isMostlyCodeLike(text)) return;
+
+            targets.push(createTextNodeTranslationTarget(node));
+        });
+
+        targets.push(...collectPreExplanationTargets(content));
+        return targets.filter((target) => target.getSourceText());
+    }
+
+    function findAnalysisSections() {
+        return [
+            document.getElementById('analysis-approach-content'),
+            document.getElementById('analysis-efficiency-content'),
+            document.getElementById('analysis-code-style-content')
+        ].filter(Boolean);
+    }
+
+    function findAnalysisToolbarAnchor(sections) {
+        const firstSection = sections[0];
+        if (!firstSection) return null;
+
+        return firstSection.closest('.grid') || firstSection;
+    }
+
+    function shouldTranslateAnalysisTextNode(node) {
+        const text = getAnalysisTextNodeSourceText(node).replace(/\s+/g, ' ').trim();
+        if (!text || !hasTranslatableEnglish(text) || isMostlyCodeLike(text)) return false;
+
+        const parent = node.parentElement;
+        if (!parent || shouldSkipTextElement(parent)) return false;
+        if (parent.closest(`#${ANALYSIS_TRANSLATE_TOOLBAR_ID}`)) return false;
+        if (parent.closest('a, button, svg, math, .katex, [data-highcharts-chart], .highcharts-container')) return false;
+        if (parent.closest('[translate="no"], [class*="language-"], [class*="linenumber"]')) return false;
+
+        return true;
+    }
+
+    function createAnalysisTextNodeTranslationTarget(node) {
+        return {
+            getSourceText() {
+                return getAnalysisTextNodeSourceText(node).trim();
+            },
+            apply(translatedText) {
+                const original = getAnalysisTextNodeSourceText(node);
+                const leading = original.match(/^\s*/)?.[0] || '';
+                const trailing = original.match(/\s*$/)?.[0] || '';
+
+                rememberAnalysisTextNode(node);
+                node.nodeValue = `${leading}${translatedText.trim()}${trailing}`;
+            }
+        };
+    }
+
+    function collectAnalysisTranslationTargets(sections) {
+        const targets = [];
+        const seenNodes = new Set();
+
+        sections.forEach((section) => {
+            const walker = document.createTreeWalker(section, NodeFilter.SHOW_TEXT, {
+                acceptNode(node) {
+                    return shouldTranslateAnalysisTextNode(node)
+                        ? NodeFilter.FILTER_ACCEPT
+                        : NodeFilter.FILTER_REJECT;
+                }
+            });
+
+            while (walker.nextNode()) {
+                const node = walker.currentNode;
+                if (seenNodes.has(node)) continue;
+
+                seenNodes.add(node);
+                targets.push(createAnalysisTextNodeTranslationTarget(node));
+            }
+        });
+
+        return targets.filter((target) => target.getSourceText());
+    }
+
+    function isGlossaryPopover(dialog) {
+        if (!dialog.closest('[data-radix-popper-content-wrapper]')) return false;
+        return Boolean(dialog.querySelector('[class*="markdown-content"]'));
+    }
+
+    function collectGlossaryTranslationTargets(dialog) {
+        const targets = [];
+        const markdown = dialog.querySelector('[class*="markdown-content"]');
+        if (!markdown) return targets;
+
+        const title = markdown.parentElement?.previousElementSibling;
+        if (title && shouldTranslateGlossaryBlock(title)) {
+            targets.push(createBlockTranslationTarget(title));
+        }
+
+        markdown.querySelectorAll('p, li').forEach((element) => {
+            if (shouldTranslateGlossaryBlock(element)) {
+                targets.push(createBlockTranslationTarget(element));
+            }
+        });
+
+        return targets.filter((target) => target.getSourceText());
+    }
+
+    async function translateGlossaryPopovers() {
+        if (!enabled || !problemTranslationActive || glossaryTranslationRunning) return;
+
+        const dialogs = Array.from(document.querySelectorAll('[data-radix-popper-content-wrapper] [role="dialog"]'))
+            .filter(isGlossaryPopover);
+        if (dialogs.length === 0) return;
+
+        const targets = dialogs.flatMap(collectGlossaryTranslationTargets);
+        if (targets.length === 0) return;
+
+        glossaryTranslationRunning = true;
+
+        try {
+            const translatedTexts = await translateTextsWithBackend(targets.map((target) => target.getSourceText()));
+            for (let index = 0; index < targets.length; index += 1) {
+                targets[index].apply(translatedTexts[index]);
+            }
+        } catch (error) {
+            console.warn('[Peekle LeetCode] Glossary translation failed.', error);
+        } finally {
+            glossaryTranslationRunning = false;
+        }
+    }
+
+    function scheduleGlossaryTranslation() {
+        if (!enabled || !problemTranslationActive || glossaryTranslationQueued) return;
+
+        glossaryTranslationQueued = true;
+        window.setTimeout(() => {
+            glossaryTranslationQueued = false;
+            translateGlossaryPopovers();
+        }, 50);
+    }
+
+    function sendRuntimeMessage(message) {
+        return new Promise((resolve) => {
+            if (!globalThis.chrome?.runtime?.sendMessage) {
+                resolve(null);
+                return;
+            }
+
+            try {
+                chrome.runtime.sendMessage(message, (response) => {
+                    if (chrome.runtime.lastError) {
+                        resolve(null);
+                        return;
+                    }
+                    resolve(response || null);
+                });
+            } catch (error) {
+                resolve(null);
+            }
+        });
+    }
+
+    function readStorage(keys) {
+        return new Promise((resolve) => {
+            if (!globalThis.chrome?.storage?.local) {
+                resolve({});
+                return;
+            }
+
+            try {
+                chrome.storage.local.get(keys, (result) => {
+                    resolve(result || {});
+                });
+            } catch (error) {
+                resolve({});
+            }
+        });
+    }
+
+    function writeStorage(items) {
+        return new Promise((resolve) => {
+            if (!globalThis.chrome?.storage?.local?.set) {
+                resolve();
+                return;
+            }
+
+            try {
+                chrome.storage.local.set(items, () => {
+                    resolve();
+                });
+            } catch (error) {
+                resolve();
+            }
+        });
+    }
+
+    async function readTranslationCache() {
+        if (!translationCachePromise) {
+            translationCachePromise = readStorage([TRANSLATION_CACHE_KEY]).then((storage) => {
+                const cache = storage[TRANSLATION_CACHE_KEY];
+                if (cache?.texts && typeof cache.texts === 'object') {
+                    return cache;
+                }
+                return { texts: {} };
+            });
+        }
+
+        return translationCachePromise;
+    }
+
+    function pruneTranslationCache(cache) {
+        const entries = Object.entries(cache.texts || {});
+        if (entries.length <= MAX_TRANSLATION_CACHE_ITEMS) return;
+
+        entries
+            .sort(([, left], [, right]) => (right.updatedAt || 0) - (left.updatedAt || 0))
+            .slice(MAX_TRANSLATION_CACHE_ITEMS)
+            .forEach(([sourceText]) => {
+                delete cache.texts[sourceText];
+            });
+    }
+
+    async function saveTranslationCache(sourceTexts, translatedTexts) {
+        const cache = await readTranslationCache();
+        const now = Date.now();
+
+        sourceTexts.forEach((sourceText, index) => {
+            const translatedText = translatedTexts[index];
+            if (!sourceText || !translatedText) return;
+
+            cache.texts[sourceText] = {
+                translatedText,
+                updatedAt: now
+            };
+        });
+
+        pruneTranslationCache(cache);
+        translationCachePromise = Promise.resolve(cache);
+        await writeStorage({ [TRANSLATION_CACHE_KEY]: cache });
+    }
+
+    async function getCachedTranslations(sourceTexts) {
+        const cache = await readTranslationCache();
+        const translations = sourceTexts.map((sourceText) => {
+            const entry = cache.texts?.[sourceText];
+            return typeof entry?.translatedText === 'string' ? entry.translatedText : null;
+        });
+
+        return translations.every(Boolean) ? translations : null;
+    }
+
+    async function getApiBaseUrl() {
+        if (!apiBaseUrlPromise) {
+            apiBaseUrlPromise = sendRuntimeMessage({ type: 'CHECK_ENV' })
+                .then((response) => response?.apiUrl || DEFAULT_API_BASE_URL)
+                .catch(() => DEFAULT_API_BASE_URL);
+        }
+
+        return apiBaseUrlPromise;
+    }
+
+    async function getPeekleToken() {
+        const response = await sendRuntimeMessage({ type: 'GET_TOKEN' });
+        if (response?.token) return response.token;
+
+        const storage = await readStorage([PEEKLE_TOKEN_KEY]);
+        return storage[PEEKLE_TOKEN_KEY] || null;
+    }
+
+    async function requestTranslationChunk(texts) {
+        const [apiBaseUrl, token] = await Promise.all([getApiBaseUrl(), getPeekleToken()]);
+
+        if (!token) {
+            throw new Error('Peekle 로그인 후 번역을 사용할 수 있습니다.');
+        }
+
+        const response = await fetch(`${apiBaseUrl}/api/leetcode/translate`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Peekle-Token': token
+            },
+            body: JSON.stringify({ texts })
+        });
+
+        let payload = null;
+        try {
+            payload = await response.json();
+        } catch (error) {
+            // Keep the user-facing error below stable when the server returns non-JSON.
+        }
+
+        if (!response.ok || payload?.success !== true) {
+            throw new Error(payload?.error?.message || '문제 번역 요청에 실패했습니다.');
+        }
+
+        const translations = payload?.data?.translations;
+        if (!Array.isArray(translations) || translations.length !== texts.length) {
+            throw new Error('번역 응답 형식이 올바르지 않습니다.');
+        }
+
+        return translations;
+    }
+
+    async function translateTextsWithBackend(texts) {
+        const cache = await readTranslationCache();
+        const translatedTexts = new Array(texts.length);
+        const missingTexts = [];
+        const missingIndexes = [];
+
+        texts.forEach((text, index) => {
+            const cachedText = cache.texts?.[text]?.translatedText;
+            if (typeof cachedText === 'string') {
+                translatedTexts[index] = cachedText;
+                return;
+            }
+
+            missingTexts.push(text);
+            missingIndexes.push(index);
+        });
+
+        if (missingTexts.length === 0) {
+            return translatedTexts;
+        }
+
+        const translatedMissingTexts = [];
+        for (let index = 0; index < missingTexts.length; index += TRANSLATION_BATCH_SIZE) {
+            const chunk = missingTexts.slice(index, index + TRANSLATION_BATCH_SIZE);
+            const translatedChunk = await requestTranslationChunk(chunk);
+
+            translatedChunk.forEach((translatedText, chunkIndex) => {
+                translatedTexts[missingIndexes[index + chunkIndex]] = translatedText;
+            });
+            translatedMissingTexts.push(...translatedChunk);
+        }
+
+        await saveTranslationCache(missingTexts, translatedMissingTexts);
+        return translatedTexts;
+    }
+
+    function createProblemTranslationSignature(sourceTexts) {
+        return `${getProblemKey()}::${sourceTexts.join('\u001f')}`;
+    }
+
+    function applyProblemTranslationTargets(targets, translatedTexts, onProgress) {
+        for (let index = 0; index < targets.length; index += 1) {
+            onProgress?.(`번역 중 ${index + 1}/${targets.length}`);
+            targets[index].apply(translatedTexts[index]);
+        }
+    }
+
+    async function applyCachedProblemTranslation(content) {
+        if (!enabled || problemTranslationActive || cachedProblemTranslationRunning) return;
+        if (manuallyRestoredProblemKey === getProblemKey()) return;
+
+        const targets = collectProblemTranslationTargets(content);
+        if (targets.length === 0) return;
+
+        const sourceTexts = targets.map((target) => target.getSourceText());
+        const signature = createProblemTranslationSignature(sourceTexts);
+        if (lastCachedProblemSignature === signature) return;
+
+        lastCachedProblemSignature = signature;
+        cachedProblemTranslationRunning = true;
+
+        try {
+            const cachedTranslations = await getCachedTranslations(sourceTexts);
+            if (!cachedTranslations || problemTranslationActive || manuallyRestoredProblemKey === getProblemKey()) {
+                return;
+            }
+
+            applyProblemTranslationTargets(targets, cachedTranslations);
+            problemTranslationActive = true;
+            scheduleGlossaryTranslation();
+            setTranslationStatus('로컬 캐시 적용');
+            syncTranslationButtonText();
+        } catch (error) {
+            console.warn('[Peekle LeetCode] Cached problem translation failed.', error);
+        } finally {
+            cachedProblemTranslationRunning = false;
+        }
+    }
+
+    function scheduleCachedProblemTranslation(content) {
+        if (!enabled || problemTranslationActive || cachedProblemTranslationRunning) return;
+        window.setTimeout(() => applyCachedProblemTranslation(content), 0);
+    }
+
+    function createAnalysisTranslationSignature(sourceTexts) {
+        return `${getProblemKey()}::analysis::${sourceTexts.join('\u001f')}`;
+    }
+
+    function applyAnalysisTranslationTargets(targets, translatedTexts, onProgress) {
+        for (let index = 0; index < targets.length; index += 1) {
+            onProgress?.(`AI 분석 번역 중 ${index + 1}/${targets.length}`);
+            targets[index].apply(translatedTexts[index]);
+        }
+    }
+
+    async function applyCachedAnalysisTranslation(sections) {
+        if (!enabled || analysisTranslationActive || cachedAnalysisTranslationRunning) return;
+
+        const targets = collectAnalysisTranslationTargets(sections);
+        if (targets.length === 0) return;
+
+        const sourceTexts = targets.map((target) => target.getSourceText());
+        const signature = createAnalysisTranslationSignature(sourceTexts);
+        if (lastCachedAnalysisSignature === signature || manuallyRestoredAnalysisSignature === signature) return;
+
+        lastCachedAnalysisSignature = signature;
+        cachedAnalysisTranslationRunning = true;
+
+        try {
+            const cachedTranslations = await getCachedTranslations(sourceTexts);
+            if (!cachedTranslations || analysisTranslationActive || manuallyRestoredAnalysisSignature === signature) {
+                return;
+            }
+
+            applyAnalysisTranslationTargets(targets, cachedTranslations);
+            analysisTranslationActive = true;
+            activeAnalysisSignature = signature;
+            setAnalysisTranslationStatus('로컬 캐시 적용');
+            syncAnalysisTranslationButtonText();
+        } catch (error) {
+            console.warn('[Peekle LeetCode] Cached AI analysis translation failed.', error);
+        } finally {
+            cachedAnalysisTranslationRunning = false;
+        }
+    }
+
+    function scheduleCachedAnalysisTranslation(sections) {
+        if (!enabled || analysisTranslationActive || cachedAnalysisTranslationRunning) return;
+        window.setTimeout(() => applyCachedAnalysisTranslation(sections), 0);
+    }
+
+    async function translateAnalysisSections(sections) {
+        if (analysisTranslationRunning) return;
+
+        if (analysisTranslationActive) {
+            restoreAnalysisTranslations(document.body);
+            manuallyRestoredAnalysisSignature = activeAnalysisSignature;
+            analysisTranslationActive = false;
+            activeAnalysisSignature = null;
+            setAnalysisTranslationStatus('원문 표시');
+            syncAnalysisTranslationButtonText();
+            return;
+        }
+
+        const targets = collectAnalysisTranslationTargets(sections);
+        if (targets.length === 0) {
+            setAnalysisTranslationStatus('번역할 AI 분석 문장을 찾지 못했습니다.');
+            syncAnalysisTranslationButtonText();
+            return;
+        }
+
+        analysisTranslationRunning = true;
+        setAnalysisTranslationButtonLoading(true);
+        setAnalysisTranslationStatus('AI 분석을 번역하는 중입니다.');
+
+        try {
+            const sourceTexts = targets.map((target) => target.getSourceText());
+            const translatedTexts = await translateTextsWithBackend(sourceTexts);
+            const signature = createAnalysisTranslationSignature(sourceTexts);
+
+            applyAnalysisTranslationTargets(targets, translatedTexts, setAnalysisTranslationStatus);
+            analysisTranslationActive = true;
+            activeAnalysisSignature = signature;
+            manuallyRestoredAnalysisSignature = null;
+            setAnalysisTranslationStatus('AI 분석 번역 완료');
+            syncAnalysisTranslationButtonText();
+        } catch (error) {
+            setAnalysisTranslationStatus(error?.message || 'AI 분석 번역 중 오류가 발생했습니다.');
+        } finally {
+            analysisTranslationRunning = false;
+            setAnalysisTranslationButtonLoading(false);
+        }
+    }
+
+    async function translateProblemDescription(content) {
+        if (problemTranslationActive) {
+            restoreProblemTranslations(document.body);
+            problemTranslationActive = false;
+            manuallyRestoredProblemKey = getProblemKey();
+            setTranslationStatus('원문 표시');
+            syncTranslationButtonText();
+            return;
+        }
+
+        const targets = collectProblemTranslationTargets(content);
+
+        if (targets.length === 0) {
+            setTranslationStatus('번역할 문제 설명을 찾지 못했습니다.');
+            syncTranslationButtonText();
+            return;
+        }
+
+        setTranslationButtonLoading(true);
+        setTranslationStatus('문제 설명을 번역하는 중입니다.');
+
+        try {
+            manuallyRestoredProblemKey = null;
+            const sourceTexts = targets.map((target) => target.getSourceText());
+            const translatedTexts = await translateTextsWithBackend(sourceTexts);
+
+            applyProblemTranslationTargets(targets, translatedTexts, setTranslationStatus);
+            problemTranslationActive = true;
+            scheduleGlossaryTranslation();
+            setTranslationStatus('번역 완료');
+            syncTranslationButtonText();
+        } catch (error) {
+            setTranslationStatus(error?.message || '번역 중 오류가 발생했습니다.');
+        } finally {
+            setTranslationButtonLoading(false);
+        }
+    }
+
+    function syncProblemTranslatorControls() {
+        if (!enabled || !isProblemPage()) {
+            removeProblemTranslationUi();
+            currentProblemKey = null;
+            problemTranslationActive = false;
+            return;
+        }
+
+        syncCurrentProblemState();
+
+        const content = findProblemDescription();
+        if (!content) return;
+
+        ensureStyle();
+
+        let toolbar = document.getElementById(TRANSLATE_TOOLBAR_ID);
+        if (!toolbar) {
+            toolbar = document.createElement('div');
+            toolbar.id = TRANSLATE_TOOLBAR_ID;
+
+            const status = document.createElement('span');
+            status.id = TRANSLATION_STATUS_ID;
+            status.textContent = '';
+
+            const button = document.createElement('button');
+            button.id = TRANSLATE_BUTTON_ID;
+            button.type = 'button';
+            button.textContent = problemTranslationActive ? '원문 보기' : '문제 번역';
+            button.addEventListener('click', () => {
+                const currentContent = findProblemDescription();
+                if (currentContent) {
+                    translateProblemDescription(currentContent);
+                }
+            });
+
+            toolbar.append(status, button);
+        }
+
+        if (toolbar.nextElementSibling !== content) {
+            content.insertAdjacentElement('beforebegin', toolbar);
+        }
+        syncTranslationButtonText();
+        scheduleCachedProblemTranslation(content);
+    }
+
+    function syncAnalysisTranslatorControls() {
+        if (!enabled || !isProblemPage()) {
+            removeAnalysisTranslationUi();
+            analysisTranslationActive = false;
+            return;
+        }
+
+        const sections = findAnalysisSections();
+        const anchor = findAnalysisToolbarAnchor(sections);
+        if (!anchor) {
+            removeAnalysisTranslationUi();
+            analysisTranslationActive = false;
+            return;
+        }
+
+        ensureStyle();
+
+        let toolbar = document.getElementById(ANALYSIS_TRANSLATE_TOOLBAR_ID);
+        if (!toolbar) {
+            toolbar = document.createElement('div');
+            toolbar.id = ANALYSIS_TRANSLATE_TOOLBAR_ID;
+
+            const status = document.createElement('span');
+            status.id = ANALYSIS_TRANSLATION_STATUS_ID;
+            status.textContent = '';
+
+            const button = document.createElement('button');
+            button.id = ANALYSIS_TRANSLATE_BUTTON_ID;
+            button.type = 'button';
+            button.textContent = analysisTranslationActive ? 'AI 분석 원문 보기' : 'AI 분석 번역';
+            button.addEventListener('click', () => {
+                const currentSections = findAnalysisSections();
+                if (currentSections.length > 0) {
+                    translateAnalysisSections(currentSections);
+                }
+            });
+
+            toolbar.append(status, button);
+        }
+
+        if (toolbar.nextElementSibling !== anchor) {
+            anchor.insertAdjacentElement('beforebegin', toolbar);
+        }
+
+        syncAnalysisTranslationButtonText();
+        scheduleCachedAnalysisTranslation(sections);
     }
 
     function translateValue(value) {
@@ -845,6 +2019,8 @@
         window.requestAnimationFrame(() => {
             queued = false;
             localize(document.body);
+            syncProblemTranslatorControls();
+            syncAnalysisTranslatorControls();
         });
     }
 
@@ -856,6 +2032,9 @@
 
     function restoreOriginals(root) {
         if (!root) return;
+
+        restoreProblemTranslations(root);
+        restoreAnalysisTranslations(root);
 
         const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
         while (walker.nextNode()) {
@@ -893,8 +2072,14 @@
         if (enabled) {
             ensureStyle();
             scheduleLocalize();
+            syncProblemTranslatorControls();
+            syncAnalysisTranslatorControls();
         } else {
+            problemTranslationActive = false;
+            analysisTranslationActive = false;
             restoreOriginals(document.body);
+            removeProblemTranslationUi();
+            removeAnalysisTranslationUi();
         }
     }
 
@@ -927,6 +2112,7 @@
 
             if (mutation.addedNodes.length > 0) {
                 shouldRun = true;
+                scheduleGlossaryTranslation();
             }
         }
 

--- a/apps/extension/playwright.config.ts
+++ b/apps/extension/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  reporter: "list",
+  timeout: 30000,
+  use: {
+    ...devices["Desktop Chrome"],
+    trace: "on-first-retry",
+  },
+});

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -56,7 +56,7 @@
         <label class="toggle-row" for="leetcode-korean-toggle">
             <span>
                 <span class="toggle-title">LeetCode 한글화</span>
-                <span class="toggle-description">문제 화면의 UI 요소를 한글로 바꿉니다.</span>
+                <span class="toggle-description">문제 화면 한글화와 문제 번역 버튼을 켭니다.</span>
             </span>
             <input id="leetcode-korean-toggle" type="checkbox" />
             <span class="toggle-switch" aria-hidden="true"></span>

--- a/apps/extension/tests/leetcode-translator.spec.ts
+++ b/apps/extension/tests/leetcode-translator.spec.ts
@@ -1,0 +1,631 @@
+import { expect, test } from "@playwright/test";
+import path from "node:path";
+
+const localizerPath = path.resolve(
+  __dirname,
+  "../content/leetcode-localizer.js",
+);
+const problemUrl = "https://leetcode.com/problems/palindrome-number/";
+const apiUrl = "https://peekle.test/api/leetcode/translate";
+const translationCacheKey = "peekle_leetcode_translation_cache_v1";
+const problemHtml = `
+  <!doctype html>
+  <html>
+    <head><title>Palindrome Number - LeetCode</title></head>
+    <body>
+      <nav id="outside-nav">This navigation must stay English.</nav>
+      <aside id="outside-panel">This sidebar must stay English.</aside>
+      <main>
+        <section data-track-load="description_content">
+          <h1>9. Palindrome Number</h1>
+          <p>Given an integer <code>x</code>, return <code>true</code> if <code>x</code> is a <span class="cursor-pointer"><button type="button">palindrome</button></span>, and <code>false</code> otherwise.</p>
+          <p>Example 1:</p>
+          <pre>Input: x = 121
+Output: true
+Explanation: 121 reads as 121 from left to right and from right to left.</pre>
+          <p>Constraints:</p>
+          <ul>
+            <li>-2^31 &lt;= x &lt;= 2^31 - 1</li>
+          </ul>
+        </section>
+      </main>
+    </body>
+  </html>
+`;
+const analysisHtml = `
+  <section id="submission-panel">
+    <div id="analysis-approach-content">
+      <span>Congratulations! You passed on your first attempt. You're in great form today!</span>
+      <div>
+        <span>핵심 아이디어:</span>
+        <span>Iterating through numbers, converting to strings to extract digits, and reconstructing the result array.</span>
+      </div>
+    </div>
+    <div id="analysis-efficiency-content">
+      <span>현재 복잡도: </span>
+      <span class="katex">O(N log M)</span>
+      <span>제안:</span>
+      <span>Your solution is already optimal; no further changes are needed.</span>
+    </div>
+    <div translate="no">
+      <pre><code>class Solution {}</code></pre>
+    </div>
+    <div id="analysis-code-style-content">
+      <span>제안:</span>
+      <span>This code is exceptionally clean and follows all best practices perfectly.</span>
+    </div>
+  </section>
+`;
+
+function translateStub(text: string) {
+  if (text.includes("Given an integer §0§")) {
+    return "정수 §0§가 주어지면 §2§가 §3§이면 §1§를 반환하고, 그렇지 않으면 §4§를 반환합니다.";
+  }
+  if (text.includes("121 reads as 121")) {
+    return "121은 왼쪽에서 오른쪽으로, 오른쪽에서 왼쪽으로 읽어도 121입니다.";
+  }
+  if (text === "Palindrome") {
+    return "팰린드롬";
+  }
+  if (text.includes("reads the same forward and backward")) {
+    return "정수가 앞뒤로 똑같이 읽히면 팰린드롬입니다.";
+  }
+  if (text.includes("For example, §0§")) {
+    return "예를 들어 §0§은 팰린드롬이고 §1§은 아닙니다.";
+  }
+  if (text.includes("Congratulations!")) {
+    return "축하합니다! 첫 시도에 통과했습니다. 오늘 컨디션이 아주 좋네요!";
+  }
+  if (text.includes("Iterating through numbers")) {
+    return "숫자를 순회하며 문자열로 변환해 각 자릿수를 추출하고 결과 배열을 다시 구성합니다.";
+  }
+  if (text.includes("already optimal")) {
+    return "이미 최적의 풀이입니다. 추가 변경은 필요하지 않습니다.";
+  }
+  if (text.includes("exceptionally clean")) {
+    return "이 코드는 매우 깔끔하며 모든 모범 사례를 잘 따르고 있습니다.";
+  }
+
+  return `번역됨: ${text}`;
+}
+
+test("translates only the Palindrome Number problem description through backend", async ({
+  page,
+}) => {
+  const backendCalls: Array<{ texts: string[]; token: string | undefined }> = [];
+
+  await page.addInitScript(() => {
+    const storageData: Record<string, unknown> = {
+      leetcodeKoreanEnabled: true,
+      peekle_token: "test-token",
+    };
+
+    Object.defineProperty(window, "__peekleStorageData", {
+      configurable: true,
+      value: storageData,
+    });
+
+    Object.defineProperty(window, "chrome", {
+      configurable: true,
+      value: {
+        runtime: {
+          lastError: null,
+          sendMessage(
+            request: { type?: string },
+            callback: (value: Record<string, unknown> | null) => void,
+          ) {
+            if (request?.type === "CHECK_ENV") {
+              callback({ apiUrl: "https://peekle.test" });
+              return;
+            }
+            if (request?.type === "GET_TOKEN") {
+              callback({ token: "test-token" });
+              return;
+            }
+            callback(null);
+          },
+          onMessage: {
+            addListener() {},
+          },
+        },
+        storage: {
+          local: {
+            get(
+              _keys: string[],
+              callback: (value: Record<string, unknown>) => void,
+            ) {
+              callback(storageData);
+            },
+            set(
+              items: Record<string, unknown>,
+              callback?: () => void,
+            ) {
+              Object.assign(storageData, items);
+              callback?.();
+            },
+          },
+          onChanged: {
+            addListener() {},
+          },
+        },
+      },
+    });
+  });
+
+  await page.route(apiUrl, async (route) => {
+    const request = route.request();
+    const body = JSON.parse(request.postData() || "{}") as { texts: string[] };
+    backendCalls.push({
+      texts: body.texts,
+      token: request.headers()["x-peekle-token"],
+    });
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: {
+          translations: body.texts.map(translateStub),
+        },
+      }),
+    });
+  });
+
+  await page.route(problemUrl, async (route) => {
+    await route.fulfill({
+      contentType: "text/html",
+      body: problemHtml,
+    });
+  });
+
+  await page.goto(problemUrl);
+  await page.addScriptTag({ path: localizerPath });
+
+  await expect(page.locator("#peekle-problem-translate-button")).toBeVisible();
+  await page.locator("#peekle-problem-translate-button").click();
+
+  await expect(page.locator("#peekle-problem-translate-button")).toHaveText(
+    "원문 보기",
+  );
+  await expect(page.locator("#peekle-problem-translation-box")).toHaveCount(0);
+  await expect(
+    page.locator('[data-track-load="description_content"] p').first(),
+  ).toHaveText(
+    "정수 x가 주어지면 x가 palindrome이면 true를 반환하고, 그렇지 않으면 false를 반환합니다.",
+  );
+  await expect(
+    page.locator('[data-track-load="description_content"] p').first(),
+  ).not.toContainText("__peekle");
+  await expect(
+    page.locator('[data-track-load="description_content"] p').first(),
+  ).not.toContainText("§");
+  await expect(
+    page.locator('[data-track-load="description_content"] button', {
+      hasText: "palindrome",
+    }),
+  ).toBeVisible();
+
+  const exampleBlock = page.locator(
+    '[data-track-load="description_content"] pre',
+  );
+  await expect(exampleBlock).toContainText("Input: x = 121");
+  await expect(exampleBlock).toContainText("Output: true");
+  await expect(exampleBlock).toContainText("설명:");
+  await expect(exampleBlock).toContainText(
+    "121은 왼쪽에서 오른쪽으로, 오른쪽에서 왼쪽으로 읽어도 121입니다.",
+  );
+  await expect(exampleBlock).not.toContainText("입력:");
+  await expect(exampleBlock).not.toContainText("출력:");
+
+  await page.evaluate(() => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-radix-popper-content-wrapper", "");
+    wrapper.innerHTML = `
+      <div role="dialog">
+        <div>
+          <div>
+            <div>Palindrome</div>
+            <div>
+              <div class="markdown-content_markdown__test">
+                <p>An integer is a <strong>palindrome</strong> when it reads the same forward and backward.</p>
+                <p>For example, <code>121</code> is a palindrome while <code>123</code> is not.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(wrapper);
+  });
+
+  await expect(page.getByRole("dialog")).toContainText("팰린드롬");
+  await expect(page.getByRole("dialog")).toContainText(
+    "정수가 앞뒤로 똑같이 읽히면 팰린드롬입니다.",
+  );
+  await expect(page.getByRole("dialog")).toContainText(
+    "예를 들어 121은 팰린드롬이고 123은 아닙니다.",
+  );
+  await expect(page.getByRole("dialog")).not.toContainText("__peekle");
+  await expect(page.getByRole("dialog")).not.toContainText("§");
+
+  const callsBeforeRestore = backendCalls.length;
+  await page.locator("#peekle-problem-translate-button").click();
+
+  await expect(page.locator("#peekle-problem-translate-button")).toHaveText(
+    "문제 번역",
+  );
+  await expect(
+    page.locator('[data-track-load="description_content"] p').first(),
+  ).toHaveText(
+    "Given an integer x, return true if x is a palindrome, and false otherwise.",
+  );
+  await expect(exampleBlock).toContainText("Explanation:");
+  await expect(exampleBlock).not.toContainText("설명:");
+  await expect(page.getByRole("dialog")).toContainText("Palindrome");
+
+  expect(backendCalls).toHaveLength(callsBeforeRestore);
+
+  await expect(page.locator("#outside-nav")).toHaveText(
+    "This navigation must stay English.",
+  );
+  await expect(page.locator("#outside-panel")).toHaveText(
+    "This sidebar must stay English.",
+  );
+
+  const requestedTexts = backendCalls.flatMap((call) => call.texts);
+  expect(backendCalls.every((call) => call.token === "test-token")).toBe(true);
+  expect(requestedTexts).toHaveLength(5);
+  expect(requestedTexts[0]).toContain("Given an integer §0§");
+  expect(requestedTexts[1]).toContain(
+    "121 reads as 121 from left to right and from right to left.",
+  );
+  expect(requestedTexts).toContain("Palindrome");
+  expect(requestedTexts).toContain(
+    "An integer is a palindrome when it reads the same forward and backward.",
+  );
+  expect(requestedTexts).toContain(
+    "For example, §0§ is a palindrome while §1§ is not.",
+  );
+  expect(requestedTexts.join("\n")).not.toContain("Input:");
+  expect(requestedTexts.join("\n")).not.toContain("Output:");
+  expect(requestedTexts.join("\n")).not.toContain(
+    "This navigation must stay English.",
+  );
+  expect(requestedTexts.join("\n")).not.toContain(
+    "This sidebar must stay English.",
+  );
+});
+
+test("applies cached problem translation immediately without backend request", async ({
+  page,
+}) => {
+  let backendCallCount = 0;
+
+  await page.addInitScript(
+    ({ cacheKey }) => {
+      const paragraphSource =
+        "Given an integer §0§, return §1§ if §2§ is a §3§, and §4§ otherwise.";
+      const explanationSource =
+        "121 reads as 121 from left to right and from right to left.";
+      const storageData: Record<string, unknown> = {
+        leetcodeKoreanEnabled: true,
+        peekle_token: "test-token",
+        [cacheKey]: {
+          texts: {
+            [paragraphSource]: {
+              translatedText:
+                "정수 §0§가 주어지면 §2§가 §3§이면 §1§를 반환하고, 그렇지 않으면 §4§를 반환합니다.",
+              updatedAt: Date.now(),
+            },
+            [explanationSource]: {
+              translatedText:
+                "121은 왼쪽에서 오른쪽으로, 오른쪽에서 왼쪽으로 읽어도 121입니다.",
+              updatedAt: Date.now(),
+            },
+          },
+        },
+      };
+
+      Object.defineProperty(window, "chrome", {
+        configurable: true,
+        value: {
+          runtime: {
+            lastError: null,
+            sendMessage(
+              request: { type?: string },
+              callback: (value: Record<string, unknown> | null) => void,
+            ) {
+              if (request?.type === "CHECK_ENV") {
+                callback({ apiUrl: "https://peekle.test" });
+                return;
+              }
+              if (request?.type === "GET_TOKEN") {
+                callback({ token: "test-token" });
+                return;
+              }
+              callback(null);
+            },
+            onMessage: {
+              addListener() {},
+            },
+          },
+          storage: {
+            local: {
+              get(
+                _keys: string[],
+                callback: (value: Record<string, unknown>) => void,
+              ) {
+                callback(storageData);
+              },
+              set(items: Record<string, unknown>, callback?: () => void) {
+                Object.assign(storageData, items);
+                callback?.();
+              },
+            },
+            onChanged: {
+              addListener() {},
+            },
+          },
+        },
+      });
+    },
+    { cacheKey: translationCacheKey },
+  );
+
+  await page.route(apiUrl, async (route) => {
+    backendCallCount += 1;
+    await route.abort();
+  });
+
+  await page.route(problemUrl, async (route) => {
+    await route.fulfill({
+      contentType: "text/html",
+      body: problemHtml,
+    });
+  });
+
+  await page.goto(problemUrl);
+  await page.addScriptTag({ path: localizerPath });
+
+  await expect(page.locator("#peekle-problem-translate-button")).toHaveText(
+    "원문 보기",
+  );
+  await expect(page.locator("#peekle-problem-translation-status")).toHaveText(
+    "로컬 캐시 적용",
+  );
+  await expect(
+    page.locator('[data-track-load="description_content"] p').first(),
+  ).toHaveText(
+    "정수 x가 주어지면 x가 palindrome이면 true를 반환하고, 그렇지 않으면 false를 반환합니다.",
+  );
+  await expect(
+    page.locator('[data-track-load="description_content"] pre'),
+  ).toContainText("설명:");
+  expect(backendCallCount).toBe(0);
+});
+
+test("translates LeetCode AI analysis section through backend", async ({
+  page,
+}) => {
+  const backendCalls: Array<{ texts: string[]; token: string | undefined }> = [];
+
+  await page.addInitScript(() => {
+    const storageData: Record<string, unknown> = {
+      leetcodeKoreanEnabled: true,
+      peekle_token: "test-token",
+    };
+
+    Object.defineProperty(window, "chrome", {
+      configurable: true,
+      value: {
+        runtime: {
+          lastError: null,
+          sendMessage(
+            request: { type?: string },
+            callback: (value: Record<string, unknown> | null) => void,
+          ) {
+            if (request?.type === "CHECK_ENV") {
+              callback({ apiUrl: "https://peekle.test" });
+              return;
+            }
+            if (request?.type === "GET_TOKEN") {
+              callback({ token: "test-token" });
+              return;
+            }
+            callback(null);
+          },
+          onMessage: {
+            addListener() {},
+          },
+        },
+        storage: {
+          local: {
+            get(
+              _keys: string[],
+              callback: (value: Record<string, unknown>) => void,
+            ) {
+              callback(storageData);
+            },
+            set(items: Record<string, unknown>, callback?: () => void) {
+              Object.assign(storageData, items);
+              callback?.();
+            },
+          },
+          onChanged: {
+            addListener() {},
+          },
+        },
+      },
+    });
+  });
+
+  await page.route(apiUrl, async (route) => {
+    const request = route.request();
+    const body = JSON.parse(request.postData() || "{}") as { texts: string[] };
+    backendCalls.push({
+      texts: body.texts,
+      token: request.headers()["x-peekle-token"],
+    });
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: {
+          translations: body.texts.map(translateStub),
+        },
+      }),
+    });
+  });
+
+  await page.route(problemUrl, async (route) => {
+    await route.fulfill({
+      contentType: "text/html",
+      body: problemHtml.replace("</main>", `${analysisHtml}</main>`),
+    });
+  });
+
+  await page.goto(problemUrl);
+  await page.addScriptTag({ path: localizerPath });
+
+  await expect(page.locator("#peekle-analysis-translate-button")).toBeVisible();
+  await page.locator("#peekle-analysis-translate-button").click();
+
+  await expect(page.locator("#peekle-analysis-translate-button")).toHaveText(
+    "AI 분석 원문 보기",
+  );
+  await expect(page.locator("#peekle-analysis-translation-status")).toHaveText(
+    "AI 분석 번역 완료",
+  );
+  await expect(page.locator("#analysis-approach-content")).toContainText(
+    "축하합니다! 첫 시도에 통과했습니다. 오늘 컨디션이 아주 좋네요!",
+  );
+  await expect(page.locator("#analysis-approach-content")).toContainText(
+    "숫자를 순회하며 문자열로 변환해 각 자릿수를 추출하고 결과 배열을 다시 구성합니다.",
+  );
+  await expect(page.locator("#analysis-efficiency-content")).toContainText(
+    "이미 최적의 풀이입니다. 추가 변경은 필요하지 않습니다.",
+  );
+  await expect(page.locator("#analysis-code-style-content")).toContainText(
+    "이 코드는 매우 깔끔하며 모든 모범 사례를 잘 따르고 있습니다.",
+  );
+  await expect(page.locator(".katex")).toContainText("O(N log M)");
+  await expect(page.locator("pre code")).toContainText("class Solution {}");
+
+  const callsBeforeRestore = backendCalls.length;
+  await page.locator("#peekle-analysis-translate-button").click();
+
+  await expect(page.locator("#peekle-analysis-translate-button")).toHaveText(
+    "AI 분석 번역",
+  );
+  await expect(page.locator("#analysis-approach-content")).toContainText(
+    "Congratulations! You passed on your first attempt. You're in great form today!",
+  );
+  await expect(page.locator("#analysis-efficiency-content")).toContainText(
+    "Your solution is already optimal; no further changes are needed.",
+  );
+  expect(backendCalls).toHaveLength(callsBeforeRestore);
+
+  const requestedTexts = backendCalls.flatMap((call) => call.texts);
+  expect(backendCalls.every((call) => call.token === "test-token")).toBe(true);
+  expect(requestedTexts).toEqual([
+    "Congratulations! You passed on your first attempt. You're in great form today!",
+    "Iterating through numbers, converting to strings to extract digits, and reconstructing the result array.",
+    "Your solution is already optimal; no further changes are needed.",
+    "This code is exceptionally clean and follows all best practices perfectly.",
+  ]);
+  expect(requestedTexts.join("\n")).not.toContain("O(N log M)");
+  expect(requestedTexts.join("\n")).not.toContain("class Solution");
+});
+
+test("shows daily translation limit apology from backend", async ({ page }) => {
+  const limitMessage =
+    "오늘 번역 가능 횟수 10회를 모두 사용했어요. 제작자의 Gemini 토큰 비용 보호를 위해 제한 중입니다. 내일 다시 이용해 주세요. 양해 부탁드립니다.";
+
+  await page.addInitScript(() => {
+    const storageData: Record<string, unknown> = {
+      leetcodeKoreanEnabled: true,
+      peekle_token: "test-token",
+    };
+
+    Object.defineProperty(window, "chrome", {
+      configurable: true,
+      value: {
+        runtime: {
+          lastError: null,
+          sendMessage(
+            request: { type?: string },
+            callback: (value: Record<string, unknown> | null) => void,
+          ) {
+            if (request?.type === "CHECK_ENV") {
+              callback({ apiUrl: "https://peekle.test" });
+              return;
+            }
+            if (request?.type === "GET_TOKEN") {
+              callback({ token: "test-token" });
+              return;
+            }
+            callback(null);
+          },
+          onMessage: {
+            addListener() {},
+          },
+        },
+        storage: {
+          local: {
+            get(
+              _keys: string[],
+              callback: (value: Record<string, unknown>) => void,
+            ) {
+              callback(storageData);
+            },
+            set(items: Record<string, unknown>, callback?: () => void) {
+              Object.assign(storageData, items);
+              callback?.();
+            },
+          },
+          onChanged: {
+            addListener() {},
+          },
+        },
+      },
+    });
+  });
+
+  await page.route(apiUrl, async (route) => {
+    await route.fulfill({
+      status: 429,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: false,
+        error: {
+          code: "TRANSLATION_005",
+          message: limitMessage,
+        },
+      }),
+    });
+  });
+
+  await page.route(problemUrl, async (route) => {
+    await route.fulfill({
+      contentType: "text/html",
+      body: problemHtml,
+    });
+  });
+
+  await page.goto(problemUrl);
+  await page.addScriptTag({ path: localizerPath });
+  await page.locator("#peekle-problem-translate-button").click();
+
+  await expect(page.locator("#peekle-problem-translate-button")).toHaveText(
+    "문제 번역",
+  );
+  await expect(page.locator("#peekle-problem-translation-status")).toHaveText(
+    limitMessage,
+  );
+  await expect(
+    page.locator('[data-track-load="description_content"] p').first(),
+  ).toHaveText(
+    "Given an integer x, return true if x is a palindrome, and false otherwise.",
+  );
+});


### PR DESCRIPTION
## 💡 의도 / 배경
pre-push에서 백엔드 전체 테스트를 실행할 때 `@SpringBootTest` 기반 통합 테스트까지 함께 수행되어, 로컬 Redis 실행 여부나 Redis 비밀번호 상태에 따라 테스트가 실패하는 문제가 있었습니다.

로컬 인프라 의존성이 있는 테스트는 기본 pre-push 검증에서 제외하고, 순수 단위 테스트만 기본 `test` 태스크에서 실행되도록 분리했습니다.

## 🛠️ 작업 내용
- [x] Gradle `test` 태스크를 단위 테스트 전용으로 설정
- [x] `*IntegrationTest`, `*ConcurrencyTest`, `PeekleBackendApplicationTests`를 기본 테스트에서 제외
- [x] 통합 테스트를 별도로 실행할 수 있는 `integrationTest` 태스크 추가

## 🔗 관련 이슈
- Closes #221

## 🖼️ 스크린샷 (선택)

## 🧪 테스트 방법
- [x] `cd apps/backend && .\gradlew.bat test --quiet`
- [x] Redis가 다른 프로젝트 컨테이너로 떠 있는 상태에서도 단위 테스트만 통과하는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [ ] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
통합 테스트는 이제 기본 `test` 태스크에서 제외되며, 필요할 때 `cd apps/backend && .\gradlew.bat integrationTest`로 별도 실행할 수 있습니다.