### PR TITLE
feat: LeetCode 번역 고도화 및 문제 메타데이터 저장

### DIFF
--- a/apps/backend/src/main/java/com/peekle/domain/leetcode/controller/LeetcodeTranslationController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/leetcode/controller/LeetcodeTranslationController.java
@@ -2,6 +2,7 @@ package com.peekle.domain.leetcode.controller;
 
 import com.peekle.domain.leetcode.dto.request.LeetcodeTranslationRequest;
 import com.peekle.domain.leetcode.dto.response.LeetcodeTranslationResponse;
+import com.peekle.domain.leetcode.service.LeetcodeSubmissionService;
 import com.peekle.domain.leetcode.service.LeetcodeTranslationQuotaService;
 import com.peekle.domain.leetcode.service.LeetcodeTranslationService;
 import com.peekle.global.dto.ApiResponse;
@@ -24,6 +25,7 @@ public class LeetcodeTranslationController {
 
     private final LeetcodeTranslationService leetcodeTranslationService;
     private final LeetcodeTranslationQuotaService leetcodeTranslationQuotaService;
+    private final LeetcodeSubmissionService leetcodeSubmissionService;
 
     @PostMapping("/translate")
     public ApiResponse<LeetcodeTranslationResponse> translate(
@@ -37,6 +39,12 @@ public class LeetcodeTranslationController {
         log.info("LeetCode 번역 요청 - userId: {}, count: {}", userId, request.texts().size());
         leetcodeTranslationService.validateRequest(request.texts());
         leetcodeTranslationQuotaService.consume(userId);
-        return ApiResponse.success(new LeetcodeTranslationResponse(leetcodeTranslationService.translate(request.texts())));
+        LeetcodeTranslationResponse response = new LeetcodeTranslationResponse(leetcodeTranslationService.translate(request.texts()));
+        try {
+            leetcodeSubmissionService.upsertProblemMetadata(request.problem());
+        } catch (RuntimeException error) {
+            log.warn("LeetCode 문제 메타데이터 저장 실패 - userId: {}, problem: {}", userId, request.problem(), error);
+        }
+        return ApiResponse.success(response);
     }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/leetcode/dto/request/LeetcodeTranslationRequest.java
+++ b/apps/backend/src/main/java/com/peekle/domain/leetcode/dto/request/LeetcodeTranslationRequest.java
@@ -4,12 +4,49 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
+import jakarta.validation.Valid;
+import java.util.ArrayList;
 import java.util.List;
 
 public record LeetcodeTranslationRequest(
         @NotEmpty(message = "번역할 텍스트가 필요합니다.")
         @Size(max = 20, message = "한 번에 최대 20개까지 번역할 수 있습니다.")
         List<@NotBlank(message = "번역할 텍스트는 비어 있을 수 없습니다.")
-                @Size(max = 2000, message = "텍스트는 2000자를 넘을 수 없습니다.") String> texts
+                @Size(max = 2000, message = "텍스트는 2000자를 넘을 수 없습니다.") String> texts,
+        @Valid
+        ProblemMetadata problem
 ) {
+    public record ProblemMetadata(
+            @Size(max = 50, message = "문제 번호는 50자를 넘을 수 없습니다.")
+            String externalId,
+            @Size(max = 50, message = "문제 번호는 50자를 넘을 수 없습니다.")
+            String problemNumber,
+            @Size(max = 255, message = "문제 slug는 255자를 넘을 수 없습니다.")
+            String titleSlug,
+            @Size(max = 255, message = "문제 제목은 255자를 넘을 수 없습니다.")
+            String title,
+            @Size(max = 255, message = "영문 제목은 255자를 넘을 수 없습니다.")
+            String englishTitle,
+            @Size(max = 255, message = "한글 제목은 255자를 넘을 수 없습니다.")
+            String koreanTitle,
+            @Size(max = 50, message = "난이도는 50자를 넘을 수 없습니다.")
+            String difficulty,
+            @Size(max = 1000, message = "문제 URL은 1000자를 넘을 수 없습니다.")
+            String problemUrl,
+            List<@Valid TagMetadata> tags
+    ) {
+        public ProblemMetadata {
+            if (tags == null) {
+                tags = new ArrayList<>();
+            }
+        }
+    }
+
+    public record TagMetadata(
+            @Size(max = 255, message = "태그 키는 255자를 넘을 수 없습니다.")
+            String key,
+            @Size(max = 255, message = "태그 이름은 255자를 넘을 수 없습니다.")
+            String name
+    ) {
+    }
 }

--- a/apps/backend/src/main/java/com/peekle/domain/leetcode/service/LeetcodeSubmissionService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/leetcode/service/LeetcodeSubmissionService.java
@@ -1,6 +1,7 @@
 package com.peekle.domain.leetcode.service;
 
 import com.peekle.domain.ai.repository.RecommendProblemRepository;
+import com.peekle.domain.leetcode.dto.request.LeetcodeTranslationRequest;
 import com.peekle.domain.leetcode.entity.LeetcodeProblemRating;
 import com.peekle.domain.leetcode.repository.LeetcodeProblemRatingRepository;
 import com.peekle.domain.league.dto.UserLeagueStatusDto;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -102,6 +104,7 @@ public class LeetcodeSubmissionService {
     private final LeagueService leagueService;
     private final RecommendProblemRepository recommendProblemRepository;
     private final LeetcodeProblemRatingRepository leetcodeProblemRatingRepository;
+    private final LeetcodeTranslationService leetcodeTranslationService;
 
     @Transactional
     public SubmissionResponse saveLeetcodeSubmission(LeetcodeSubmissionRequest request) {
@@ -182,6 +185,34 @@ public class LeetcodeSubmissionService {
                 .build();
     }
 
+    @Transactional
+    public void upsertProblemMetadata(LeetcodeTranslationRequest.ProblemMetadata metadata) {
+        if (metadata == null) return;
+
+        LeetcodeSubmissionRequest request = new LeetcodeSubmissionRequest();
+        request.setExternalId(metadata.externalId());
+        request.setProblemNumber(metadata.problemNumber());
+        request.setTitleSlug(metadata.titleSlug());
+        request.setTitle(metadata.title());
+        request.setEnglishTitle(metadata.englishTitle());
+        request.setKoreanTitle(metadata.koreanTitle());
+        request.setDifficulty(metadata.difficulty());
+        request.setProblemUrl(metadata.problemUrl());
+        request.setTags(metadata.tags().stream()
+                .filter(Objects::nonNull)
+                .map(this::toSubmissionTagRequest)
+                .toList());
+
+        resolveProblem(request);
+    }
+
+    private LeetcodeSubmissionRequest.TagRequest toSubmissionTagRequest(LeetcodeTranslationRequest.TagMetadata metadata) {
+        LeetcodeSubmissionRequest.TagRequest tagRequest = new LeetcodeSubmissionRequest.TagRequest();
+        tagRequest.setKey(metadata.key());
+        tagRequest.setName(metadata.name());
+        return tagRequest;
+    }
+
     private User resolveUser(String extensionToken) {
         if (!hasText(extensionToken)) {
             throw new BusinessException(ErrorCode.INVALID_TOKEN);
@@ -198,31 +229,46 @@ public class LeetcodeSubmissionService {
         }
 
         Set<Tag> tags = resolveTags(request.getTags());
-        String title = resolveTitle(request);
         String englishTitle = trimToNull(request.getEnglishTitle());
         if (englishTitle == null) {
             englishTitle = trimToNull(request.getTitle());
         }
+        String koreanTitle = resolveKoreanTitle(request, englishTitle);
+        String title = koreanTitle != null ? koreanTitle : resolveTitle(request);
         String difficulty = normalizeDifficulty(request.getDifficulty());
         DifficultyMetadata difficultyMetadata = resolveDifficultyMetadata(titleSlug, difficulty);
         String problemUrl = resolveProblemUrl(titleSlug, request.getProblemUrl());
 
         Problem problem = problemRepository.findByExternalIdAndSource(externalId, LEETCODE_SOURCE)
-                .orElseGet(() -> problemRepository.save(new Problem(
-                        LEETCODE_SOURCE,
-                        externalId,
-                        title,
-                        difficulty,
-                        problemUrl)));
+                .orElseGet(() -> resolveLegacySlugProblem(titleSlug, externalId)
+                        .orElseGet(() -> problemRepository.save(new Problem(
+                                LEETCODE_SOURCE,
+                                externalId,
+                                title,
+                                difficulty,
+                                problemUrl))));
 
-        applyProblemMetadata(problem, title, englishTitle, difficulty, difficultyMetadata, problemUrl, tags, request);
+        applyProblemMetadata(problem, title, englishTitle, koreanTitle, difficulty, difficultyMetadata, problemUrl, tags, request);
         return problem;
+    }
+
+    private Optional<Problem> resolveLegacySlugProblem(String titleSlug, String externalId) {
+        if (!hasText(titleSlug) || titleSlug.equals(externalId)) {
+            return Optional.empty();
+        }
+
+        return problemRepository.findByExternalIdAndSource(titleSlug, LEETCODE_SOURCE)
+                .map(problem -> {
+                    problem.setExternalId(externalId);
+                    return problem;
+                });
     }
 
     private void applyProblemMetadata(
             Problem problem,
             String title,
             String englishTitle,
+            String koreanTitle,
             String difficulty,
             DifficultyMetadata difficultyMetadata,
             String problemUrl,
@@ -234,6 +280,9 @@ public class LeetcodeSubmissionService {
         }
         if (!Objects.equals(problem.getEnglishTitle(), englishTitle)) {
             problem.setEnglishTitle(englishTitle);
+        }
+        if (!Objects.equals(problem.getKoreanTitle(), koreanTitle)) {
+            problem.setKoreanTitle(koreanTitle);
         }
         if (!Objects.equals(problem.getTier(), difficulty)) {
             problem.setTier(difficulty);
@@ -250,7 +299,7 @@ public class LeetcodeSubmissionService {
         if (!Objects.equals(problem.getUrl(), problemUrl)) {
             problem.setUrl(problemUrl);
         }
-        String language = hasText(request.getKoreanTitle()) ? "ko" : "en";
+        String language = hasText(koreanTitle) ? "ko" : "en";
         if (!Objects.equals(problem.getLanguage(), language)) {
             problem.setLanguage(language);
         }
@@ -355,6 +404,25 @@ public class LeetcodeSubmissionService {
 
         String titleSlug = trimToNull(request.getTitleSlug());
         return titleSlug != null ? titleSlug : "제목 미상";
+    }
+
+    private String resolveKoreanTitle(LeetcodeSubmissionRequest request, String englishTitle) {
+        String koreanTitle = trimToNull(request.getKoreanTitle());
+        if (hasKoreanText(koreanTitle)) return koreanTitle;
+
+        String title = trimToNull(request.getTitle());
+        if (hasKoreanText(title)) return title;
+
+        if (!hasText(englishTitle) || hasKoreanText(englishTitle)) {
+            return hasKoreanText(englishTitle) ? englishTitle : null;
+        }
+
+        try {
+            String translatedTitle = leetcodeTranslationService.translate(List.of(englishTitle)).get(0);
+            return hasKoreanText(translatedTitle) ? trimToNull(translatedTitle) : null;
+        } catch (RuntimeException error) {
+            return null;
+        }
     }
 
     private String resolveProblemUrl(String titleSlug, String rawProblemUrl) {
@@ -487,6 +555,10 @@ public class LeetcodeSubmissionService {
 
     private boolean hasText(String value) {
         return value != null && !value.trim().isEmpty();
+    }
+
+    private boolean hasKoreanText(String value) {
+        return value != null && value.matches(".*[ㄱ-ㅎㅏ-ㅣ가-힣].*");
     }
 
     private String trimToNull(String value) {

--- a/apps/backend/src/main/java/com/peekle/domain/problem/controller/ProblemController.java
+++ b/apps/backend/src/main/java/com/peekle/domain/problem/controller/ProblemController.java
@@ -1,5 +1,6 @@
 package com.peekle.domain.problem.controller;
 
+import com.peekle.domain.problem.dto.ProblemExternalIdResponse;
 import com.peekle.domain.problem.dto.ProblemSearchResponse;
 import com.peekle.domain.problem.service.ProblemService;
 import com.peekle.domain.problem.service.ProblemSyncJobService;
@@ -86,6 +87,13 @@ public class ProblemController {
             @RequestParam(defaultValue = "BOJ") String source) {
         Map<String, Long> response = problemService.getProblemIdByExternalId(externalId, source);
         return ApiResponse.success(response);
+    }
+
+    @GetMapping("/by-external-id/detail")
+    public ApiResponse<ProblemExternalIdResponse> getProblemByExternalId(
+            @RequestParam String externalId,
+            @RequestParam(defaultValue = "BOJ") String source) {
+        return ApiResponse.success(problemService.findByExternalId(externalId, source));
     }
 
     @GetMapping("/tags")

--- a/apps/backend/src/main/java/com/peekle/domain/problem/dto/ProblemExternalIdResponse.java
+++ b/apps/backend/src/main/java/com/peekle/domain/problem/dto/ProblemExternalIdResponse.java
@@ -1,0 +1,27 @@
+package com.peekle.domain.problem.dto;
+
+import com.peekle.domain.problem.entity.Problem;
+
+public record ProblemExternalIdResponse(
+        Long id,
+        String source,
+        String externalId,
+        String title,
+        String englishTitle,
+        String koreanTitle,
+        String tier,
+        String url
+) {
+    public static ProblemExternalIdResponse from(Problem problem) {
+        return new ProblemExternalIdResponse(
+                problem.getId(),
+                problem.getSource(),
+                problem.getExternalId(),
+                problem.getTitle(),
+                problem.getEnglishTitle(),
+                problem.getKoreanTitle(),
+                problem.getTier(),
+                problem.getUrl()
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/peekle/domain/problem/entity/Problem.java
+++ b/apps/backend/src/main/java/com/peekle/domain/problem/entity/Problem.java
@@ -41,6 +41,9 @@ public class Problem {
     @Column(name = "english_title")
     private String englishTitle;
 
+    @Column(name = "korean_title")
+    private String koreanTitle;
+
     @Column(nullable = false)
     private String tier; // 표시용 난이도: Gold 5, Easy, Medium, Hard, Unrated
 

--- a/apps/backend/src/main/java/com/peekle/domain/problem/repository/ProblemRepository.java
+++ b/apps/backend/src/main/java/com/peekle/domain/problem/repository/ProblemRepository.java
@@ -81,14 +81,14 @@ public interface ProblemRepository extends JpaRepository<Problem, Long>, Problem
         * 특정 레벨 범위 내에서 무작위로 N개의 문제를 가져옵니다.
         * PostgreSQL의 ORDER BY RANDOM()을 사용합니다.
         */
-       @Query(nativeQuery = true, value = "SELECT id, source, external_id, title, english_title, tier, leetcode_rating, difficulty_source, url, accepted_user_count, level, language FROM problems p " +
+       @Query(nativeQuery = true, value = "SELECT id, source, external_id, title, english_title, korean_title, tier, leetcode_rating, difficulty_source, url, accepted_user_count, level, language FROM problems p " +
                      "WHERE p.source = 'BOJ' " +
                      "AND p.tier IN :tiers " +
                      "AND p.title ~ '[ㄱ-ㅎㅏ-ㅣ가-힣]' " +
                      "ORDER BY RANDOM() LIMIT :limit")
        List<Problem> findRandomProblemsByTiers(@Param("tiers") List<String> tiers, @Param("limit") int limit);
 
-       @Query(nativeQuery = true, value = "SELECT p.id, p.source, p.external_id, p.title, p.english_title, p.tier, p.leetcode_rating, p.difficulty_source, p.url, p.accepted_user_count, p.level, p.language FROM problems p "
+       @Query(nativeQuery = true, value = "SELECT p.id, p.source, p.external_id, p.title, p.english_title, p.korean_title, p.tier, p.leetcode_rating, p.difficulty_source, p.url, p.accepted_user_count, p.level, p.language FROM problems p "
                      +
                      "WHERE p.source = 'BOJ' " +
                      "AND p.tier IN :tiers " +

--- a/apps/backend/src/main/java/com/peekle/domain/problem/service/ProblemService.java
+++ b/apps/backend/src/main/java/com/peekle/domain/problem/service/ProblemService.java
@@ -2,6 +2,7 @@ package com.peekle.domain.problem.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.peekle.domain.problem.dto.ProblemExternalIdResponse;
 import com.peekle.domain.problem.dto.ProblemSearchResponse;
 import com.peekle.domain.problem.entity.Problem;
 import com.peekle.domain.problem.entity.Tag;
@@ -408,6 +409,13 @@ public class ProblemService {
         Map<String, Long> response = new HashMap<>();
         response.put("problemId", problem.getId());
         return response;
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemExternalIdResponse findByExternalId(String externalId, String source) {
+        return problemRepository.findByExternalIdAndSource(externalId, source)
+                .map(ProblemExternalIdResponse::from)
+                .orElse(null);
     }
 
     /**

--- a/apps/backend/src/main/java/com/peekle/global/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/com/peekle/global/config/SecurityConfig.java
@@ -59,7 +59,9 @@ public class SecurityConfig {
                                                 // Extension / APIs
                                                 .requestMatchers("/api/submissions/**").permitAll()
                                                 .requestMatchers(HttpMethod.GET, "/api/problems/search",
-                                                                "/api/problems/by-external-id", "/api/problems/tags")
+                                                                "/api/problems/by-external-id",
+                                                                "/api/problems/by-external-id/detail",
+                                                                "/api/problems/tags")
                                                 .permitAll()
                                                 .requestMatchers("/api/problems/sync").authenticated()
                                                 .requestMatchers("/api/users/me/**").permitAll() // Extension token

--- a/apps/backend/src/main/resources/db/migration-postgres/V23__add_problem_korean_title.sql
+++ b/apps/backend/src/main/resources/db/migration-postgres/V23__add_problem_korean_title.sql
@@ -1,0 +1,15 @@
+ALTER TABLE problems
+    ADD COLUMN IF NOT EXISTS korean_title VARCHAR(255);
+
+UPDATE problems p
+SET external_id = r.problem_number::TEXT
+FROM leetcode_problem_ratings r
+WHERE p.source = 'LEETCODE'
+    AND p.external_id = r.title_slug
+    AND r.problem_number IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM problems existing
+        WHERE existing.source = p.source
+            AND existing.external_id = r.problem_number::TEXT
+    );

--- a/apps/extension/content/leetcode-localizer.js
+++ b/apps/extension/content/leetcode-localizer.js
@@ -15,14 +15,20 @@
     const TRANSLATION_CACHE_KEY = 'peekle_leetcode_translation_cache_v1';
     const TRANSLATION_BATCH_SIZE = 20;
     const MAX_TRANSLATION_CACHE_ITEMS = 600;
+    const LEETCODE_SOURCE = 'LEETCODE';
+    const TITLE_ORIGINAL_TEXT_ATTR = 'data-peekle-title-original-text';
+    const TITLE_EXTERNAL_ID_ATTR = 'data-peekle-title-external-id';
     const originalTextByNode = new WeakMap();
     const originalAttributesByElement = new WeakMap();
     const originalProblemHtmlByElement = new Map();
     const originalProblemTextByNode = new Map();
+    const problemTitleCache = new Map();
     let enabled = false;
     let problemTranslationActive = false;
     let apiBaseUrlPromise = null;
     let translationCachePromise = null;
+    let problemTitleLookupRunning = false;
+    let lastProblemTitleRenderKey = null;
     let cachedProblemTranslationRunning = false;
     let lastCachedProblemSignature = null;
     let manuallyRestoredProblemKey = null;
@@ -54,6 +60,7 @@
         ['for as low as', '월'],
         ['/month.', '부터 이용하세요.'],
         ['Go Premium', '프리미엄으로 업그레이드'],
+        ['You are submitting too frequently. Please try again later or Subscribe to Premium for shorter wait times.', '너무 자주 제출하고 있습니다. 잠시 후 다시 시도하거나 프리미엄을 구독하면 대기 시간을 줄일 수 있습니다.'],
         ['Add Card', '카드 추가'],
         ['Billing History', '결제 내역'],
         ['Contact Us', '문의하기'],
@@ -821,11 +828,119 @@
         return window.location.pathname.match(/^\/problems\/([^/]+)/)?.[1] || '';
     }
 
+    function hasKoreanText(value) {
+        return /[ㄱ-ㅎㅏ-ㅣ가-힣]/.test(value || '');
+    }
+
+    function normalizeText(value) {
+        return String(value || '').replace(/\s+/g, ' ').trim();
+    }
+
+    function parseProblemTitle(text) {
+        const match = normalizeText(text).match(/^(\d+)\.\s*(.+)$/);
+        if (!match) return null;
+
+        return {
+            externalId: match[1],
+            englishTitle: match[2].replace(/\s*\([^()]*[ㄱ-ㅎㅏ-ㅣ가-힣][^()]*\)\s*$/, '').trim()
+        };
+    }
+
+    function findProblemTitleElement() {
+        const slug = getProblemKey();
+        if (!slug) return null;
+
+        const selectors = [
+            '[data-cy="question-title"]',
+            `a[href="/problems/${slug}/"]`,
+            `a[href="/problems/${slug}/description/"]`
+        ];
+
+        for (const selector of selectors) {
+            const elements = Array.from(document.querySelectorAll(selector));
+            const matched = elements.find((element) => parseProblemTitle(element.innerText || element.textContent));
+            if (matched) return matched;
+        }
+
+        return null;
+    }
+
+    function findDifficulty() {
+        const lines = (document.body?.innerText || '')
+            .split('\n')
+            .map(normalizeText)
+            .filter(Boolean);
+
+        return lines.find((line) => /^(Easy|Medium|Hard)$/.test(line)) || '';
+    }
+
+    function extractProblemTags() {
+        const tagLinks = Array.from(document.querySelectorAll('a[href^="/tag/"], a[href*="leetcode.com/tag/"]'));
+        const seen = new Set();
+
+        return tagLinks
+            .map((link) => {
+                const href = link.getAttribute('href') || '';
+                const key = href.match(/\/tag\/([^/?#]+)/)?.[1] || '';
+                const name = normalizeText(link.innerText || link.textContent) || key;
+
+                return {
+                    key,
+                    name
+                };
+            })
+            .filter((tag) => tag.key)
+            .filter((tag) => {
+                if (seen.has(tag.key)) return false;
+                seen.add(tag.key);
+                return true;
+            });
+    }
+
+    function buildProblemMetadata() {
+        const titleElement = findProblemTitleElement();
+        const parsedTitle = parseProblemTitle(titleElement?.innerText || titleElement?.textContent || '');
+        if (!parsedTitle?.externalId) return null;
+
+        const titleSlug = getProblemKey();
+        return {
+            source: LEETCODE_SOURCE,
+            externalId: parsedTitle.externalId,
+            problemNumber: parsedTitle.externalId,
+            titleSlug,
+            title: parsedTitle.englishTitle,
+            englishTitle: parsedTitle.englishTitle,
+            difficulty: findDifficulty(),
+            problemUrl: titleSlug ? `https://leetcode.com/problems/${titleSlug}/description/` : window.location.href,
+            tags: extractProblemTags()
+        };
+    }
+
+    function restoreProblemTitle() {
+        document.querySelectorAll(`[${TITLE_ORIGINAL_TEXT_ATTR}]`).forEach((element) => {
+            const originalText = element.getAttribute(TITLE_ORIGINAL_TEXT_ATTR);
+            if (originalText) element.textContent = originalText;
+            element.removeAttribute(TITLE_ORIGINAL_TEXT_ATTR);
+            element.removeAttribute(TITLE_EXTERNAL_ID_ATTR);
+        });
+        lastProblemTitleRenderKey = null;
+    }
+
+    function clearProblemTitleState() {
+        document.querySelectorAll(`[${TITLE_ORIGINAL_TEXT_ATTR}]`).forEach((element) => {
+            element.removeAttribute(TITLE_ORIGINAL_TEXT_ATTR);
+            element.removeAttribute(TITLE_EXTERNAL_ID_ATTR);
+        });
+        lastProblemTitleRenderKey = null;
+    }
+
     function syncCurrentProblemState() {
         const nextProblemKey = getProblemKey();
         if (currentProblemKey === nextProblemKey) return;
 
+        clearProblemTitleState();
         currentProblemKey = nextProblemKey;
+        lastProblemTitleRenderKey = null;
         problemTranslationActive = false;
         cachedProblemTranslationRunning = false;
         lastCachedProblemSignature = null;
@@ -1543,11 +1658,88 @@
         return storage[PEEKLE_TOKEN_KEY] || null;
     }
 
-    async function requestTranslationChunk(texts) {
+    async function getLeetcodeProblemByExternalId(externalId) {
+        const cacheKey = `${LEETCODE_SOURCE}:${externalId}`;
+        if (problemTitleCache.has(cacheKey)) {
+            return problemTitleCache.get(cacheKey);
+        }
+
+        const apiBaseUrl = await getApiBaseUrl();
+        const query = new URLSearchParams({
+            externalId,
+            source: LEETCODE_SOURCE
+        });
+
+        try {
+            const response = await fetch(`${apiBaseUrl}/api/problems/by-external-id/detail?${query.toString()}`);
+            if (!response.ok) {
+                problemTitleCache.set(cacheKey, null);
+                return null;
+            }
+
+            const payload = await response.json();
+            const problem = payload?.success === true ? payload.data || null : null;
+            problemTitleCache.set(cacheKey, problem);
+            return problem;
+        } catch (error) {
+            console.warn('[Peekle LeetCode] Failed to fetch problem title.', error);
+            return null;
+        }
+    }
+
+    function getKoreanProblemTitle(problem) {
+        const koreanTitle = normalizeText(problem?.koreanTitle);
+        if (hasKoreanText(koreanTitle)) return koreanTitle;
+
+        const title = normalizeText(problem?.title);
+        return hasKoreanText(title) ? title : '';
+    }
+
+    async function syncLeetcodeProblemTitle() {
+        if (!enabled || !isProblemPage() || problemTitleLookupRunning) return;
+
+        const titleElement = findProblemTitleElement();
+        if (!titleElement) return;
+
+        const originalText = titleElement.getAttribute(TITLE_ORIGINAL_TEXT_ATTR)
+            || normalizeText(titleElement.innerText || titleElement.textContent);
+        const parsedTitle = parseProblemTitle(originalText);
+        if (!parsedTitle) return;
+
+        const renderKey = `${getProblemKey()}:${parsedTitle.externalId}:${originalText}`;
+        if (lastProblemTitleRenderKey === renderKey) return;
+
+        problemTitleLookupRunning = true;
+        lastProblemTitleRenderKey = renderKey;
+
+        try {
+            const problem = await getLeetcodeProblemByExternalId(parsedTitle.externalId);
+            const koreanTitle = getKoreanProblemTitle(problem);
+            if (!koreanTitle) return;
+
+            const nextText = `${parsedTitle.externalId}. ${parsedTitle.englishTitle}(${koreanTitle})`;
+            if (normalizeText(titleElement.textContent) === nextText) return;
+
+            if (!titleElement.hasAttribute(TITLE_ORIGINAL_TEXT_ATTR)) {
+                titleElement.setAttribute(TITLE_ORIGINAL_TEXT_ATTR, originalText);
+            }
+            titleElement.setAttribute(TITLE_EXTERNAL_ID_ATTR, parsedTitle.externalId);
+            titleElement.textContent = nextText;
+        } finally {
+            problemTitleLookupRunning = false;
+        }
+    }
+
+    async function requestTranslationChunk(texts, problemMetadata = null) {
         const [apiBaseUrl, token] = await Promise.all([getApiBaseUrl(), getPeekleToken()]);
 
         if (!token) {
             throw new Error('Peekle 로그인 후 번역을 사용할 수 있습니다.');
+        }
+
+        const body = { texts };
+        if (problemMetadata) {
+            body.problem = problemMetadata;
         }
 
         const response = await fetch(`${apiBaseUrl}/api/leetcode/translate`, {
@@ -1556,7 +1748,7 @@
                 'Content-Type': 'application/json',
                 'X-Peekle-Token': token
             },
-            body: JSON.stringify({ texts })
+            body: JSON.stringify(body)
         });
 
         let payload = null;
@@ -1600,9 +1792,10 @@
         }
 
         const translatedMissingTexts = [];
+        const problemMetadata = buildProblemMetadata();
         for (let index = 0; index < missingTexts.length; index += TRANSLATION_BATCH_SIZE) {
             const chunk = missingTexts.slice(index, index + TRANSLATION_BATCH_SIZE);
-            const translatedChunk = await requestTranslationChunk(chunk);
+            const translatedChunk = await requestTranslationChunk(chunk, index === 0 ? problemMetadata : null);
 
             translatedChunk.forEach((translatedText, chunkIndex) => {
                 translatedTexts[missingIndexes[index + chunkIndex]] = translatedText;
@@ -2019,6 +2212,7 @@
         window.requestAnimationFrame(() => {
             queued = false;
             localize(document.body);
+            syncLeetcodeProblemTitle();
             syncProblemTranslatorControls();
             syncAnalysisTranslatorControls();
         });
@@ -2072,11 +2266,13 @@
         if (enabled) {
             ensureStyle();
             scheduleLocalize();
+            syncLeetcodeProblemTitle();
             syncProblemTranslatorControls();
             syncAnalysisTranslatorControls();
         } else {
             problemTranslationActive = false;
             analysisTranslationActive = false;
+            restoreProblemTitle();
             restoreOriginals(document.body);
             removeProblemTranslationUi();
             removeAnalysisTranslationUi();

--- a/apps/extension/content/leetcode-submission-detector.js
+++ b/apps/extension/content/leetcode-submission-detector.js
@@ -172,25 +172,42 @@
         }
     }
 
-    function detectResult(text) {
-        const normalized = normalizeText(text);
-        const resultCandidates = [
-            ['Accepted', '통과'],
-            ['Wrong Answer', '오답'],
-            ['Compile Error', '컴파일 에러'],
-            ['Runtime Error', '런타임 에러'],
-            ['Time Limit Exceeded', '시간 초과'],
-            ['Memory Limit Exceeded', '메모리 초과'],
-            ['Output Limit Exceeded', '출력 초과']
-        ];
+    const RESULT_DEFINITIONS = [
+        { result: 'Wrong Answer', aliases: ['Wrong Answer', '오답'] },
+        { result: 'Compile Error', aliases: ['Compile Error', '컴파일 에러'] },
+        { result: 'Runtime Error', aliases: ['Runtime Error', '런타임 에러'] },
+        { result: 'Time Limit Exceeded', aliases: ['Time Limit Exceeded', '시간 초과'] },
+        { result: 'Memory Limit Exceeded', aliases: ['Memory Limit Exceeded', '메모리 초과'] },
+        { result: 'Output Limit Exceeded', aliases: ['Output Limit Exceeded', '출력 초과'] },
+        { result: 'Accepted', aliases: ['Accepted', '통과'] }
+    ];
 
-        for (const [english, korean] of resultCandidates) {
-            if (normalized.includes(english) || normalized.includes(korean)) {
-                return english;
+    function findExactResultLine(lines, definitions = RESULT_DEFINITIONS) {
+        for (const line of lines) {
+            for (const definition of definitions) {
+                if (definition.aliases.includes(line)) {
+                    return definition.result;
+                }
             }
         }
 
         return '';
+    }
+
+    function detectResult(text) {
+        const lines = String(text || '')
+            .split('\n')
+            .map(normalizeText)
+            .filter(Boolean);
+
+        const primaryResult = findExactResultLine(lines.slice(0, 12));
+        if (primaryResult) return primaryResult;
+
+        const failedResults = RESULT_DEFINITIONS.filter(({ result }) => result !== 'Accepted');
+        const failedResult = findExactResultLine(lines, failedResults);
+        if (failedResult) return failedResult;
+
+        return findExactResultLine(lines, RESULT_DEFINITIONS.filter(({ result }) => result === 'Accepted'));
     }
 
     function parseNumberAfterLabel(text, labels, unitPattern) {


### PR DESCRIPTION
## 💡 의도 / 배경
LeetCode 문제 번역 시점에 이미 문제 번호, 제목, 난이도, 태그, URL 같은 메타데이터를 확인할 수 있지만, 기존에는 이 정보가 Peekle DB에 안정적으로 저장되지 않았습니다.

그 결과 LeetCode 문제를 번역하거나 제출해도 문제 제목이 영문으로만 남거나, 실제 문제 번호 대신 slug 기반 식별자가 저장될 수 있어 이후 제출 기록, 활동 내역, 화면 렌더링에서 문제 정보 재사용이 어려웠습니다.

## 🛠️ 작업 내용
- [x] LeetCode 번역 요청에 문제 메타데이터를 함께 전송하도록 확장 프로그램 로직을 추가했습니다.
- [x] 번역 성공 후 LeetCode 문제 정보를 DB에 upsert하도록 백엔드 로직을 추가했습니다.
- [x] `problems.korean_title` 컬럼을 추가하고, 영문 제목과 한글 제목을 분리 저장하도록 개선했습니다.
- [x] LeetCode 문제 조회 API를 추가해 `source + externalId` 기준으로 문제 메타데이터를 조회할 수 있도록 했습니다.
- [x] DB에 한글 제목이 있으면 LeetCode 화면 제목을 `영문 제목(한글 제목)` 형태로 표시하도록 개선했습니다.
- [x] 기존 slug 기반 LeetCode externalId 저장분을 가능한 경우 실제 문제 번호 기반 externalId로 정리하도록 migration을 추가했습니다.
- [x] LeetCode 오답/컴파일 에러 제출이 기존 Accepted 텍스트와 섞여 성공 제출로 오인되지 않도록 결과 판정 로직을 개선했습니다.

## 🔗 관련 이슈
- Closes #228

## 🖼️ 스크린샷 (선택)
없음

## 🧪 테스트 방법
- [x] `node --check apps/extension/content/leetcode-localizer.js`
- [x] `node --check apps/extension/content/leetcode-submission-detector.js`
- [x] `./gradlew.bat compileJava`
- [x] LeetCode Palindrome Number에서 오답 제출 후 `Wrong Answer`가 Accepted로 감지되지 않는지 확인

## ✅ 체크리스트
- [x] 이 PR이 프로젝트의 코드 컨벤션과 일치하는가?
- [x] 관련된 이슈를 Closes 항목에 포함시켰는가?
- [x] 셀프 리뷰를 진행했는가?
- [x] 빌드 및 테스트(pre-push)를 통과했는가?

## 💬 리뷰어에게 (선택)
LeetCode 문제 제목 번역은 번역 요청 성공 후 문제 메타데이터 upsert 과정에서 저장됩니다. 문제 저장 실패가 번역 UI를 막지 않도록 warning 로그만 남기고 번역 응답은 유지하는 정책으로 처리했습니다.